### PR TITLE
fix: revert to cached state on failed deletes

### DIFF
--- a/lib/features/accounts/presentation/bloc/account_list/account_list_bloc.dart
+++ b/lib/features/accounts/presentation/bloc/account_list/account_list_bloc.dart
@@ -138,11 +138,10 @@ class AccountListBloc extends Bloc<AccountListEvent, AccountListState> {
         result.fold(
           (failure) {
             log.warning(
-                "[AccountListBloc] Deletion failed: ${failure.message}. Reverting UI and emitting Error.");
-            // Revert UI
-            emit(currentState);
+                "[AccountListBloc] Deletion failed: ${failure.message}. Reverting to previous state.");
             emit(AccountListError(_mapFailureToMessage(failure,
                 context: "Failed to delete account")));
+            emit(currentState);
           },
           (_) {
             log.info(
@@ -154,9 +153,9 @@ class AccountListBloc extends Bloc<AccountListEvent, AccountListState> {
       } catch (e) {
         log.severe(
             "[AccountListBloc] Unexpected error in _onDeleteAccountRequested for ID ${event.accountId}");
-        emit(currentState); // Revert optimistic update
         emit(AccountListError(
             "An unexpected error occurred during deletion: ${e.toString()}"));
+        emit(currentState); // Revert optimistic update
       }
     } else {
       log.warning(


### PR DESCRIPTION
## Summary
- avoid full reload when deleting accounts or transactions fails by re-emitting prior state

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689dbb3a2ec88320aac7b804c6b17392