### PR TITLE
Handle non-custom category update validation

### DIFF
--- a/lib/features/categories/data/repositories/category_repository_impl.dart
+++ b/lib/features/categories/data/repositories/category_repository_impl.dart
@@ -179,20 +179,19 @@ class CategoryRepositoryImpl implements CategoryRepository {
   Future<Either<Failure, void>> updateCategory(Category category) async {
     log.info(
         "[CategoryRepo] updateCategory called for '${category.name}' (ID: ${category.id}), Type: ${category.type.name}. Custom: ${category.isCustom}");
+    if (!category.isCustom) {
+      log.warning(
+          "[CategoryRepo] Attempted to update a non-custom category.");
+      return const Left(
+          ValidationFailure("Only custom categories can be updated."));
+    }
     try {
       final model = CategoryModel.fromEntity(category);
-      if (!category.isCustom) {
-        log.warning(
-            "[CategoryRepo] Updating predefined category personalization NOT YET IMPLEMENTED. Ignoring update.");
-        // TODO: Implement saving personalization
-        return const Right(null);
-      } else {
-        await localDataSource.updateCustomCategory(model);
-        invalidateCache(); // Invalidate cache after successful update
-        log.info(
-            "[CategoryRepo] Custom category '${category.name}' updated successfully.");
-        return const Right(null);
-      }
+      await localDataSource.updateCustomCategory(model);
+      invalidateCache(); // Invalidate cache after successful update
+      log.info(
+          "[CategoryRepo] Custom category '${category.name}' updated successfully.");
+      return const Right(null);
     } catch (e) {
       invalidateCache(); // Invalidate on error?
       log.warning(

--- a/lib/features/categories/domain/usecases/update_custom_category.dart
+++ b/lib/features/categories/domain/usecases/update_custom_category.dart
@@ -17,6 +17,12 @@ class UpdateCustomCategoryUseCase
     final category = params.category;
     log.info(
         "[UpdateCustomCategoryUseCase] Executing for category ID: ${category.id}, Name: '${category.name}'.");
+    if (!category.isCustom) {
+      log.warning(
+          "[UpdateCustomCategoryUseCase] Validation failed: Only custom categories can be updated.");
+      return const Left(
+          ValidationFailure("Only custom categories can be updated."));
+    }
 
     // Validation (similar to Add, but allow existing name if ID matches)
     if (category.name.trim().isEmpty) {

--- a/test/features/categories/data/repositories/category_repository_impl_test.dart
+++ b/test/features/categories/data/repositories/category_repository_impl_test.dart
@@ -1,0 +1,53 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/categories/data/datasources/category_local_data_source.dart';
+import 'package:expense_tracker/features/categories/data/datasources/category_predefined_data_source.dart';
+import 'package:expense_tracker/features/categories/data/repositories/category_repository_impl.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockCategoryLocalDataSource extends Mock implements CategoryLocalDataSource {}
+
+class MockCategoryPredefinedDataSource extends Mock
+    implements CategoryPredefinedDataSource {}
+
+void main() {
+  late CategoryRepositoryImpl repository;
+  late MockCategoryLocalDataSource mockLocalDataSource;
+  late MockCategoryPredefinedDataSource mockExpensePredefinedDataSource;
+  late MockCategoryPredefinedDataSource mockIncomePredefinedDataSource;
+
+  setUp(() {
+    mockLocalDataSource = MockCategoryLocalDataSource();
+    mockExpensePredefinedDataSource = MockCategoryPredefinedDataSource();
+    mockIncomePredefinedDataSource = MockCategoryPredefinedDataSource();
+    repository = CategoryRepositoryImpl(
+      localDataSource: mockLocalDataSource,
+      expensePredefinedDataSource: mockExpensePredefinedDataSource,
+      incomePredefinedDataSource: mockIncomePredefinedDataSource,
+    );
+  });
+
+  test('should return ValidationFailure when updating non-custom category',
+      () async {
+    const nonCustomCategory = Category(
+      id: '1',
+      name: 'Food',
+      iconName: 'food',
+      colorHex: '#FFFFFF',
+      type: CategoryType.expense,
+      isCustom: false,
+    );
+
+    final result = await repository.updateCategory(nonCustomCategory);
+
+    expect(
+      result,
+      equals(const Left(
+          ValidationFailure('Only custom categories can be updated.'))),
+    );
+    verifyZeroInteractions(mockLocalDataSource);
+  });
+}

--- a/test/features/categories/domain/usecases/update_custom_category_test.dart
+++ b/test/features/categories/domain/usecases/update_custom_category_test.dart
@@ -1,0 +1,41 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category_type.dart';
+import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
+import 'package:expense_tracker/features/categories/domain/usecases/update_custom_category.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockCategoryRepository extends Mock implements CategoryRepository {}
+
+void main() {
+  late UpdateCustomCategoryUseCase usecase;
+  late MockCategoryRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockCategoryRepository();
+    usecase = UpdateCustomCategoryUseCase(mockRepository);
+  });
+
+  test('should return ValidationFailure when category is not custom', () async {
+    const nonCustomCategory = Category(
+      id: '1',
+      name: 'Food',
+      iconName: 'food',
+      colorHex: '#FFFFFF',
+      type: CategoryType.expense,
+      isCustom: false,
+    );
+
+    final params = UpdateCustomCategoryParams(category: nonCustomCategory);
+    final result = await usecase(params);
+
+    expect(
+      result,
+      equals(const Left(
+          ValidationFailure('Only custom categories can be updated.'))),
+    );
+    verifyZeroInteractions(mockRepository);
+  });
+}


### PR DESCRIPTION
## Summary
- Prevent updates to non-custom categories by returning a ValidationFailure
- Validate category type in UpdateCustomCategoryUseCase
- Add tests covering repository and use case failure cases

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d979ec7d0832092107dd27524b9b2