### PR TITLE
Handle missing AccountListBloc in filter dialog

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -210,7 +210,7 @@ class AppTheme {
       scaffoldBackgroundColor: colorScheme.background,
 
       // --- Component Themes (Configure using colorScheme and modeTheme) ---
-      cardTheme: CardTheme(
+      cardTheme: CardThemeData(
         elevation: modeTheme.cardStyle == CardStyle.flat
             ? 0
             : (modeTheme.cardStyle == CardStyle.floating ? 6 : 1.5),
@@ -218,12 +218,12 @@ class AppTheme {
             ? const EdgeInsets.symmetric(horizontal: 8, vertical: 4)
             : const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(
-                modeTheme.cardStyle == CardStyle.flat
-                    ? 8
-                    : (modeTheme.layoutDensity == LayoutDensity.spacious
-                        ? 20
-                        : 16))),
+          borderRadius: BorderRadius.circular(
+            modeTheme.cardStyle == CardStyle.flat
+                ? 8
+                : (modeTheme.layoutDensity == LayoutDensity.spacious ? 20 : 16),
+          ),
+        ),
         color: modePrefix == 'aether'
             ? colorScheme.surfaceVariant.withOpacity(0.85)
             : (modePrefix == 'quantum'

--- a/lib/features/transactions/presentation/widgets/transaction_filter_dialog.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_filter_dialog.dart
@@ -293,26 +293,29 @@ class _TransactionFilterDialogState extends State<TransactionFilterDialog> {
       actionsPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       actions: <Widget>[
         TextButton(
-            child: const Text('Clear All'),
-            onPressed: () {
-              widget.onClearFilter();
-              Navigator.of(context).pop();
-            }),
-        const Spacer(), // Push buttons to the right
+          onPressed: () {
+            widget.onClearFilter();
+            Navigator.of(context).pop();
+          },
+          child: const Text('Clear All'),
+        ),
         TextButton(
-            child: const Text('Cancel'),
-            onPressed: () => Navigator.of(context).pop()),
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
         ElevatedButton(
-            child: const Text('Apply Filters'),
-            onPressed: () {
-              widget.onApplyFilter(
-                  _selectedStartDate,
-                  _selectedEndDate,
-                  _selectedTransactionType,
-                  _selectedAccountId,
-                  _selectedCategoryId);
-              Navigator.of(context).pop();
-            }),
+          onPressed: () {
+            widget.onApplyFilter(
+              _selectedStartDate,
+              _selectedEndDate,
+              _selectedTransactionType,
+              _selectedAccountId,
+              _selectedCategoryId,
+            );
+            Navigator.of(context).pop();
+          },
+          child: const Text('Apply Filters'),
+        ),
       ],
     );
   }

--- a/lib/features/transactions/presentation/widgets/transaction_filter_dialog.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_filter_dialog.dart
@@ -6,6 +6,16 @@ import 'package:expense_tracker/features/transactions/domain/entities/transactio
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+extension MaybeReadBuildContext on BuildContext {
+  T? maybeRead<T>() {
+    try {
+      return read<T>();
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
 // Callback type for applying filters
 typedef ApplyFiltersCallback = void Function(
   DateTime? startDate,

--- a/test/features/transactions/presentation/widgets/transaction_filter_dialog_test.dart
+++ b/test/features/transactions/presentation/widgets/transaction_filter_dialog_test.dart
@@ -1,0 +1,24 @@
+import 'package:expense_tracker/features/transactions/presentation/widgets/transaction_filter_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('does not crash when AccountListBloc is absent', (tester) async {
+    bool callbackInvoked = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TransactionFilterDialog(
+          onApplyFilter: (a, b, c, d, e) {},
+          onClearFilter: () {},
+          availableCategories: const [],
+          onLoadAccounts: () => callbackInvoked = true,
+          accountSelectorBuilder: (selected, onChanged) => const SizedBox(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TransactionFilterDialog), findsOneWidget);
+    expect(callbackInvoked, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- Safely dispatch LoadAccounts only when AccountListBloc is available
- Allow providing a custom account selector when the bloc is absent
- Add widget test to ensure the dialog doesn't crash without AccountListBloc

## Testing
- `flutter test test/features/transactions/presentation/widgets/transaction_filter_dialog_test.dart` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689d97af0ec48320a549b15cf36137eb