### PR TITLE
fix: correct DI header paths

### DIFF
--- a/lib/core/di/service_configurations/accounts_dependencies.dart
+++ b/lib/core/di/service_configurations/accounts_dependencies.dart
@@ -1,4 +1,4 @@
-// lib/core/di/service_configuration/accounts_dependencies.dart
+// lib/core/di/service_configurations/accounts_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/events/data_change_event.dart';
 import 'package:expense_tracker/core/services/demo_mode_service.dart'; // Import service

--- a/lib/core/di/service_configurations/analytics_dependencies.dart
+++ b/lib/core/di/service_configurations/analytics_dependencies.dart
@@ -1,4 +1,4 @@
-// lib/core/di/service_configuration/analytics_dependencies.dart
+// lib/core/di/service_configurations/analytics_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/events/data_change_event.dart';
 import 'package:expense_tracker/features/analytics/domain/usecases/get_expense_summary.dart';

--- a/lib/core/di/service_configurations/budget_dependencies.dart
+++ b/lib/core/di/service_configurations/budget_dependencies.dart
@@ -1,3 +1,4 @@
+// lib/core/di/service_configurations/budget_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/events/data_change_event.dart';
 import 'package:expense_tracker/core/services/demo_mode_service.dart';

--- a/lib/core/di/service_configurations/categories_dependencies.dart
+++ b/lib/core/di/service_configurations/categories_dependencies.dart
@@ -1,4 +1,4 @@
-// lib/core/di/service_configuration/categories_dependencies.dart
+// lib/core/di/service_configurations/categories_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/features/categories/data/datasources/category_local_data_source.dart';
 import 'package:expense_tracker/features/categories/data/datasources/category_predefined_data_source.dart';

--- a/lib/core/di/service_configurations/dashboard_dependencies.dart
+++ b/lib/core/di/service_configurations/dashboard_dependencies.dart
@@ -1,4 +1,4 @@
-// lib/core/di/service_configuration/dashboard_dependencies.dart
+// lib/core/di/service_configurations/dashboard_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/events/data_change_event.dart';
 import 'package:expense_tracker/features/dashboard/domain/usecases/get_financial_overview.dart';

--- a/lib/core/di/service_configurations/data_management_dependencies.dart
+++ b/lib/core/di/service_configurations/data_management_dependencies.dart
@@ -1,4 +1,4 @@
-// lib/core/di/service_configuration/data_management_dependencies.dart
+// lib/core/di/service_configurations/data_management_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/features/settings/data/repositories/data_management_repository_impl.dart';
 import 'package:expense_tracker/features/settings/domain/repositories/data_management_repository.dart';

--- a/lib/core/di/service_configurations/expenses_dependencies.dart
+++ b/lib/core/di/service_configurations/expenses_dependencies.dart
@@ -1,3 +1,4 @@
+// lib/core/di/service_configurations/expenses_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/services/demo_mode_service.dart';
 import 'package:expense_tracker/features/expenses/data/datasources/expense_local_data_source.dart';

--- a/lib/core/di/service_configurations/goal_dependencies.dart
+++ b/lib/core/di/service_configurations/goal_dependencies.dart
@@ -1,3 +1,4 @@
+// lib/core/di/service_configurations/goal_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/events/data_change_event.dart';
 import 'package:expense_tracker/core/services/demo_mode_service.dart';

--- a/lib/core/di/service_configurations/income_dependencies.dart
+++ b/lib/core/di/service_configurations/income_dependencies.dart
@@ -1,3 +1,4 @@
+// lib/core/di/service_configurations/income_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/services/demo_mode_service.dart';
 import 'package:expense_tracker/features/income/data/datasources/income_local_data_source.dart';

--- a/lib/core/di/service_configurations/recurring_transactions_dependencies.dart
+++ b/lib/core/di/service_configurations/recurring_transactions_dependencies.dart
@@ -1,3 +1,4 @@
+// lib/core/di/service_configurations/recurring_transactions_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source.dart';
 import 'package:expense_tracker/features/recurring_transactions/data/repositories/recurring_transaction_repository_impl.dart';

--- a/lib/core/di/service_configurations/settings_dependencies.dart
+++ b/lib/core/di/service_configurations/settings_dependencies.dart
@@ -1,4 +1,4 @@
-// lib/core/di/service_configuration/settings_dependencies.dart
+// lib/core/di/service_configurations/settings_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/services/demo_mode_service.dart'; // Import Demo Service
 import 'package:expense_tracker/features/settings/data/datasources/settings_local_data_source.dart';

--- a/lib/core/di/service_configurations/transactions_dependencies.dart
+++ b/lib/core/di/service_configurations/transactions_dependencies.dart
@@ -1,4 +1,4 @@
-// lib/core/di/service_configuration/transactions_dependencies.dart
+// lib/core/di/service_configurations/transactions_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/events/data_change_event.dart';
 import 'package:expense_tracker/features/transactions/domain/usecases/get_transactions_usecase.dart';


### PR DESCRIPTION
## Summary
- fix incorrect header path in accounts_dependencies.dart
- ensure all service configuration dependency files include accurate header comments

## Testing
- `dart format lib/core/di/service_configurations/*.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d88350cac8320a7f1c1228cec9269