### PR TITLE
feat(goal): audit goal total saved cache

### DIFF
--- a/lib/core/di/service_configurations/goal_dependencies.dart
+++ b/lib/core/di/service_configurations/goal_dependencies.dart
@@ -27,6 +27,7 @@ import 'package:expense_tracker/features/goals/domain/usecases/get_contributions
 import 'package:expense_tracker/features/goals/domain/usecases/get_goals.dart';
 import 'package:expense_tracker/features/goals/domain/usecases/update_contribution.dart';
 import 'package:expense_tracker/features/goals/domain/usecases/update_goal.dart';
+import 'package:expense_tracker/features/goals/domain/usecases/audit_goal_totals.dart';
 // Blocs
 import 'package:expense_tracker/features/goals/presentation/bloc/add_edit_goal/add_edit_goal_bloc.dart';
 import 'package:expense_tracker/features/goals/presentation/bloc/goal_list/goal_list_bloc.dart';
@@ -96,6 +97,9 @@ class GoalDependencies {
     }
     if (!sl.isRegistered<CheckGoalAchievementUseCase>()) {
       sl.registerLazySingleton(() => CheckGoalAchievementUseCase(sl()));
+    }
+    if (!sl.isRegistered<AuditGoalTotalsUseCase>()) {
+      sl.registerLazySingleton(() => AuditGoalTotalsUseCase(sl()));
     }
 
     // --- Blocs ---

--- a/lib/features/goals/data/repositories/goal_contribution_repository_impl.dart
+++ b/lib/features/goals/data/repositories/goal_contribution_repository_impl.dart
@@ -166,4 +166,25 @@ class GoalContributionRepositoryImpl implements GoalContributionRepository {
           CacheFailure("Failed to update contribution: ${e.toString()}"));
     }
   }
+
+  @override
+  Future<Either<Failure, void>> auditGoalTotals() async {
+    log.info("[ContributionRepo] Auditing cached totals for all goals");
+    try {
+      final goals = await goalDataSource.getGoals();
+      for (final goal in goals) {
+        final result = await _updateGoalTotalSavedCache(goal.id);
+        if (result.isLeft()) {
+          log.warning(
+              "[ContributionRepo] Failed to sync total saved cache for goal ${goal.id}");
+        }
+      }
+      return const Right(null);
+    } catch (e, s) {
+      log.severe(
+          "[ContributionRepo] Error auditing goal total saved caches$e$s");
+      return Left(CacheFailure(
+          "Failed to audit goal total saved caches: ${e.toString()}"));
+    }
+  }
 }

--- a/lib/features/goals/domain/repositories/goal_contribution_repository.dart
+++ b/lib/features/goals/domain/repositories/goal_contribution_repository.dart
@@ -11,4 +11,10 @@ abstract class GoalContributionRepository {
   Future<Either<Failure, GoalContribution>> updateContribution(
       GoalContribution contribution);
   Future<Either<Failure, void>> deleteContribution(String contributionId);
+  /// Audits all goals and recalculates the cached total saved amount.
+  ///
+  /// This can be used by a periodic background task to ensure that the
+  /// `totalSavedCache` field on each goal remains accurate even if an earlier
+  /// operation crashed before the cache was updated.
+  Future<Either<Failure, void>> auditGoalTotals();
 }

--- a/lib/features/goals/domain/usecases/audit_goal_totals.dart
+++ b/lib/features/goals/domain/usecases/audit_goal_totals.dart
@@ -1,0 +1,20 @@
+// lib/features/goals/domain/usecases/audit_goal_totals.dart
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/core/usecases/usecase.dart';
+import 'package:expense_tracker/features/goals/domain/repositories/goal_contribution_repository.dart';
+
+/// Use case that audits all goals and recalculates their cached total saved
+/// amounts. This can be run periodically or on startup to ensure the
+/// `totalSavedCache` field of each goal remains in sync with its
+/// contributions.
+class AuditGoalTotalsUseCase implements UseCase<void, NoParams> {
+  final GoalContributionRepository repository;
+
+  AuditGoalTotalsUseCase(this.repository);
+
+  @override
+  Future<Either<Failure, void>> call(NoParams params) {
+    return repository.auditGoalTotals();
+  }
+}


### PR DESCRIPTION
## Summary
- add repository method to audit and sync goal totalSaved cache across all goals
- expose new AuditGoalTotalsUseCase and register it for dependency injection

## Testing
- `dart format lib/features/goals/domain/repositories/goal_contribution_repository.dart lib/features/goals/data/repositories/goal_contribution_repository_impl.dart lib/features/goals/domain/usecases/audit_goal_totals.dart lib/core/di/service_configurations/goal_dependencies.dart` *(failed: command not found: dart)*
- `flutter test` *(failed: command not found: flutter)*
- `apt-get install -y dart` *(failed: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689dbb8930e08320982b3d509be76f57