### PR TITLE
Improve transaction UX and window persistence

### DIFF
--- a/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
+++ b/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
@@ -75,7 +75,7 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
             isRecurring: true,
           );
           transactionResult =
-              (await addExpense(AddExpenseParams(newExpense))).map((_) => null);
+              (await addExpense(AddExpenseParams(newExpense))).map((_) {});
         } else {
           final newIncome = Income(
             id: uuid.v4(),
@@ -88,7 +88,7 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
             isRecurring: true,
           );
           transactionResult =
-              (await addIncome(AddIncomeParams(newIncome))).map((_) => null);
+              (await addIncome(AddIncomeParams(newIncome))).map((_) {});
         }
 
         return await transactionResult.fold<Future<Either<Failure, void>>>(

--- a/lib/features/reports/presentation/widgets/report_filter_controls.dart
+++ b/lib/features/reports/presentation/widgets/report_filter_controls.dart
@@ -325,9 +325,12 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                 Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      TextButton(
-                          onPressed: _clearFilters,
-                          child: const Text('Clear All')),
+                      Tooltip(
+                        message: 'Reset filters to their default values',
+                        child: TextButton(
+                            onPressed: _clearFilters,
+                            child: const Text('Clear Filters')),
+                      ),
                       Row(children: [
                         TextButton(
                             onPressed: () => Navigator.pop(context),

--- a/lib/features/transactions/presentation/pages/add_edit_transaction_page.dart
+++ b/lib/features/transactions/presentation/pages/add_edit_transaction_page.dart
@@ -77,7 +77,7 @@ class _AddEditTransactionPageState extends State<AddEditTransactionPage> {
         cancelText: "No, pick myself",
         barrierDismissible: false,
       ).then((confirmed) {
-        if (!mounted) return;
+        if (!mounted || !context.mounted) return;
         if (confirmed == true) {
           log.info("[AddEditTxnPage] Suggestion accepted.");
           _bloc.add(AcceptCategorySuggestion(suggestedCategory));
@@ -103,7 +103,7 @@ class _AddEditTransactionPageState extends State<AddEditTransactionPage> {
         cancelText: "Select Existing",
         barrierDismissible: false,
       ).then((create) {
-        if (!mounted) return;
+        if (!mounted || !context.mounted) return;
         if (create == true) {
           log.info("[AddEditTxnPage] User chose to create a new category.");
           _bloc.add(const CreateCustomCategoryRequested());

--- a/lib/features/transactions/presentation/widgets/transaction_calendar_view.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_calendar_view.dart
@@ -14,9 +14,6 @@ class TransactionCalendarView extends StatelessWidget {
   final CalendarFormat calendarFormat;
   final DateTime focusedDay;
   final DateTime? selectedDay;
-  final List<TransactionEntity> selectedDayTransactions;
-  final List<TransactionEntity> currentTransactionsForCalendar;
-  final Function(DateTime) getEventsForDay;
   final Function(DateTime, DateTime) onDaySelected;
   final Function(CalendarFormat) onFormatChanged;
   final Function(DateTime) onPageChanged;
@@ -29,9 +26,6 @@ class TransactionCalendarView extends StatelessWidget {
     required this.calendarFormat,
     required this.focusedDay,
     required this.selectedDay,
-    required this.selectedDayTransactions,
-    required this.currentTransactionsForCalendar,
-    required this.getEventsForDay,
     required this.onDaySelected,
     required this.onFormatChanged,
     required this.onPageChanged,
@@ -42,12 +36,10 @@ class TransactionCalendarView extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    if (state.status == ListStatus.loading &&
-        currentTransactionsForCalendar.isEmpty) {
+    if (state.status == ListStatus.loading && state.transactions.isEmpty) {
       return const Center(child: CircularProgressIndicator());
     }
-    if (state.status == ListStatus.error &&
-        currentTransactionsForCalendar.isEmpty) {
+    if (state.status == ListStatus.error && state.transactions.isEmpty) {
       return Center(
           child: Padding(
               padding: const EdgeInsets.all(20.0),
@@ -56,6 +48,18 @@ class TransactionCalendarView extends StatelessWidget {
                   style: TextStyle(color: theme.colorScheme.error),
                   textAlign: TextAlign.center)));
     }
+    List<TransactionEntity> eventsForDay(DateTime day) {
+      final normalizedDay = DateTime(day.year, day.month, day.day);
+      return state.transactions.where((txn) {
+        final normalizedTxnDate =
+            DateTime(txn.date.year, txn.date.month, txn.date.day);
+        return isSameDay(normalizedTxnDate, normalizedDay);
+      }).toList();
+    }
+
+    final selectedDayTransactions = selectedDay != null
+        ? eventsForDay(selectedDay!)
+        : <TransactionEntity>[];
 
     return Column(
       children: [
@@ -70,7 +74,7 @@ class TransactionCalendarView extends StatelessWidget {
             CalendarFormat.twoWeeks: '2 Weeks',
             CalendarFormat.week: 'Week',
           },
-          eventLoader: (day) => getEventsForDay(day),
+          eventLoader: eventsForDay,
           calendarStyle: CalendarStyle(
             todayDecoration: BoxDecoration(
                 color: theme.colorScheme.primary.withOpacity(0.3),
@@ -126,14 +130,15 @@ class TransactionCalendarView extends StatelessWidget {
         ),
         const Divider(height: 1, thickness: 1),
         Expanded(
-          child: _buildSelectedDayTransactionList(context, settings),
+          child: _buildSelectedDayTransactionList(
+              context, settings, selectedDayTransactions),
         ),
       ],
     );
   }
 
-  Widget _buildSelectedDayTransactionList(
-      BuildContext context, SettingsState settings) {
+  Widget _buildSelectedDayTransactionList(BuildContext context,
+      SettingsState settings, List<TransactionEntity> selectedDayTransactions) {
     final theme = Theme.of(context);
     if (selectedDayTransactions.isEmpty) {
       return Center(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 // lib/main.dart
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:expense_tracker/core/constants/app_constants.dart';
 import 'package:expense_tracker/core/constants/hive_constants.dart';
 import 'package:expense_tracker/core/di/service_locator.dart';
@@ -60,32 +61,42 @@ Future<void> main() async {
     Hive.registerAdapter(RecurringRuleAuditLogModelAdapter());
 
     log.info("Opening Hive boxes...");
-    final expenseBox =
-        await Hive.openBox<ExpenseModel>(HiveConstants.expenseBoxName);
-    final accountBox =
-        await Hive.openBox<AssetAccountModel>(HiveConstants.accountBoxName);
-    final incomeBox =
-        await Hive.openBox<IncomeModel>(HiveConstants.incomeBoxName);
-    final categoryBox =
-        await Hive.openBox<CategoryModel>(HiveConstants.categoryBoxName);
+    final expenseBox = await Hive.openBox<ExpenseModel>(
+      HiveConstants.expenseBoxName,
+    );
+    final accountBox = await Hive.openBox<AssetAccountModel>(
+      HiveConstants.accountBoxName,
+    );
+    final incomeBox = await Hive.openBox<IncomeModel>(
+      HiveConstants.incomeBoxName,
+    );
+    final categoryBox = await Hive.openBox<CategoryModel>(
+      HiveConstants.categoryBoxName,
+    );
     final userHistoryBox = await Hive.openBox<UserHistoryRuleModel>(
-        HiveConstants.userHistoryRuleBoxName);
-    final budgetBox =
-        await Hive.openBox<BudgetModel>(HiveConstants.budgetBoxName);
+      HiveConstants.userHistoryRuleBoxName,
+    );
+    final budgetBox = await Hive.openBox<BudgetModel>(
+      HiveConstants.budgetBoxName,
+    );
     final goalBox = await Hive.openBox<GoalModel>(HiveConstants.goalBoxName);
     final contributionBox = await Hive.openBox<GoalContributionModel>(
-        HiveConstants.goalContributionBoxName);
+      HiveConstants.goalContributionBoxName,
+    );
     final recurringRuleBox = await Hive.openBox<RecurringRuleModel>(
-        HiveConstants.recurringRuleBoxName);
+      HiveConstants.recurringRuleBoxName,
+    );
     final recurringRuleAuditLogBox =
         await Hive.openBox<RecurringRuleAuditLogModel>(
-            HiveConstants.recurringRuleAuditLogBoxName);
+          HiveConstants.recurringRuleAuditLogBoxName,
+        );
     log.info("All Hive boxes opened.");
 
     final prefs = await SharedPreferences.getInstance();
     log.info("SharedPreferences instance obtained.");
 
-    if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+    if (!kIsWeb &&
+        (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
       await windowManager.ensureInitialized();
       final width = prefs.getDouble('window-width');
       final height = prefs.getDouble('window-height');
@@ -130,50 +141,52 @@ Future<void> main() async {
   }
 
   // --- Global Bloc Providers ---
-  runApp(MultiBlocProvider(
-    providers: [
-      // SettingsBloc MUST be provided early for Router redirect logic
-      BlocProvider<SettingsBloc>(
-        create: (context) => sl<SettingsBloc>()..add(const LoadSettings()),
-        lazy: false, // Load settings immediately
-      ),
-      BlocProvider<DataManagementBloc>(
-        create: (context) => sl<DataManagementBloc>(),
-        lazy: true,
-      ),
-      BlocProvider<AccountListBloc>(
-        create: (context) => sl<AccountListBloc>()..add(const LoadAccounts()),
-        lazy: false, // Load immediately for dashboard dependencies
-      ),
-      BlocProvider<TransactionListBloc>(
-        create: (context) =>
-            sl<TransactionListBloc>()..add(const LoadTransactions()),
-        lazy: false,
-      ),
-      BlocProvider<CategoryManagementBloc>(
-        create: (context) =>
-            sl<CategoryManagementBloc>()..add(const LoadCategories()),
-        lazy: true,
-      ),
-      BlocProvider<BudgetListBloc>(
-        create: (context) => sl<BudgetListBloc>()..add(const LoadBudgets()),
-        lazy: false,
-      ),
-      BlocProvider<GoalListBloc>(
-        create: (context) => sl<GoalListBloc>()..add(const LoadGoals()),
-        lazy: false,
-      ),
-      BlocProvider<DashboardBloc>(
-        create: (context) => sl<DashboardBloc>()..add(const LoadDashboard()),
-        lazy: false,
-      ),
-      BlocProvider<SummaryBloc>(
-        create: (context) => sl<SummaryBloc>()..add(const LoadSummary()),
-        lazy: true,
-      ),
-    ],
-    child: const MyApp(), // Use MyApp directly, router handles initial screen
-  ));
+  runApp(
+    MultiBlocProvider(
+      providers: [
+        // SettingsBloc MUST be provided early for Router redirect logic
+        BlocProvider<SettingsBloc>(
+          create: (context) => sl<SettingsBloc>()..add(const LoadSettings()),
+          lazy: false, // Load settings immediately
+        ),
+        BlocProvider<DataManagementBloc>(
+          create: (context) => sl<DataManagementBloc>(),
+          lazy: true,
+        ),
+        BlocProvider<AccountListBloc>(
+          create: (context) => sl<AccountListBloc>()..add(const LoadAccounts()),
+          lazy: false, // Load immediately for dashboard dependencies
+        ),
+        BlocProvider<TransactionListBloc>(
+          create: (context) =>
+              sl<TransactionListBloc>()..add(const LoadTransactions()),
+          lazy: false,
+        ),
+        BlocProvider<CategoryManagementBloc>(
+          create: (context) =>
+              sl<CategoryManagementBloc>()..add(const LoadCategories()),
+          lazy: true,
+        ),
+        BlocProvider<BudgetListBloc>(
+          create: (context) => sl<BudgetListBloc>()..add(const LoadBudgets()),
+          lazy: false,
+        ),
+        BlocProvider<GoalListBloc>(
+          create: (context) => sl<GoalListBloc>()..add(const LoadGoals()),
+          lazy: false,
+        ),
+        BlocProvider<DashboardBloc>(
+          create: (context) => sl<DashboardBloc>()..add(const LoadDashboard()),
+          lazy: false,
+        ),
+        BlocProvider<SummaryBloc>(
+          create: (context) => sl<SummaryBloc>()..add(const LoadSummary()),
+          lazy: true,
+        ),
+      ],
+      child: const MyApp(), // Use MyApp directly, router handles initial screen
+    ),
+  );
 }
 
 class _WindowPersistenceListener extends WindowListener {
@@ -203,7 +216,9 @@ class InitializationErrorApp extends StatelessWidget {
   Widget build(BuildContext context) {
     // Provide default theme data even if settings failed
     final defaultThemePair = AppTheme.buildTheme(
-        SettingsState.defaultUIMode, SettingsState.defaultPaletteIdentifier);
+      SettingsState.defaultUIMode,
+      SettingsState.defaultPaletteIdentifier,
+    );
 
     return MaterialApp(
       theme: defaultThemePair.light,
@@ -221,9 +236,10 @@ class InitializationErrorApp extends StatelessWidget {
                 Text(
                   "Application Initialization Failed",
                   style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.red.shade900),
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.red.shade900,
+                  ),
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 12),

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,18 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <screen_retriever/screen_retriever_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
+  screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+  g_autoptr(FlPluginRegistrar) window_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+  window_manager_plugin_register_with_registrar(window_manager_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,7 +3,9 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  screen_retriever
   url_launcher_linux
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,14 +9,18 @@ import file_picker
 import local_auth_darwin
 import package_info_plus
 import path_provider_foundation
+import screen_retriever
 import shared_preferences_foundation
 import url_launcher_macos
+import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FLALocalAuthPlugin.register(with: registry.registrar(forPlugin: "FLALocalAuthPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -861,6 +861,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: "6ee02c8a1158e6dae7ca430da79436e3b1c9563c8cf02f524af997c201ac2b90"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.9"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1274,6 +1282,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.12.0"
+  window_manager:
+    dependency: "direct main"
+    description:
+      name: window_manager
+      sha256: "8699323b30da4cdbe2aa2e7c9de567a6abd8a97d9a5c850a3c86dcd0b34bbfbf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.9"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   percent_indicator: ^4.2.4
   confetti: ^0.7.0
   fl_chart: ^0.68.0
+  window_manager: ^0.3.7
 
 
 dev_dependencies:

--- a/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
+++ b/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
@@ -6,7 +6,6 @@ import 'package:expense_tracker/features/categories/domain/entities/category_typ
 import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
 import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
 import 'package:expense_tracker/features/expenses/domain/usecases/add_expense.dart';
-import 'package:expense_tracker/features/income/domain/entities/income.dart';
 import 'package:expense_tracker/features/income/domain/usecases/add_income.dart';
 import 'package:expense_tracker/features/income/domain/entities/income.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule.dart';
@@ -271,7 +270,8 @@ void main() {
         () => mockRecurringTransactionRepository.updateRecurringRule(any()));
   });
 
-  test('should handle monthly rule without dayOfMonth by defaulting to current day',
+  test(
+      'should handle monthly rule without dayOfMonth by defaulting to current day',
       () async {
     // Arrange
     final ruleWithoutDayOfMonth = RecurringRule(
@@ -306,10 +306,8 @@ void main() {
     await usecase(const NoParams());
 
     // Assert
-    final captured = verify(() =>
-            mockRecurringTransactionRepository.updateRecurringRule(captureAny()))
-        .captured
-        .single as RecurringRule;
+    final captured = verify(() => mockRecurringTransactionRepository
+        .updateRecurringRule(captureAny())).captured.single as RecurringRule;
     expect(captured.nextOccurrenceDate, expectedNextDate);
   });
 
@@ -349,10 +347,8 @@ void main() {
     await usecase(const NoParams());
 
     // Assert
-    final captured = verify(() =>
-            mockRecurringTransactionRepository.updateRecurringRule(captureAny()))
-        .captured
-        .single as RecurringRule;
+    final captured = verify(() => mockRecurringTransactionRepository
+        .updateRecurringRule(captureAny())).captured.single as RecurringRule;
     expect(captured.nextOccurrenceDate, expectedNextDate);
   });
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,13 +8,19 @@
 
 #include <local_auth_windows/local_auth_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <screen_retriever/screen_retriever_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
+#include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   LocalAuthPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("LocalAuthPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  ScreenRetrieverPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
+  WindowManagerPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,7 +5,9 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   local_auth_windows
   permission_handler_windows
+  screen_retriever
   url_launcher_windows
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -26,7 +26,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
 
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
-  Win32Window::Size size(1280, 720);
+  // Let the window_manager plugin restore the last window size.
+  Win32Window::Size size(0, 0);
   if (!window.Create(L"expense_tracking", origin, size)) {
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
## Summary
- guard async dialog callbacks with mounted checks
- confirm before switching transaction type to avoid unintentional category reset
- streamline transaction calendar to read from bloc state directly
- persist desktop window size using window_manager and remove hardcoded dimensions
- clarify report filter reset button with tooltip and new label
- fix analyzer warnings in recurring transactions use case

## Testing
- `flutter analyze`
- `flutter test`
