### PR TITLE
Return NotFoundFailure for missing categories

### DIFF
--- a/lib/features/categories/data/repositories/category_repository_impl.dart
+++ b/lib/features/categories/data/repositories/category_repository_impl.dart
@@ -135,20 +135,26 @@ class CategoryRepositoryImpl implements CategoryRepository {
   }
 
   @override
-  Future<Either<Failure, Category?>> getCategoryById(String categoryId) async {
+  Future<Either<Failure, Category>> getCategoryById(String categoryId) async {
     log.fine("[CategoryRepo] getCategoryById called for ID: $categoryId");
     final allCategoriesResult = await getAllCategories();
-    return allCategoriesResult.fold((failure) => Left(failure), (categories) {
-      // Use firstWhereOrNull from collection package for safety
-      final category =
-          categories.firstWhereOrNull((cat) => cat.id == categoryId);
-      if (category != null) {
-        log.fine("[CategoryRepo] Found category by ID: ${category.name}");
-      } else {
-        log.warning("[CategoryRepo] Category with ID '$categoryId' not found.");
-      }
-      return Right(category); // Return Right(null) if not found
-    });
+    return allCategoriesResult.fold(
+      (failure) => Left(failure),
+      (categories) {
+        // Use firstWhereOrNull from collection package for safety
+        final category =
+            categories.firstWhereOrNull((cat) => cat.id == categoryId);
+        if (category != null) {
+          log.fine("[CategoryRepo] Found category by ID: ${category.name}");
+          return Right(category);
+        } else {
+          log.warning(
+              "[CategoryRepo] Category with ID '$categoryId' not found.");
+          return Left(
+              NotFoundFailure("Category with ID '$categoryId' not found"));
+        }
+      },
+    );
   }
 
   @override

--- a/lib/features/categories/domain/repositories/category_repository.dart
+++ b/lib/features/categories/domain/repositories/category_repository.dart
@@ -17,7 +17,7 @@ abstract class CategoryRepository {
   Future<Either<Failure, List<Category>>> getCustomCategories(
       {CategoryType? type}); // Allow filtering custom by type
 
-  Future<Either<Failure, Category?>> getCategoryById(String categoryId);
+  Future<Either<Failure, Category>> getCategoryById(String categoryId);
   Future<Either<Failure, void>> addCustomCategory(
       Category category); // Category now includes type
   Future<Either<Failure, void>> updateCategory(

--- a/lib/features/categories/domain/usecases/categorize_transaction.dart
+++ b/lib/features/categories/domain/usecases/categorize_transaction.dart
@@ -230,7 +230,8 @@ class CategorizeTransactionUseCase
   Future<Category?> _getCategoryById(String? categoryId) async {
     /* ... same as before ... */
     if (categoryId == null) return null;
-    final result = await categoryRepository.getCategoryById(categoryId);
+    final result =
+        await categoryRepository.getCategoryById(categoryId!);
     return result.fold(
       (failure) {
         log.warning(

--- a/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
+++ b/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
@@ -12,6 +12,7 @@ import 'package:expense_tracker/features/recurring_transactions/domain/entities/
 import 'package:expense_tracker/features/recurring_transactions/domain/repositories/recurring_transaction_repository.dart';
 import 'package:expense_tracker/features/transactions/domain/entities/transaction_entity.dart';
 import 'package:uuid/uuid.dart';
+import 'package:expense_tracker/main.dart';
 
 class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
   final RecurringTransactionRepository recurringTransactionRepository;

--- a/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
+++ b/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
@@ -12,7 +12,7 @@ import 'package:expense_tracker/features/recurring_transactions/domain/entities/
 import 'package:expense_tracker/features/recurring_transactions/domain/repositories/recurring_transaction_repository.dart';
 import 'package:expense_tracker/features/transactions/domain/entities/transaction_entity.dart';
 import 'package:uuid/uuid.dart';
-import 'package:expense_tracker/main.dart';
+import 'package:expense_tracker/main.dart' as app_logger;
 
 class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
   final RecurringTransactionRepository recurringTransactionRepository;
@@ -57,11 +57,11 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
     categoryResult.fold(
       (failure) {
         if (failure is NotFoundFailure) {
-          log.warning(
+          app_logger.log.warning(
               "[GenerateTransactionsOnLaunch] Category with ID '${rule.categoryId}' not found. Continuing with null category.");
           category = null;
         } else {
-          log.warning(
+          app_logger.log.warning(
               "[GenerateTransactionsOnLaunch] Failed to fetch category for rule ${rule.id}: ${failure.message}");
           category = null;
         }

--- a/test/features/categories/data/repositories/category_repository_impl_test.dart
+++ b/test/features/categories/data/repositories/category_repository_impl_test.dart
@@ -1,0 +1,56 @@
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/categories/data/datasources/category_local_data_source.dart';
+import 'package:expense_tracker/features/categories/data/datasources/category_predefined_data_source.dart';
+import 'package:expense_tracker/features/categories/data/models/category_model.dart';
+import 'package:expense_tracker/features/categories/data/repositories/category_repository_impl.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockCategoryLocalDataSource extends Mock implements CategoryLocalDataSource {}
+
+class MockCategoryPredefinedDataSource extends Mock
+    implements CategoryPredefinedDataSource {}
+
+void main() {
+  late CategoryRepositoryImpl repository;
+  late MockCategoryLocalDataSource mockLocal;
+  late MockCategoryPredefinedDataSource mockExpensePredefined;
+  late MockCategoryPredefinedDataSource mockIncomePredefined;
+
+  setUp(() {
+    mockLocal = MockCategoryLocalDataSource();
+    mockExpensePredefined = MockCategoryPredefinedDataSource();
+    mockIncomePredefined = MockCategoryPredefinedDataSource();
+    repository = CategoryRepositoryImpl(
+      localDataSource: mockLocal,
+      expensePredefinedDataSource: mockExpensePredefined,
+      incomePredefinedDataSource: mockIncomePredefined,
+    );
+  });
+
+  final expenseModel = CategoryModel(
+    id: 'e1',
+    name: 'Expense',
+    iconName: 'icon',
+    colorHex: '#000000',
+    isCustom: false,
+    typeIndex: CategoryType.expense.index,
+  );
+
+  test('returns NotFoundFailure when category ID missing', () async {
+    when(() => mockExpensePredefined.getPredefinedCategories())
+        .thenAnswer((_) async => [expenseModel]);
+    when(() => mockIncomePredefined.getPredefinedCategories())
+        .thenAnswer((_) async => []);
+    when(() => mockLocal.getCustomCategories()).thenAnswer((_) async => []);
+
+    final result = await repository.getCategoryById('missing');
+
+    expect(result.isLeft(), true);
+    result.fold(
+      (failure) => expect(failure, isA<NotFoundFailure>()),
+      (_) => fail('Expected failure'),
+    );
+  });
+}

--- a/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
+++ b/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
@@ -7,6 +7,7 @@ import 'package:expense_tracker/features/categories/domain/repositories/category
 import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
 import 'package:expense_tracker/features/expenses/domain/usecases/add_expense.dart';
 import 'package:expense_tracker/features/income/domain/usecases/add_income.dart';
+import 'package:expense_tracker/features/income/domain/entities/income.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule_enums.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/repositories/recurring_transaction_repository.dart';
@@ -43,6 +44,29 @@ void main() {
       date: DateTime.now(),
       accountId: '',
     )));
+    registerFallbackValue(AddIncomeParams(Income(
+      id: '',
+      title: '',
+      amount: 0,
+      date: DateTime.now(),
+      accountId: '',
+    )));
+    registerFallbackValue(RecurringRule(
+      id: '',
+      description: '',
+      amount: 0,
+      transactionType: TransactionType.expense,
+      accountId: '',
+      categoryId: '',
+      frequency: Frequency.monthly,
+      dayOfMonth: 1,
+      interval: 1,
+      startDate: DateTime.now(),
+      endConditionType: EndConditionType.never,
+      status: RuleStatus.active,
+      nextOccurrenceDate: DateTime.now(),
+      occurrencesGenerated: 0,
+    ));
   });
 
   setUp(() {


### PR DESCRIPTION
## Summary
- Fail `getCategoryById` with `NotFoundFailure` when a category ID is missing
- Handle missing category failures in expense, income and recurring transaction logic
- Test category lookup failure scenarios
