### PR TITLE
Propagate failures during recurring transaction generation

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -210,7 +210,7 @@ class AppTheme {
       scaffoldBackgroundColor: colorScheme.background,
 
       // --- Component Themes (Configure using colorScheme and modeTheme) ---
-      cardTheme: CardTheme(
+      cardTheme: CardThemeData(
         elevation: modeTheme.cardStyle == CardStyle.flat
             ? 0
             : (modeTheme.cardStyle == CardStyle.floating ? 6 : 1.5),

--- a/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
+++ b/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
@@ -34,14 +34,18 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
     final today = DateTime(now.year, now.month, now.day);
 
     final rulesOrFailure = await recurringTransactionRepository.getRecurringRules();
-    return rulesOrFailure.fold(
-      (failure) => Left(failure),
+    return await rulesOrFailure.fold<Future<Either<Failure, void>>>(
+      (failure) async => Left(failure),
       (rules) async {
         final activeRules = rules.where((rule) => rule.status == RuleStatus.active).toList();
 
         for (var rule in activeRules) {
-          if (rule.nextOccurrenceDate.isBefore(today) || rule.nextOccurrenceDate.isAtSameMomentAs(today)) {
-            await _processRule(rule);
+          if (rule.nextOccurrenceDate.isBefore(today) ||
+              rule.nextOccurrenceDate.isAtSameMomentAs(today)) {
+            final result = await _processRule(rule);
+            if (result.isLeft()) {
+              return result;
+            }
           }
         }
         return const Right(null);
@@ -49,11 +53,12 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
     );
   }
 
-  Future<void> _processRule(RecurringRule rule) async {
+  Future<Either<Failure, void>> _processRule(RecurringRule rule) async {
     final categoryOrFailure = await categoryRepository.getCategoryById(rule.categoryId);
     final category = categoryOrFailure.getOrElse(() => null);
 
     // 1. Generate transaction
+    late Either<Failure, Object> transactionResult;
     if (rule.transactionType == TransactionType.expense) {
       final newExpense = Expense(
         id: uuid.v4(),
@@ -64,7 +69,7 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
         accountId: rule.accountId,
         isRecurring: true,
       );
-      await addExpense(AddExpenseParams(newExpense));
+      transactionResult = await addExpense(AddExpenseParams(newExpense));
     } else {
       final newIncome = Income(
         id: uuid.v4(),
@@ -76,38 +81,44 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
         notes: '',
         isRecurring: true,
       );
-      await addIncome(AddIncomeParams(newIncome));
+      transactionResult = await addIncome(AddIncomeParams(newIncome));
     }
 
-    // 2. Update rule
-    final newOccurrencesGenerated = rule.occurrencesGenerated + 1;
-    final newNextOccurrenceDate = _calculateNextOccurrence(rule);
+    return await transactionResult.fold<Future<Either<Failure, void>>>(
+      (failure) async => Left(failure),
+      (_) async {
+        // 2. Update rule
+        final newOccurrencesGenerated = rule.occurrencesGenerated + 1;
+        final newNextOccurrenceDate = _calculateNextOccurrence(rule);
 
-    RuleStatus newStatus = rule.status;
+        RuleStatus newStatus = rule.status;
 
-    // 3. Check end condition
-    bool hasEnded = false;
-    if (rule.endConditionType == EndConditionType.afterOccurrences) {
-      if (newOccurrencesGenerated >= rule.totalOccurrences!) {
-        hasEnded = true;
-      }
-    } else if (rule.endConditionType == EndConditionType.onDate) {
-      if (rule.endDate != null && newNextOccurrenceDate.isAfter(rule.endDate!)) {
-        hasEnded = true;
-      }
-    }
+        // 3. Check end condition
+        bool hasEnded = false;
+        if (rule.endConditionType == EndConditionType.afterOccurrences) {
+          if (newOccurrencesGenerated >= rule.totalOccurrences!) {
+            hasEnded = true;
+          }
+        } else if (rule.endConditionType == EndConditionType.onDate) {
+          if (rule.endDate != null &&
+              newNextOccurrenceDate.isAfter(rule.endDate!)) {
+            hasEnded = true;
+          }
+        }
 
-    if (hasEnded) {
-      newStatus = RuleStatus.completed;
-    }
+        if (hasEnded) {
+          newStatus = RuleStatus.completed;
+        }
 
-    final updatedRule = rule.copyWith(
-      status: newStatus,
-      nextOccurrenceDate: newNextOccurrenceDate,
-      occurrencesGenerated: newOccurrencesGenerated,
+        final updatedRule = rule.copyWith(
+          status: newStatus,
+          nextOccurrenceDate: newNextOccurrenceDate,
+          occurrencesGenerated: newOccurrencesGenerated,
+        );
+
+        return await recurringTransactionRepository.updateRecurringRule(updatedRule);
+      },
     );
-
-    await recurringTransactionRepository.updateRecurringRule(updatedRule);
   }
 
   DateTime _calculateNextOccurrence(RecurringRule rule) {

--- a/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
+++ b/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
@@ -122,9 +122,9 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
               nextOccurrenceDate: newNextOccurrenceDate,
               occurrencesGenerated: newOccurrencesGenerated,
             );
-
-            return await recurringTransactionRepository
+            final updateResult = await recurringTransactionRepository
                 .updateRecurringRule(updatedRule);
+            return updateResult;
           },
         );
       },

--- a/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
+++ b/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
@@ -51,6 +51,22 @@ void main() {
       date: DateTime.now(),
       accountId: '',
     )));
+    registerFallbackValue(RecurringRule(
+      id: '',
+      description: '',
+      amount: 0,
+      transactionType: TransactionType.expense,
+      accountId: '',
+      categoryId: '',
+      frequency: Frequency.monthly,
+      dayOfMonth: 1,
+      interval: 1,
+      startDate: DateTime.now(),
+      endConditionType: EndConditionType.never,
+      status: RuleStatus.active,
+      nextOccurrenceDate: DateTime.now(),
+      occurrencesGenerated: 0,
+    ));
   });
 
   setUp(() {

--- a/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
+++ b/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
@@ -169,8 +169,8 @@ void main() {
     // Assert
     verifyNever(() => mockAddExpenseUseCase(any()));
     verifyNever(() => mockAddIncomeUseCase(any()));
-    verifyNever(() =>
-        mockRecurringTransactionRepository.updateRecurringRule(any()));
+    verifyNever(
+        () => mockRecurringTransactionRepository.updateRecurringRule(any()));
   });
 
   test('should return failure when addExpense fails', () async {
@@ -189,8 +189,8 @@ void main() {
     // Assert
     expect(result, equals(const Left(failure)));
     verify(() => mockAddExpenseUseCase(any())).called(1);
-    verifyNever(() =>
-        mockRecurringTransactionRepository.updateRecurringRule(any()));
+    verifyNever(
+        () => mockRecurringTransactionRepository.updateRecurringRule(any()));
   });
 
   test('should return failure when addIncome fails', () async {
@@ -209,8 +209,8 @@ void main() {
     // Assert
     expect(result, equals(const Left(failure)));
     verify(() => mockAddIncomeUseCase(any())).called(1);
-    verifyNever(() =>
-        mockRecurringTransactionRepository.updateRecurringRule(any()));
+    verifyNever(
+        () => mockRecurringTransactionRepository.updateRecurringRule(any()));
   });
 
   test('should return failure when updateRecurringRule fails', () async {
@@ -234,5 +234,24 @@ void main() {
     verify(() => mockAddExpenseUseCase(any())).called(1);
     verify(() => mockRecurringTransactionRepository.updateRecurringRule(any()))
         .called(1);
+  });
+
+  test('should return failure when category lookup fails', () async {
+    // Arrange
+    const failure = ServerFailure('getCategoryById failed');
+    when(() => mockRecurringTransactionRepository.getRecurringRules())
+        .thenAnswer((_) async => Right([tRule]));
+    when(() => mockCategoryRepository.getCategoryById(any()))
+        .thenAnswer((_) async => const Left(failure));
+
+    // Act
+    final result = await usecase(const NoParams());
+
+    // Assert
+    expect(result, equals(const Left(failure)));
+    verify(() => mockCategoryRepository.getCategoryById(any())).called(1);
+    verifyNever(() => mockAddExpenseUseCase(any()));
+    verifyNever(
+        () => mockRecurringTransactionRepository.updateRecurringRule(any()));
   });
 }

--- a/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
+++ b/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
@@ -75,6 +75,7 @@ void main() {
     mockAddExpenseUseCase = MockAddExpenseUseCase();
     mockAddIncomeUseCase = MockAddIncomeUseCase();
     mockUuid = MockUuid();
+    when(() => mockUuid.v4()).thenReturn('new_id');
     usecase = GenerateTransactionsOnLaunch(
       recurringTransactionRepository: mockRecurringTransactionRepository,
       categoryRepository: mockCategoryRepository,
@@ -146,7 +147,6 @@ void main() {
         .thenAnswer((_) async => Right(tExpense));
     when(() => mockRecurringTransactionRepository.updateRecurringRule(any()))
         .thenAnswer((_) async => const Right(null));
-    when(() => mockUuid.v4()).thenReturn('new_id');
 
     // Act
     await usecase(const NoParams());
@@ -240,7 +240,6 @@ void main() {
         .thenAnswer((_) async => Right(tExpense));
     when(() => mockRecurringTransactionRepository.updateRecurringRule(any()))
         .thenAnswer((_) async => const Left(failure));
-    when(() => mockUuid.v4()).thenReturn('new_id');
 
     // Act
     final result = await usecase(const NoParams());


### PR DESCRIPTION
## Summary
- Ensure GenerateTransactionsOnLaunch stops processing and returns failures from addExpense/addIncome and rule updates
- Add tests for failure propagation from transaction creation and rule updates

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689d97061b148320bb7287c52f93663d