### PR TITLE
Remove unsafe TransactionEntity casting

### DIFF
--- a/lib/features/budgets/presentation/pages/budget_detail_page.dart
+++ b/lib/features/budgets/presentation/pages/budget_detail_page.dart
@@ -189,22 +189,12 @@ class _BudgetDetailPageState extends State<BudgetDetailPage> {
     final Map<String, String> params = {
       RouteNames.paramTransactionId: transaction.id
     };
-    final dynamic extraData = transaction.originalEntity;
-
-    if (extraData == null) {
-      log.severe(
-          "[BudgetDetail] CRITICAL: originalEntity is null for transaction ID ${transaction.id}. Cannot navigate.");
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-          content: Text("Error preparing transaction data."),
-          backgroundColor: Colors.red));
-      return;
-    }
     log.info("[BudgetDetail] Attempting navigation via pushNamed:");
     log.info("  Route Name: $routeName");
     log.info("  Path Params: $params");
-    log.info("  Extra Data Type: ${extraData?.runtimeType}");
+    log.info("  Extra Data Type: ${transaction.runtimeType}");
     try {
-      context.pushNamed(routeName, pathParameters: params, extra: extraData);
+      context.pushNamed(routeName, pathParameters: params, extra: transaction);
       log.info("[BudgetDetail] pushNamed executed.");
     } catch (e, s) {
       log.severe("[BudgetDetail] Error executing pushNamed: $e\n$s");

--- a/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -97,16 +97,7 @@ class _DashboardPageState extends State<DashboardPage> {
     final Map<String, String> params = {
       RouteNames.paramTransactionId: transaction.id
     };
-    final dynamic extraData = transaction.originalEntity;
-    if (extraData == null) {
-      log.severe(
-          "[DashboardPage] CRITICAL: originalEntity is null for transaction ID ${transaction.id}. Cannot navigate.");
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-          content: Text("Error preparing edit data."),
-          backgroundColor: Colors.red));
-      return;
-    }
-    context.pushNamed(routeName, pathParameters: params, extra: extraData);
+    context.pushNamed(routeName, pathParameters: params, extra: transaction);
   }
 
   Widget _buildElementalQuantumDashboard(BuildContext context,

--- a/lib/features/transactions/domain/entities/transaction_entity.dart
+++ b/lib/features/transactions/domain/entities/transaction_entity.dart
@@ -20,6 +20,10 @@ class TransactionEntity extends Equatable {
   final double? confidenceScore;
   final bool isRecurring;
 
+  // Preserve original typed entities to avoid reconstruction/casting
+  final Expense? expense;
+  final Income? income;
+
   // Private constructor
   const TransactionEntity._({
     required this.id,
@@ -33,6 +37,8 @@ class TransactionEntity extends Equatable {
     required this.status,
     required this.confidenceScore,
     required this.isRecurring,
+    this.expense,
+    this.income,
   });
 
   // Factory constructor from Expense
@@ -49,6 +55,8 @@ class TransactionEntity extends Equatable {
       status: expense.status,
       confidenceScore: expense.confidenceScore,
       isRecurring: expense.isRecurring,
+      expense: expense,
+      income: null,
     );
   }
 
@@ -66,37 +74,9 @@ class TransactionEntity extends Equatable {
       status: income.status,
       confidenceScore: income.confidenceScore,
       isRecurring: income.isRecurring,
+      expense: null,
+      income: income,
     );
-  }
-
-  // Helper to get original Expense/Income if needed (use with caution)
-  dynamic get originalEntity {
-    if (type == TransactionType.expense) {
-      // Reconstruct Expense - assumes category is already hydrated
-      return Expense(
-          id: id,
-          title: title,
-          amount: amount,
-          date: date,
-          category: category,
-          accountId: accountId,
-          status: status,
-          confidenceScore: confidenceScore,
-          isRecurring: isRecurring);
-    } else {
-      // Reconstruct Income
-      return Income(
-          id: id,
-          title: title,
-          amount: amount,
-          date: date,
-          category: category,
-          accountId: accountId,
-          notes: notes,
-          status: status,
-          confidenceScore: confidenceScore,
-          isRecurring: isRecurring);
-    }
   }
 
   @override

--- a/lib/features/transactions/presentation/pages/transaction_detail_page.dart
+++ b/lib/features/transactions/presentation/pages/transaction_detail_page.dart
@@ -52,25 +52,12 @@ class TransactionDetailPage extends StatelessWidget {
     final Map<String, String> params = {
       RouteNames.paramTransactionId: transaction.id
     };
-    final dynamic extraData =
-        transaction.originalEntity; // Pass original Expense/Income
-
-    if (extraData == null) {
-      log.severe(
-          "[TxnDetailPage] CRITICAL: originalEntity is null for transaction ID ${transaction.id}. Cannot navigate.");
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-        content: Text("Error preparing edit data."),
-        backgroundColor: Colors.red,
-      ));
-      return;
-    }
-
     log.info("[TxnDetailPage] Navigating via pushNamed:");
     log.info("  Route Name: $routeName");
     log.info("  Path Params: $params");
-    log.info("  Extra Data Type: ${extraData?.runtimeType}");
+    log.info("  Extra Data Type: ${transaction.runtimeType}");
 
-    context.pushNamed(routeName, pathParameters: params, extra: extraData);
+    context.pushNamed(routeName, pathParameters: params, extra: transaction);
   }
 
   @override

--- a/lib/features/transactions/presentation/pages/transaction_list_page.dart
+++ b/lib/features/transactions/presentation/pages/transaction_list_page.dart
@@ -168,26 +168,12 @@ class _TransactionListPageState extends State<TransactionListPage> {
     final Map<String, String> params = {
       RouteNames.paramTransactionId: transaction.id,
     };
-    final dynamic extraData = transaction.originalEntity;
-
-    if (extraData == null) {
-      log.severe(
-        "[TxnListPage] CRITICAL: originalEntity is null for transaction ID ${transaction.id}. Cannot navigate.",
-      );
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text("Error preparing navigation data."),
-          backgroundColor: Colors.red,
-        ),
-      );
-      return;
-    }
     log.info("[TxnListPage] Attempting navigation via pushNamed:");
     log.info("  Route Name: $routeName");
     log.info("  Path Params: $params");
-    log.info("  Extra Data Type: ${extraData?.runtimeType}");
+    log.info("  Extra Data Type: ${transaction.runtimeType}");
     try {
-      context.pushNamed(routeName, pathParameters: params, extra: extraData);
+      context.pushNamed(routeName, pathParameters: params, extra: transaction);
       log.info("[TxnListPage] pushNamed executed.");
     } catch (e, s) {
       log.severe("[TxnListPage] Error executing pushNamed: $e\n$s");

--- a/lib/features/transactions/presentation/widgets/transaction_list_view.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_list_view.dart
@@ -108,7 +108,7 @@ class TransactionListView extends StatelessWidget {
         Widget cardItem;
         if (transaction.type == TransactionType.expense) {
           cardItem = ExpenseCard(
-            expense: transaction.originalEntity as Expense, // Cast required
+            expense: transaction.expense!,
             onCardTap: (exp) {
               // Pass original Expense
               if (state.isInBatchEditMode) {
@@ -136,7 +136,7 @@ class TransactionListView extends StatelessWidget {
         } else {
           // Income
           cardItem = IncomeCard(
-            income: transaction.originalEntity as Income, // Cast required
+            income: transaction.income!,
             onCardTap: (inc) {
               // Pass original Income
               if (state.isInBatchEditMode) {


### PR DESCRIPTION
## Summary
- avoid rebuilding Expense/Income by storing originals in TransactionEntity
- pass TransactionEntity directly to routes instead of dynamic `originalEntity`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dbb7e70ac83209d54f59486cd6b1e