### PR TITLE
Handle audit log failures in update recurring rule

### DIFF
--- a/lib/features/recurring_transactions/domain/usecases/update_recurring_rule.dart
+++ b/lib/features/recurring_transactions/domain/usecases/update_recurring_rule.dart
@@ -30,7 +30,10 @@ class UpdateRecurringRule implements UseCase<void, RecurringRule> {
       (oldRule) async {
         final logs = _createAuditLogs(oldRule, newRule);
         for (var log in logs) {
-          await addAuditLog(log);
+          final logResult = await addAuditLog(log);
+          if (logResult.isLeft()) {
+            return logResult;
+          }
         }
         return repository.updateRecurringRule(newRule);
       },

--- a/test/features/recurring_transactions/domain/usecases/update_recurring_rule_test.dart
+++ b/test/features/recurring_transactions/domain/usecases/update_recurring_rule_test.dart
@@ -1,6 +1,7 @@
 import 'package:dartz/dartz.dart';
 import 'package:expense_tracker/core/error/failure.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule_audit_log.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule_enums.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/repositories/recurring_transaction_repository.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/usecases/add_audit_log.dart';
@@ -23,19 +24,6 @@ void main() {
   late MockAddAuditLog mockAddAuditLog;
   late MockUuid mockUuid;
 
-  setUp(() {
-    mockRepository = MockRecurringTransactionRepository();
-    mockGetRecurringRuleById = MockGetRecurringRuleById();
-    mockAddAuditLog = MockAddAuditLog();
-    mockUuid = MockUuid();
-    usecase = UpdateRecurringRule(
-      repository: mockRepository,
-      getRecurringRuleById: mockGetRecurringRuleById,
-      addAuditLog: mockAddAuditLog,
-      uuid: mockUuid,
-    );
-  });
-
   final tOldRule = RecurringRule(
     id: '1',
     description: 'Old Description',
@@ -53,6 +41,34 @@ void main() {
   );
 
   final tNewRule = tOldRule.copyWith(description: 'New Description', amount: 150);
+
+  setUpAll(() {
+    registerFallbackValue(tOldRule);
+    registerFallbackValue(
+      RecurringRuleAuditLog(
+        id: 'log',
+        ruleId: 'rule',
+        timestamp: DateTime(2023, 1, 1),
+        userId: 'user',
+        fieldChanged: 'field',
+        oldValue: 'old',
+        newValue: 'new',
+      ),
+    );
+  });
+
+  setUp(() {
+    mockRepository = MockRecurringTransactionRepository();
+    mockGetRecurringRuleById = MockGetRecurringRuleById();
+    mockAddAuditLog = MockAddAuditLog();
+    mockUuid = MockUuid();
+    usecase = UpdateRecurringRule(
+      repository: mockRepository,
+      getRecurringRuleById: mockGetRecurringRuleById,
+      addAuditLog: mockAddAuditLog,
+      uuid: mockUuid,
+    );
+  });
 
   test('should create audit logs for changed fields', () async {
     // Arrange

--- a/test/features/recurring_transactions/domain/usecases/update_recurring_rule_test.dart
+++ b/test/features/recurring_transactions/domain/usecases/update_recurring_rule_test.dart
@@ -91,6 +91,7 @@ void main() {
     when(() => mockGetRecurringRuleById(any())).thenAnswer((_) async => Right(tOldRule));
     when(() => mockAddAuditLog(any())).thenAnswer((_) async => Left(failure));
     when(() => mockRepository.updateRecurringRule(any())).thenAnswer((_) async => const Right(null));
+    when(() => mockUuid.v4()).thenReturn('new_log_id');
 
     // Act
     final result = await usecase(tNewRule);


### PR DESCRIPTION
## Summary
- halt rule update if any audit log creation fails
- test that audit log failure prevents rule updates

## Testing
- `flutter test test/features/recurring_transactions/domain/usecases/update_recurring_rule_test.dart` *(command failed: bash: command not found: flutter)*
- `dart test test/features/recurring_transactions/domain/usecases/update_recurring_rule_test.dart` *(command failed: bash: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_689d977d36d88320bc244ec9b3428dc5