### PR TITLE
Preserve balance when editing accounts

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -210,7 +210,7 @@ class AppTheme {
       scaffoldBackgroundColor: colorScheme.background,
 
       // --- Component Themes (Configure using colorScheme and modeTheme) ---
-      cardTheme: CardTheme(
+      cardTheme: CardThemeData(
         elevation: modeTheme.cardStyle == CardStyle.flat
             ? 0
             : (modeTheme.cardStyle == CardStyle.floating ? 6 : 1.5),

--- a/lib/features/accounts/presentation/bloc/add_edit_account/add_edit_account_bloc.dart
+++ b/lib/features/accounts/presentation/bloc/add_edit_account/add_edit_account_bloc.dart
@@ -39,13 +39,17 @@ class AddEditAccountBloc
     emit(state.copyWith(status: FormStatus.submitting, clearError: true));
 
     final bool isEditing = event.existingAccountId != null;
-    // Current balance is calculated by repository, use 0 or initial value as placeholder
+    // Preserve existing current balance when editing; repository recalculates later
+    final currentBalance = isEditing
+        ? state.initialAccount?.currentBalance ?? event.initialBalance
+        : event.initialBalance;
+
     final accountData = AssetAccount(
       id: event.existingAccountId ?? _uuid.v4(),
       name: event.name,
       type: event.type,
       initialBalance: event.initialBalance,
-      currentBalance: event.initialBalance, // Placeholder, repo recalculates
+      currentBalance: currentBalance,
     );
 
     log.info(

--- a/test/features/accounts/presentation/bloc/add_edit_account_bloc_test.dart
+++ b/test/features/accounts/presentation/bloc/add_edit_account_bloc_test.dart
@@ -1,0 +1,84 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/utils/enums.dart';
+import 'package:expense_tracker/features/accounts/domain/entities/asset_account.dart';
+import 'package:expense_tracker/features/accounts/domain/repositories/asset_account_repository.dart';
+import 'package:expense_tracker/features/accounts/domain/usecases/add_asset_account.dart';
+import 'package:expense_tracker/features/accounts/domain/usecases/update_asset_account.dart';
+import 'package:expense_tracker/features/accounts/presentation/bloc/add_edit_account/add_edit_account_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockAssetAccountRepository extends Mock
+    implements AssetAccountRepository {}
+
+void main() {
+  late MockAssetAccountRepository repository;
+  late AddAssetAccountUseCase addUseCase;
+  late UpdateAssetAccountUseCase updateUseCase;
+
+  setUpAll(() {
+    registerFallbackValue(const AssetAccount(
+      id: 'fallback',
+      name: 'fallback',
+      type: AssetType.cash,
+      currentBalance: 0,
+    ));
+  });
+
+  setUp(() {
+    repository = MockAssetAccountRepository();
+    addUseCase = AddAssetAccountUseCase(repository);
+    updateUseCase = UpdateAssetAccountUseCase(repository);
+  });
+
+  group('AddEditAccountBloc', () {
+    final existingAccount = AssetAccount(
+      id: '1',
+      name: 'Existing',
+      type: AssetType.bank,
+      initialBalance: 100,
+      currentBalance: 200,
+    );
+
+    blocTest<AddEditAccountBloc, AddEditAccountState>(
+      'preserves current balance when editing',
+      build: () {
+        when(() => repository.updateAssetAccount(any())).thenAnswer(
+          (invocation) async => Right(invocation.positionalArguments.first),
+        );
+        return AddEditAccountBloc(
+          addAssetAccountUseCase: addUseCase,
+          updateAssetAccountUseCase: updateUseCase,
+          initialAccount: existingAccount,
+        );
+      },
+      act: (bloc) => bloc.add(
+        const SaveAccountRequested(
+          name: 'Updated',
+          type: AssetType.bank,
+          initialBalance: 500,
+          existingAccountId: '1',
+        ),
+      ),
+      expect: () => [
+        AddEditAccountState(
+          status: FormStatus.submitting,
+          initialAccount: existingAccount,
+        ),
+        AddEditAccountState(
+          status: FormStatus.success,
+          initialAccount: existingAccount,
+        ),
+      ],
+      verify: (_) {
+        final captured =
+            verify(() => repository.updateAssetAccount(captureAny()))
+                .captured
+                .single as AssetAccount;
+        expect(captured.currentBalance, existingAccount.currentBalance);
+        expect(captured.initialBalance, 500);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Keep existing balance when editing an account in `AddEditAccountBloc`
- Add unit test verifying repository receives the unchanged balance during edits
- Update theme to use `CardThemeData` and resolve compilation failure

## Testing
- `flutter test test/features/accounts/presentation/bloc/add_edit_account_bloc_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_689d97a3bf688320a703464e21e821a6