### PR TITLE
Scope report filters per report page

### DIFF
--- a/lib/core/di/service_configurations/report_dependencies.dart
+++ b/lib/core/di/service_configurations/report_dependencies.dart
@@ -48,32 +48,34 @@ class ReportDependencies {
         () => CsvExportHelper(downloaderService: sl()));
 
     // --- Blocs ---
-    // Shared filter bloc - Singleton
-    sl.registerLazySingleton<ReportFilterBloc>(() => ReportFilterBloc(
-          // --- FINAL FIX: Use parameter names from the Bloc's constructor ---
-          categoryRepository: sl<
-              GetCategoriesUseCase>(), // Parameter name is 'categoryRepository'
-          accountRepository: sl<
-              GetAssetAccountsUseCase>(), // Parameter name is 'accountRepository'
-          budgetRepository:
-              sl<GetBudgetsUseCase>(), // Parameter name is 'budgetRepository'
-          goalRepository:
-              sl<GetGoalsUseCase>(), // Parameter name is 'goalRepository'
-          // --- END FIX ---
+    // Filter bloc - Factory (new instance per report page)
+    sl.registerFactory<ReportFilterBloc>(() => ReportFilterBloc(
+          categoryRepository: sl<GetCategoriesUseCase>(),
+          accountRepository: sl<GetAssetAccountsUseCase>(),
+          budgetRepository: sl<GetBudgetsUseCase>(),
+          goalRepository: sl<GetGoalsUseCase>(),
         ));
 
-    // Individual report Blocs (depend on filter bloc stream) - Factory
-    sl.registerFactory<SpendingCategoryReportBloc>(() =>
-        SpendingCategoryReportBloc(
-            getSpendingCategoryReportUseCase: sl(), reportFilterBloc: sl()));
-    sl.registerFactory<SpendingTimeReportBloc>(() => SpendingTimeReportBloc(
-        getSpendingTimeReportUseCase: sl(), reportFilterBloc: sl()));
-    sl.registerFactory<IncomeExpenseReportBloc>(() => IncomeExpenseReportBloc(
-        getIncomeExpenseReportUseCase: sl(), reportFilterBloc: sl()));
-    sl.registerFactory<BudgetPerformanceReportBloc>(() =>
-        BudgetPerformanceReportBloc(
-            getBudgetPerformanceReportUseCase: sl(), reportFilterBloc: sl()));
-    sl.registerFactory<GoalProgressReportBloc>(() => GoalProgressReportBloc(
-        getGoalProgressReportUseCase: sl(), reportFilterBloc: sl()));
+    // Individual report Blocs require an external ReportFilterBloc
+    sl.registerFactoryParam<SpendingCategoryReportBloc, ReportFilterBloc, void>(
+        (filterBloc, _) => SpendingCategoryReportBloc(
+            getSpendingCategoryReportUseCase: sl(),
+            reportFilterBloc: filterBloc));
+    sl.registerFactoryParam<SpendingTimeReportBloc, ReportFilterBloc, void>(
+        (filterBloc, _) => SpendingTimeReportBloc(
+            getSpendingTimeReportUseCase: sl(),
+            reportFilterBloc: filterBloc));
+    sl.registerFactoryParam<IncomeExpenseReportBloc, ReportFilterBloc, void>(
+        (filterBloc, _) => IncomeExpenseReportBloc(
+            getIncomeExpenseReportUseCase: sl(),
+            reportFilterBloc: filterBloc));
+    sl.registerFactoryParam<BudgetPerformanceReportBloc, ReportFilterBloc, void>(
+        (filterBloc, _) => BudgetPerformanceReportBloc(
+            getBudgetPerformanceReportUseCase: sl(),
+            reportFilterBloc: filterBloc));
+    sl.registerFactoryParam<GoalProgressReportBloc, ReportFilterBloc, void>(
+        (filterBloc, _) => GoalProgressReportBloc(
+            getGoalProgressReportUseCase: sl(),
+            reportFilterBloc: filterBloc));
   }
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -369,76 +369,96 @@ class AppRouter {
         path: RouteNames.reportSpendingCategory, // Relative path
         name: RouteNames.reportSpendingCategory,
         parentNavigatorKey: parentKey, // Ensure it pushes onto root
-        pageBuilder: (context, state) => MaterialPage(
-          key: state.pageKey,
-          child: BlocProvider(
-            create: (_) => sl<SpendingCategoryReportBloc>(),
-            child: BlocProvider.value(
-              value: sl<ReportFilterBloc>(),
-              child: const SpendingByCategoryPage(),
+        pageBuilder: (context, state) {
+          final filterBloc = sl<ReportFilterBloc>();
+          return MaterialPage(
+            key: state.pageKey,
+            child: BlocProvider<ReportFilterBloc>(
+              create: (_) => filterBloc,
+              child: BlocProvider<SpendingCategoryReportBloc>(
+                create: (_) =>
+                    sl<SpendingCategoryReportBloc>(param1: filterBloc),
+                child: const SpendingByCategoryPage(),
+              ),
             ),
-          ),
-        ),
+          );
+        },
       ),
       GoRoute(
         path: RouteNames.reportSpendingTime,
         name: RouteNames.reportSpendingTime,
         parentNavigatorKey: parentKey,
-        pageBuilder: (context, state) => MaterialPage(
-          key: state.pageKey,
-          child: BlocProvider(
-            create: (_) => sl<SpendingTimeReportBloc>(),
-            child: BlocProvider.value(
-              value: sl<ReportFilterBloc>(),
-              child: const SpendingOverTimePage(),
+        pageBuilder: (context, state) {
+          final filterBloc = sl<ReportFilterBloc>();
+          return MaterialPage(
+            key: state.pageKey,
+            child: BlocProvider<ReportFilterBloc>(
+              create: (_) => filterBloc,
+              child: BlocProvider<SpendingTimeReportBloc>(
+                create: (_) =>
+                    sl<SpendingTimeReportBloc>(param1: filterBloc),
+                child: const SpendingOverTimePage(),
+              ),
             ),
-          ),
-        ),
+          );
+        },
       ),
       GoRoute(
         path: RouteNames.reportIncomeExpense,
         name: RouteNames.reportIncomeExpense,
         parentNavigatorKey: parentKey,
-        pageBuilder: (context, state) => MaterialPage(
-          key: state.pageKey,
-          child: BlocProvider(
-            create: (_) => sl<IncomeExpenseReportBloc>(),
-            child: BlocProvider.value(
-              value: sl<ReportFilterBloc>(),
-              child: const IncomeVsExpensePage(),
+        pageBuilder: (context, state) {
+          final filterBloc = sl<ReportFilterBloc>();
+          return MaterialPage(
+            key: state.pageKey,
+            child: BlocProvider<ReportFilterBloc>(
+              create: (_) => filterBloc,
+              child: BlocProvider<IncomeExpenseReportBloc>(
+                create: (_) =>
+                    sl<IncomeExpenseReportBloc>(param1: filterBloc),
+                child: const IncomeVsExpensePage(),
+              ),
             ),
-          ),
-        ),
+          );
+        },
       ),
       GoRoute(
         path: RouteNames.reportBudgetPerformance,
         name: RouteNames.reportBudgetPerformance,
         parentNavigatorKey: parentKey,
-        pageBuilder: (context, state) => MaterialPage(
-          key: state.pageKey,
-          child: BlocProvider(
-            create: (_) => sl<BudgetPerformanceReportBloc>(),
-            child: BlocProvider.value(
-              value: sl<ReportFilterBloc>(),
-              child: const BudgetPerformancePage(),
+        pageBuilder: (context, state) {
+          final filterBloc = sl<ReportFilterBloc>();
+          return MaterialPage(
+            key: state.pageKey,
+            child: BlocProvider<ReportFilterBloc>(
+              create: (_) => filterBloc,
+              child: BlocProvider<BudgetPerformanceReportBloc>(
+                create: (_) =>
+                    sl<BudgetPerformanceReportBloc>(param1: filterBloc),
+                child: const BudgetPerformancePage(),
+              ),
             ),
-          ),
-        ),
+          );
+        },
       ),
       GoRoute(
         path: RouteNames.reportGoalProgress,
         name: RouteNames.reportGoalProgress,
         parentNavigatorKey: parentKey,
-        pageBuilder: (context, state) => MaterialPage(
-          key: state.pageKey,
-          child: BlocProvider(
-            create: (_) => sl<GoalProgressReportBloc>(),
-            child: BlocProvider.value(
-              value: sl<ReportFilterBloc>(),
-              child: const GoalProgressPage(),
+        pageBuilder: (context, state) {
+          final filterBloc = sl<ReportFilterBloc>();
+          return MaterialPage(
+            key: state.pageKey,
+            child: BlocProvider<ReportFilterBloc>(
+              create: (_) => filterBloc,
+              child: BlocProvider<GoalProgressReportBloc>(
+                create: (_) =>
+                    sl<GoalProgressReportBloc>(param1: filterBloc),
+                child: const GoalProgressPage(),
+              ),
             ),
-          ),
-        ),
+          );
+        },
       ),
     ];
   }


### PR DESCRIPTION
## Summary
- register ReportFilterBloc as a factory and inject it into report blocs on demand
- create fresh ReportFilterBloc instances for each report route so filters are isolated

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dbb44bebc8320aa111fb8f1633928