### PR TITLE
Harden category deletion and unify string helpers

### DIFF
--- a/lib/core/di/service_configurations/goal_dependencies.dart
+++ b/lib/core/di/service_configurations/goal_dependencies.dart
@@ -32,6 +32,7 @@ import 'package:expense_tracker/features/goals/domain/usecases/audit_goal_totals
 import 'package:expense_tracker/features/goals/presentation/bloc/add_edit_goal/add_edit_goal_bloc.dart';
 import 'package:expense_tracker/features/goals/presentation/bloc/goal_list/goal_list_bloc.dart';
 import 'package:expense_tracker/features/goals/presentation/bloc/log_contribution/log_contribution_bloc.dart';
+import 'package:expense_tracker/features/goals/presentation/bloc/contribution_list/contribution_list_bloc.dart';
 // External
 import 'package:uuid/uuid.dart';
 import 'dart:async'; // For Stream
@@ -41,30 +42,34 @@ class GoalDependencies {
     // --- Data Sources (Proxies) ---
     if (!sl.isRegistered<GoalLocalDataSource>()) {
       sl.registerLazySingleton<GoalLocalDataSource>(
-          () => DemoAwareGoalDataSource(
-                hiveDataSource: sl<HiveGoalLocalDataSource>(),
-                demoModeService: sl<DemoModeService>(),
-              ));
+        () => DemoAwareGoalDataSource(
+          hiveDataSource: sl<HiveGoalLocalDataSource>(),
+          demoModeService: sl<DemoModeService>(),
+        ),
+      );
     }
     if (!sl.isRegistered<GoalContributionLocalDataSource>()) {
       sl.registerLazySingleton<GoalContributionLocalDataSource>(
-          () => DemoAwareGoalContributionDataSource(
-                hiveDataSource: sl<HiveContributionLocalDataSource>(),
-                demoModeService: sl<DemoModeService>(),
-              ));
+        () => DemoAwareGoalContributionDataSource(
+          hiveDataSource: sl<HiveContributionLocalDataSource>(),
+          demoModeService: sl<DemoModeService>(),
+        ),
+      );
     }
 
     // --- Repositories ---
     if (!sl.isRegistered<GoalRepository>()) {
       sl.registerLazySingleton<GoalRepository>(
-          () => GoalRepositoryImpl(localDataSource: sl()));
+        () => GoalRepositoryImpl(localDataSource: sl()),
+      );
     }
     if (!sl.isRegistered<GoalContributionRepository>()) {
       sl.registerLazySingleton<GoalContributionRepository>(
-          () => GoalContributionRepositoryImpl(
-                contributionDataSource: sl(),
-                goalDataSource: sl(), // Goal DS needed for cache update
-              ));
+        () => GoalContributionRepositoryImpl(
+          contributionDataSource: sl(),
+          goalDataSource: sl(), // Goal DS needed for cache update
+        ),
+      );
     }
 
     // --- Use Cases ---
@@ -104,28 +109,42 @@ class GoalDependencies {
 
     // --- Blocs ---
     if (!sl.isRegistered<GoalListBloc>()) {
-      sl.registerFactory(() => GoalListBloc(
-            getGoalsUseCase: sl<GetGoalsUseCase>(),
-            archiveGoalUseCase: sl<ArchiveGoalUseCase>(),
-            dataChangeStream: sl<Stream<DataChangedEvent>>(),
-            deleteGoalUseCase: sl<DeleteGoalUseCase>(),
-          ));
+      sl.registerFactory(
+        () => GoalListBloc(
+          getGoalsUseCase: sl<GetGoalsUseCase>(),
+          archiveGoalUseCase: sl<ArchiveGoalUseCase>(),
+          dataChangeStream: sl<Stream<DataChangedEvent>>(),
+          deleteGoalUseCase: sl<DeleteGoalUseCase>(),
+        ),
+      );
     }
     if (!sl.isRegistered<AddEditGoalBloc>()) {
       sl.registerFactoryParam<AddEditGoalBloc, Goal?, void>(
-          (initialGoal, _) => AddEditGoalBloc(
-                addGoalUseCase: sl<AddGoalUseCase>(),
-                updateGoalUseCase: sl<UpdateGoalUseCase>(),
-                initialGoal: initialGoal,
-              ));
+        (initialGoal, _) => AddEditGoalBloc(
+          addGoalUseCase: sl<AddGoalUseCase>(),
+          updateGoalUseCase: sl<UpdateGoalUseCase>(),
+          initialGoal: initialGoal,
+        ),
+      );
     }
     if (!sl.isRegistered<LogContributionBloc>()) {
-      sl.registerFactory(() => LogContributionBloc(
-            addContributionUseCase: sl<AddContributionUseCase>(),
-            updateContributionUseCase: sl<UpdateContributionUseCase>(),
-            deleteContributionUseCase: sl<DeleteContributionUseCase>(),
-            checkGoalAchievementUseCase: sl<CheckGoalAchievementUseCase>(),
-          ));
+      sl.registerFactory(
+        () => LogContributionBloc(
+          addContributionUseCase: sl<AddContributionUseCase>(),
+          updateContributionUseCase: sl<UpdateContributionUseCase>(),
+          deleteContributionUseCase: sl<DeleteContributionUseCase>(),
+          checkGoalAchievementUseCase: sl<CheckGoalAchievementUseCase>(),
+        ),
+      );
+    }
+    if (!sl.isRegistered<ContributionListBloc>()) {
+      sl.registerFactoryParam<ContributionListBloc, String, void>(
+        (goalId, _) => ContributionListBloc(
+          goalId: goalId,
+          getContributionsUseCase: sl<GetContributionsForGoalUseCase>(),
+          dataChangeStream: sl<Stream<DataChangedEvent>>(),
+        ),
+      );
     }
   }
 }

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -66,20 +66,30 @@ class AppTheme {
   // --- Central Factory Method (Refactored) ---
   static AppThemeDataPair buildTheme(UIMode mode, String paletteIdentifier) {
     // 1. Get the configuration object for the mode and palette
-    final IThemePaletteConfig config =
-        _getConfigForMode(mode, paletteIdentifier);
+    final IThemePaletteConfig config = _getConfigForMode(
+      mode,
+      paletteIdentifier,
+    );
 
     // 2. Build the custom theme extensions
-    final AppModeTheme lightModeTheme =
-        _buildModeThemeExtension(config, Brightness.light);
-    final AppModeTheme darkModeTheme =
-        _buildModeThemeExtension(config, Brightness.dark);
+    final AppModeTheme lightModeTheme = _buildModeThemeExtension(
+      config,
+      Brightness.light,
+    );
+    final AppModeTheme darkModeTheme = _buildModeThemeExtension(
+      config,
+      Brightness.dark,
+    );
 
     // 3. Build the final ThemeData using the SINGLE base builder
-    final ThemeData lightTheme =
-        _buildBaseThemeData(config.lightColorScheme, lightModeTheme);
-    final ThemeData darkTheme =
-        _buildBaseThemeData(config.darkColorScheme, darkModeTheme);
+    final ThemeData lightTheme = _buildBaseThemeData(
+      config.lightColorScheme,
+      lightModeTheme,
+    );
+    final ThemeData darkTheme = _buildBaseThemeData(
+      config.darkColorScheme,
+      darkModeTheme,
+    );
 
     return AppThemeDataPair(light: lightTheme, dark: darkTheme);
   }
@@ -115,9 +125,12 @@ class AppTheme {
 
   // --- Helper to build AppModeTheme from Config (Remains the same) ---
   static AppModeTheme _buildModeThemeExtension(
-      IThemePaletteConfig config, Brightness brightness) {
-    final assets =
-        brightness == Brightness.light ? config.lightAssets : config.darkAssets;
+    IThemePaletteConfig config,
+    Brightness brightness,
+  ) {
+    final assets = brightness == Brightness.light
+        ? config.lightAssets
+        : config.darkAssets;
     final incomeGlow = brightness == Brightness.light
         ? config.incomeGlowColorLight
         : config.incomeGlowColorDark;
@@ -140,7 +153,9 @@ class AppTheme {
 
   // --- SINGLE Base Theme Builder (Consolidated) ---
   static ThemeData _buildBaseThemeData(
-      ColorScheme colorScheme, AppModeTheme modeTheme) {
+    ColorScheme colorScheme,
+    AppModeTheme modeTheme,
+  ) {
     // Determine Font based on mode or config (Example using modeTheme)
     TextTheme baseTextTheme;
     // Infer mode from palette ID prefix
@@ -169,11 +184,13 @@ class AppTheme {
     final textTheme = baseTextTheme
         .copyWith(
           // Common tweaks
-          titleLarge:
-              baseTextTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
+          titleLarge: baseTextTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
           bodyMedium: baseTextTheme.bodyMedium?.copyWith(fontSize: 14),
-          labelLarge:
-              baseTextTheme.labelLarge?.copyWith(fontWeight: FontWeight.w500),
+          labelLarge: baseTextTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w500,
+          ),
           // Mode-specific tweaks (example for Quantum)
           bodySmall: modePrefix == 'quantum'
               ? baseTextTheme.bodySmall?.copyWith(fontSize: 11)
@@ -227,8 +244,8 @@ class AppTheme {
         color: modePrefix == 'aether'
             ? colorScheme.surfaceVariant.withOpacity(0.85)
             : (modePrefix == 'quantum'
-                ? colorScheme.surface
-                : colorScheme.surfaceContainer),
+                  ? colorScheme.surface
+                  : colorScheme.surfaceContainer),
         clipBehavior: modePrefix == 'aether' ? Clip.antiAlias : Clip.none,
       ),
 
@@ -237,37 +254,45 @@ class AppTheme {
             ? const EdgeInsets.symmetric(horizontal: 12, vertical: 2)
             : const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
         dense: modeTheme.layoutDensity == LayoutDensity.compact,
-        minVerticalPadding:
-            modeTheme.layoutDensity == LayoutDensity.compact ? 8 : 12,
-        horizontalTitleGap:
-            modeTheme.layoutDensity == LayoutDensity.compact ? 8 : 16,
+        minVerticalPadding: modeTheme.layoutDensity == LayoutDensity.compact
+            ? 8
+            : 12,
+        horizontalTitleGap: modeTheme.layoutDensity == LayoutDensity.compact
+            ? 8
+            : 16,
         iconColor: colorScheme.onSurfaceVariant, // Default icon color
         titleTextStyle: textTheme.bodyLarge, // Default title style
         subtitleTextStyle: textTheme.bodyMedium?.copyWith(
-            color: colorScheme.onSurfaceVariant), // Default subtitle style
+          color: colorScheme.onSurfaceVariant,
+        ), // Default subtitle style
       ),
 
       inputDecorationTheme: InputDecorationTheme(
         border: OutlineInputBorder(
-            borderRadius:
-                BorderRadius.circular(modePrefix == 'quantum' ? 6 : 12)),
+          borderRadius: BorderRadius.circular(modePrefix == 'quantum' ? 6 : 12),
+        ),
         enabledBorder: OutlineInputBorder(
           borderSide: BorderSide(
-              color: modePrefix == 'aether'
-                  ? Colors.transparent
-                  : colorScheme.outlineVariant,
-              width: 0.8),
+            color: modePrefix == 'aether'
+                ? Colors.transparent
+                : colorScheme.outlineVariant,
+            width: 0.8,
+          ),
           borderRadius: BorderRadius.circular(
-              modePrefix == 'quantum' ? 6 : (modePrefix == 'aether' ? 16 : 12)),
+            modePrefix == 'quantum' ? 6 : (modePrefix == 'aether' ? 16 : 12),
+          ),
         ),
         focusedBorder: modePrefix == 'aether'
             ? OutlineInputBorder(
                 borderRadius: BorderRadius.circular(16),
-                borderSide: BorderSide(color: colorScheme.primary, width: 1.5))
+                borderSide: BorderSide(color: colorScheme.primary, width: 1.5),
+              )
             : OutlineInputBorder(
                 borderSide: BorderSide(color: colorScheme.primary, width: 1.5),
-                borderRadius:
-                    BorderRadius.circular(modePrefix == 'quantum' ? 6 : 12)),
+                borderRadius: BorderRadius.circular(
+                  modePrefix == 'quantum' ? 6 : 12,
+                ),
+              ),
         filled: modePrefix == 'aether',
         fillColor: modePrefix == 'aether'
             ? colorScheme.surfaceVariant.withOpacity(0.7)
@@ -286,24 +311,27 @@ class AppTheme {
       ),
 
       elevatedButtonTheme: ElevatedButtonThemeData(
-          style: ElevatedButton.styleFrom(
-        backgroundColor: modePrefix == 'aether'
-            ? colorScheme.primaryContainer
-            : colorScheme.primary,
-        foregroundColor: modePrefix == 'aether'
-            ? colorScheme.onPrimaryContainer
-            : colorScheme.onPrimary,
-        padding: modeTheme.layoutDensity == LayoutDensity.compact
-            ? const EdgeInsets.symmetric(horizontal: 16, vertical: 10)
-            : const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
-        textStyle: textTheme.labelLarge,
-        shape: RoundedRectangleBorder(
-            borderRadius:
-                BorderRadius.circular(modePrefix == 'quantum' ? 6 : 12)),
-        elevation: modeTheme.cardStyle == CardStyle.flat
-            ? 0
-            : (modePrefix == 'aether' ? 4 : 2),
-      )),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: modePrefix == 'aether'
+              ? colorScheme.primaryContainer
+              : colorScheme.primary,
+          foregroundColor: modePrefix == 'aether'
+              ? colorScheme.onPrimaryContainer
+              : colorScheme.onPrimary,
+          padding: modeTheme.layoutDensity == LayoutDensity.compact
+              ? const EdgeInsets.symmetric(horizontal: 16, vertical: 10)
+              : const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+          textStyle: textTheme.labelLarge,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(
+              modePrefix == 'quantum' ? 6 : 12,
+            ),
+          ),
+          elevation: modeTheme.cardStyle == CardStyle.flat
+              ? 0
+              : (modePrefix == 'aether' ? 4 : 2),
+        ),
+      ),
 
       floatingActionButtonTheme: FloatingActionButtonThemeData(
         backgroundColor: modePrefix == 'aether'
@@ -316,8 +344,8 @@ class AppTheme {
             ? 0
             : (modePrefix == 'aether' ? 6 : 4),
         shape: RoundedRectangleBorder(
-            borderRadius:
-                BorderRadius.circular(modePrefix == 'aether' ? 20 : 16)),
+          borderRadius: BorderRadius.circular(modePrefix == 'aether' ? 20 : 16),
+        ),
       ),
 
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
@@ -326,17 +354,20 @@ class AppTheme {
             ? colorScheme.surfaceVariant.withOpacity(0.9)
             : colorScheme.surfaceContainerHighest, // Adjusted BG
         selectedItemColor: colorScheme.primary,
-        unselectedItemColor: colorScheme.onSurfaceVariant
-            .withOpacity(modePrefix == 'quantum' ? 0.6 : 0.7),
+        unselectedItemColor: colorScheme.onSurfaceVariant.withOpacity(
+          modePrefix == 'quantum' ? 0.6 : 0.7,
+        ),
         elevation: modeTheme.cardStyle == CardStyle.flat ? 0 : 2,
         selectedLabelStyle: modePrefix == 'quantum'
             ? textTheme.labelSmall
             : textTheme.labelSmall?.copyWith(fontWeight: FontWeight.w500),
         unselectedLabelStyle: textTheme.labelSmall,
         selectedIconTheme: IconThemeData(
-            size: modePrefix == 'quantum' ? 20 : 24), // Adjusted size
+          size: modePrefix == 'quantum' ? 20 : 24,
+        ), // Adjusted size
         unselectedIconTheme: IconThemeData(
-            size: modePrefix == 'quantum' ? 20 : 24), // Adjusted size
+          size: modePrefix == 'quantum' ? 20 : 24,
+        ), // Adjusted size
       ),
 
       dividerTheme: DividerThemeData(
@@ -356,13 +387,16 @@ class AppTheme {
               dataRowMinHeight: 36,
               dataRowMaxHeight: 40,
               headingTextStyle: textTheme.labelSmall?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: colorScheme.onSurfaceVariant),
-              dataTextStyle:
-                  textTheme.bodySmall?.copyWith(color: colorScheme.onSurface),
+                fontWeight: FontWeight.w600,
+                color: colorScheme.onSurfaceVariant,
+              ),
+              dataTextStyle: textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurface,
+              ),
               dividerThickness: 0.8,
-              dataRowColor: MaterialStateProperty.resolveWith<Color?>(
-                  (Set<MaterialState> states) {
+              dataRowColor: MaterialStateProperty.resolveWith<Color?>((
+                Set<MaterialState> states,
+              ) {
                 if (states.contains(MaterialState.selected)) {
                   return colorScheme.primaryContainer.withOpacity(0.2);
                 }
@@ -372,17 +406,9 @@ class AppTheme {
           : null,
 
       // Add the AppModeTheme extension
-      extensions: <ThemeExtension<dynamic>>[
-        modeTheme,
-      ],
+      extensions: <ThemeExtension<dynamic>>[modeTheme],
     );
   }
 }
 
 // Keep String capitalization extension
-extension StringExtension on String {
-  String capitalize() {
-    if (isEmpty) return this;
-    return "${this[0].toUpperCase()}${substring(1)}";
-  }
-}

--- a/lib/core/utils/string_extensions.dart
+++ b/lib/core/utils/string_extensions.dart
@@ -1,0 +1,6 @@
+extension StringCapitalization on String {
+  String capitalize() {
+    if (isEmpty) return this;
+    return '${this[0].toUpperCase()}${substring(1)}';
+  }
+}

--- a/lib/features/accounts/data/models/asset_account_model.dart
+++ b/lib/features/accounts/data/models/asset_account_model.dart
@@ -1,6 +1,7 @@
 import 'package:hive/hive.dart';
 import 'package:expense_tracker/features/accounts/domain/entities/asset_account.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:expense_tracker/main.dart';
 
 part 'asset_account_model.g.dart';
 
@@ -39,14 +40,20 @@ class AssetAccountModel extends HiveObject {
   }
 
   AssetAccount toEntity(double currentBalance) {
-    // Icon is now determined in the entity or widget
+    final assetType = (typeIndex >= 0 && typeIndex < AssetType.values.length)
+        ? AssetType.values[typeIndex]
+        : AssetType.other;
+    if (typeIndex < 0 || typeIndex >= AssetType.values.length) {
+      log.warning(
+        '[AssetAccountModel] Invalid typeIndex $typeIndex, defaulting to AssetType.other',
+      );
+    }
     return AssetAccount(
       id: id,
       name: name,
-      type: AssetType.values[typeIndex], // Get enum from index
+      type: assetType,
       initialBalance: initialBalance,
       currentBalance: currentBalance,
-      // iconData is handled by the entity/widget now
     );
   }
 

--- a/lib/features/accounts/presentation/widgets/account_form.dart
+++ b/lib/features/accounts/presentation/widgets/account_form.dart
@@ -1,5 +1,6 @@
 // lib/features/accounts/presentation/widgets/account_form.dart
 import 'package:expense_tracker/features/accounts/domain/entities/asset_account.dart';
+import 'package:expense_tracker/core/utils/string_extensions.dart';
 import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -8,8 +9,8 @@ import 'package:expense_tracker/core/widgets/common_form_fields.dart'; // Import
 import 'package:expense_tracker/core/theme/app_mode_theme.dart';
 
 // Callback remains the same, still submitting the value from the field as 'initialBalance'
-typedef AccountSubmitCallback = Function(
-    String name, AssetType type, double initialBalance);
+typedef AccountSubmitCallback =
+    Function(String name, AssetType type, double initialBalance);
 
 class AccountForm extends StatefulWidget {
   final AssetAccount? initialAccount;
@@ -27,13 +28,6 @@ class AccountForm extends StatefulWidget {
 
   @override
   State<AccountForm> createState() => _AccountFormState();
-}
-
-extension StringExtensionCapitalize on String {
-  String capitalizeForm() {
-    if (isEmpty) return this;
-    return "${this[0].toUpperCase()}${substring(1)}";
-  }
 }
 
 class _AccountFormState extends State<AccountForm> {
@@ -54,9 +48,9 @@ class _AccountFormState extends State<AccountForm> {
     _balanceController = TextEditingController(
       text: _isEditing
           ? widget.currentBalanceForDisplay?.toStringAsFixed(2) ??
-              '0.00' // Use current balance if editing
+                '0.00' // Use current balance if editing
           : initial?.initialBalance.toStringAsFixed(2) ??
-              '0.00', // Use initial or default if adding
+                '0.00', // Use initial or default if adding
     );
     // --- END MODIFIED ---
     _selectedType = initial?.type ?? AssetType.bank;
@@ -78,11 +72,15 @@ class _AccountFormState extends State<AccountForm> {
       final balanceFromField =
           double.tryParse(_balanceController.text.replaceAll(',', '.')) ?? 0.0;
       // --- END ---
-      widget.onSubmit(name, _selectedType,
-          balanceFromField); // Pass the value from the field
+      widget.onSubmit(
+        name,
+        _selectedType,
+        balanceFromField,
+      ); // Pass the value from the field
     } else {
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-          content: Text('Please correct the errors in the form.')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please correct the errors in the form.')),
+      );
     }
   }
 
@@ -94,15 +92,21 @@ class _AccountFormState extends State<AccountForm> {
     final modeTheme = context.modeTheme;
 
     // --- Determine Label Text Dynamically ---
-    final String balanceLabel =
-        _isEditing ? 'Current Balance' : 'Initial Balance';
+    final String balanceLabel = _isEditing
+        ? 'Current Balance'
+        : 'Initial Balance';
     // --- End ---
 
     return Form(
       key: _formKey,
       child: ListView(
-        padding: modeTheme?.pagePadding
-                .copyWith(left: 16, right: 16, bottom: 40, top: 16) ??
+        padding:
+            modeTheme?.pagePadding.copyWith(
+              left: 16,
+              right: 16,
+              bottom: 40,
+              top: 16,
+            ) ??
             const EdgeInsets.all(16.0).copyWith(bottom: 40),
         children: [
           // Name
@@ -120,19 +124,28 @@ class _AccountFormState extends State<AccountForm> {
             value: _selectedType,
             labelText: 'Account Type',
             prefixIcon: CommonFormFields.getPrefixIcon(
-                context, 'category', Icons.category_outlined),
+              context,
+              'category',
+              Icons.category_outlined,
+            ),
             items: AssetType.values.map((AssetType type) {
-              final iconData =
-                  AssetAccount(id: '', name: '', type: type, currentBalance: 0)
-                      .iconData;
+              final iconData = AssetAccount(
+                id: '',
+                name: '',
+                type: type,
+                currentBalance: 0,
+              ).iconData;
               return DropdownMenuItem<AssetType>(
                 value: type,
                 child: Row(
                   children: [
-                    Icon(iconData,
-                        size: 20, color: theme.colorScheme.secondary),
+                    Icon(
+                      iconData,
+                      size: 20,
+                      color: theme.colorScheme.secondary,
+                    ),
                     const SizedBox(width: 8),
-                    Text(type.name.capitalizeForm()),
+                    Text(type.name.capitalize()),
                   ],
                 ),
               );
@@ -172,8 +185,9 @@ class _AccountFormState extends State<AccountForm> {
               padding: const EdgeInsets.only(top: 4.0, left: 12.0),
               child: Text(
                 'Editing this updates the initial balance setting.',
-                style: theme.textTheme.bodySmall
-                    ?.copyWith(color: theme.disabledColor),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.disabledColor,
+                ),
               ),
             ),
           // --- END MODIFIED ---
@@ -181,15 +195,18 @@ class _AccountFormState extends State<AccountForm> {
 
           // Submit Button
           ElevatedButton.icon(
-            icon: Icon(widget.initialAccount == null
-                ? Icons.add_circle_outline
-                : Icons.save_outlined),
-            label: Text(widget.initialAccount == null
-                ? 'Add Account'
-                : 'Update Account'),
+            icon: Icon(
+              widget.initialAccount == null
+                  ? Icons.add_circle_outline
+                  : Icons.save_outlined,
+            ),
+            label: Text(
+              widget.initialAccount == null ? 'Add Account' : 'Update Account',
+            ),
             style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                textStyle: theme.textTheme.titleMedium),
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              textStyle: theme.textTheme.titleMedium,
+            ),
             onPressed: _submitForm,
           ),
         ],

--- a/lib/features/budgets/presentation/widgets/budget_form.dart
+++ b/lib/features/budgets/presentation/widgets/budget_form.dart
@@ -14,16 +14,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
 
-typedef BudgetSubmitCallback = Function(
-  String name,
-  BudgetType type,
-  double targetAmount,
-  BudgetPeriodType period,
-  DateTime? startDate,
-  DateTime? endDate,
-  List<String>? categoryIds,
-  String? notes,
-);
+typedef BudgetSubmitCallback =
+    Function(
+      String name,
+      BudgetType type,
+      double targetAmount,
+      BudgetPeriodType period,
+      DateTime? startDate,
+      DateTime? endDate,
+      List<String>? categoryIds,
+      String? notes,
+    );
 
 class BudgetForm extends StatefulWidget {
   final Budget? initialBudget;
@@ -39,13 +40,6 @@ class BudgetForm extends StatefulWidget {
 
   @override
   State<BudgetForm> createState() => _BudgetFormState();
-}
-
-extension StringExtensionCapitalize on String {
-  String capitalizeForm() {
-    if (isEmpty) return this;
-    return "${this[0].toUpperCase()}${substring(1)}";
-  }
 }
 
 class _BudgetFormState extends State<BudgetForm> {
@@ -67,19 +61,23 @@ class _BudgetFormState extends State<BudgetForm> {
     final initial = widget.initialBudget;
     _nameController = TextEditingController(text: initial?.name ?? '');
     _amountController = TextEditingController(
-        text: initial?.targetAmount.toStringAsFixed(2) ?? '');
+      text: initial?.targetAmount.toStringAsFixed(2) ?? '',
+    );
     _notesController = TextEditingController(text: initial?.notes ?? '');
     _selectedType = initial?.type ?? BudgetType.overall;
     _selectedPeriod = initial?.period ?? BudgetPeriodType.recurringMonthly;
     _selectedStartDate = initial?.startDate;
     _selectedEndDate = initial?.endDate;
-    _selectedCategoryIds = initial?.categoryIds
+    _selectedCategoryIds =
+        initial?.categoryIds
             ?.where(
-                (id) => widget.availableCategories.any((cat) => cat.id == id))
+              (id) => widget.availableCategories.any((cat) => cat.id == id),
+            )
             .toList() ??
         [];
     log.info(
-        "[BudgetForm] initState. Type: $_selectedType, Period: $_selectedPeriod, Initial Categories: ${_selectedCategoryIds.length}");
+      "[BudgetForm] initState. Type: $_selectedType, Period: $_selectedPeriod, Initial Categories: ${_selectedCategoryIds.length}",
+    );
   }
 
   @override
@@ -94,10 +92,11 @@ class _BudgetFormState extends State<BudgetForm> {
     final DateTime initial =
         (isStartDate ? _selectedStartDate : _selectedEndDate) ?? DateTime.now();
     final DateTime? picked = await showDatePicker(
-        context: context,
-        initialDate: initial,
-        firstDate: DateTime(2000),
-        lastDate: DateTime(2101));
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2101),
+    );
     if (picked != null && mounted) {
       setState(() {
         if (isStartDate) {
@@ -107,8 +106,14 @@ class _BudgetFormState extends State<BudgetForm> {
             _selectedEndDate = _selectedStartDate;
           }
         } else {
-          _selectedEndDate =
-              DateTime(picked.year, picked.month, picked.day, 23, 59, 59);
+          _selectedEndDate = DateTime(
+            picked.year,
+            picked.month,
+            picked.day,
+            23,
+            59,
+            59,
+          );
           if (_selectedStartDate != null &&
               _selectedStartDate!.isAfter(_selectedEndDate!)) {
             _selectedStartDate = _selectedEndDate;
@@ -122,9 +127,11 @@ class _BudgetFormState extends State<BudgetForm> {
   void _showCategoryMultiSelect(BuildContext context) {
     final theme = Theme.of(context);
     final expenseCategories = widget.availableCategories
-        .where((cat) =>
-            cat.type == CategoryType.expense &&
-            cat.id != Category.uncategorized.id)
+        .where(
+          (cat) =>
+              cat.type == CategoryType.expense &&
+              cat.id != Category.uncategorized.id,
+        )
         .toList();
     final items = expenseCategories
         .map((category) => MultiSelectItem<String>(category.id, category.name))
@@ -134,44 +141,55 @@ class _BudgetFormState extends State<BudgetForm> {
         .toList();
 
     showModalBottomSheet(
-        isScrollControlled: true,
-        context: context,
-        builder: (ctx) {
-          return MultiSelectBottomSheet<String>(
-            items: items,
-            initialValue: validInitialValue,
-            title: const Text("Select Expense Categories"),
-            selectedColor: theme.colorScheme.primary,
-            selectedItemsTextStyle: theme.textTheme.bodyMedium
-                ?.copyWith(color: theme.colorScheme.primary),
-            itemsTextStyle: theme.textTheme.bodyMedium,
-            searchHint: "Search Categories",
-            searchIcon:
-                Icon(Icons.search, color: theme.colorScheme.onSurfaceVariant),
-            searchTextStyle: theme.textTheme.bodyMedium,
-            confirmText: Text('CONFIRM',
-                style: TextStyle(
-                    color: theme.colorScheme.primary,
-                    fontWeight: FontWeight.bold)),
-            cancelText: Text('CANCEL',
-                style: TextStyle(color: theme.colorScheme.onSurfaceVariant)),
-            searchable: true,
-            onConfirm: (values) {
-              final newSelection = values.map((e) => e.toString()).toList();
-              setState(() {
-                _selectedCategoryIds = newSelection;
-                if (_selectedCategoryIds.isNotEmpty) {
-                  _categoryErrorText = null;
-                }
-              });
-              log.info(
-                  "[BudgetForm] Selected Category IDs: $_selectedCategoryIds");
-              WidgetsBinding.instance.addPostFrameCallback(
-                  (_) => _formKey.currentState?.validate());
-            },
-            maxChildSize: 0.7,
-          );
-        });
+      isScrollControlled: true,
+      context: context,
+      builder: (ctx) {
+        return MultiSelectBottomSheet<String>(
+          items: items,
+          initialValue: validInitialValue,
+          title: const Text("Select Expense Categories"),
+          selectedColor: theme.colorScheme.primary,
+          selectedItemsTextStyle: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.primary,
+          ),
+          itemsTextStyle: theme.textTheme.bodyMedium,
+          searchHint: "Search Categories",
+          searchIcon: Icon(
+            Icons.search,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          searchTextStyle: theme.textTheme.bodyMedium,
+          confirmText: Text(
+            'CONFIRM',
+            style: TextStyle(
+              color: theme.colorScheme.primary,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          cancelText: Text(
+            'CANCEL',
+            style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+          ),
+          searchable: true,
+          onConfirm: (values) {
+            final newSelection = values.map((e) => e.toString()).toList();
+            setState(() {
+              _selectedCategoryIds = newSelection;
+              if (_selectedCategoryIds.isNotEmpty) {
+                _categoryErrorText = null;
+              }
+            });
+            log.info(
+              "[BudgetForm] Selected Category IDs: $_selectedCategoryIds",
+            );
+            WidgetsBinding.instance.addPostFrameCallback(
+              (_) => _formKey.currentState?.validate(),
+            );
+          },
+          maxChildSize: 0.7,
+        );
+      },
+    );
   }
 
   void _submitForm() {
@@ -209,10 +227,12 @@ class _BudgetFormState extends State<BudgetForm> {
       );
     } else {
       log.warning(
-          "[BudgetForm] Form validation failed (Form valid: $isFormValid, Category valid: $isCategoryValid).");
+        "[BudgetForm] Form validation failed (Form valid: $isFormValid, Category valid: $isCategoryValid).",
+      );
       if (!isFormValid) {
         ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text("Please correct the errors.")));
+          const SnackBar(content: Text("Please correct the errors.")),
+        );
       }
     }
   }
@@ -227,8 +247,13 @@ class _BudgetFormState extends State<BudgetForm> {
     return Form(
       key: _formKey,
       child: ListView(
-        padding: modeTheme?.pagePadding
-                .copyWith(left: 16, right: 16, bottom: 40, top: 16) ??
+        padding:
+            modeTheme?.pagePadding.copyWith(
+              left: 16,
+              right: 16,
+              bottom: 40,
+              top: 16,
+            ) ??
             const EdgeInsets.all(16.0).copyWith(bottom: 40),
         children: [
           // Name
@@ -258,10 +283,17 @@ class _BudgetFormState extends State<BudgetForm> {
             value: _selectedType,
             labelText: 'Budget Type',
             prefixIcon: CommonFormFields.getPrefixIcon(
-                context, 'type', Icons.merge_type_outlined),
+              context,
+              'type',
+              Icons.merge_type_outlined,
+            ),
             items: BudgetType.values
-                .map((BudgetType type) => DropdownMenuItem<BudgetType>(
-                    value: type, child: Text(type.displayName)))
+                .map(
+                  (BudgetType type) => DropdownMenuItem<BudgetType>(
+                    value: type,
+                    child: Text(type.displayName),
+                  ),
+                )
                 .toList(),
             onChanged: (BudgetType? newValue) {
               if (newValue != null) {
@@ -294,14 +326,17 @@ class _BudgetFormState extends State<BudgetForm> {
                 padding: const EdgeInsets.only(left: 16.0, top: 4.0),
                 child: Text(
                   _selectedCategoryIds
-                      .map((id) =>
-                          widget.availableCategories
-                              .firstWhereOrNull((c) => c.id == id)
-                              ?.name ??
-                          '?')
+                      .map(
+                        (id) =>
+                            widget.availableCategories
+                                .firstWhereOrNull((c) => c.id == id)
+                                ?.name ??
+                            '?',
+                      )
                       .join(', '),
-                  style: theme.textTheme.bodySmall
-                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                 ),
@@ -314,11 +349,17 @@ class _BudgetFormState extends State<BudgetForm> {
             value: _selectedPeriod,
             labelText: 'Period',
             prefixIcon: CommonFormFields.getPrefixIcon(
-                context, 'repeat', Icons.repeat_outlined),
+              context,
+              'repeat',
+              Icons.repeat_outlined,
+            ),
             items: BudgetPeriodType.values
-                .map((BudgetPeriodType type) =>
-                    DropdownMenuItem<BudgetPeriodType>(
-                        value: type, child: Text(type.displayName)))
+                .map(
+                  (BudgetPeriodType type) => DropdownMenuItem<BudgetPeriodType>(
+                    value: type,
+                    child: Text(type.displayName),
+                  ),
+                )
                 .toList(),
             onChanged: (BudgetPeriodType? newValue) {
               if (newValue != null) {
@@ -341,7 +382,8 @@ class _BudgetFormState extends State<BudgetForm> {
           if (_selectedPeriod == BudgetPeriodType.oneTime) ...[
             FormField<bool>(
               key: ValueKey('date_picker_validator_$_selectedPeriod'),
-              initialValue: _selectedStartDate != null &&
+              initialValue:
+                  _selectedStartDate != null &&
                   _selectedEndDate != null &&
                   !_selectedEndDate!.isBefore(_selectedStartDate!),
               validator: (value) {
@@ -358,44 +400,54 @@ class _BudgetFormState extends State<BudgetForm> {
               builder: (formFieldState) => Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Row(children: [
-                    Expanded(
-                      child: CommonFormFields.buildDatePickerTile(
-                        context: context,
-                        selectedDate: _selectedStartDate,
-                        label: 'Start Date *',
-                        onTap: () => _selectDate(context, true)
-                            .then((_) => formFieldState.didChange(true)),
-                        onClear: () => setState(() {
-                          _selectedStartDate = null;
-                          formFieldState.didChange(false);
-                        }),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: CommonFormFields.buildDatePickerTile(
+                          context: context,
+                          selectedDate: _selectedStartDate,
+                          label: 'Start Date *',
+                          onTap: () => _selectDate(
+                            context,
+                            true,
+                          ).then((_) => formFieldState.didChange(true)),
+                          onClear: () => setState(() {
+                            _selectedStartDate = null;
+                            formFieldState.didChange(false);
+                          }),
+                        ),
                       ),
-                    ),
-                    const Padding(
+                      const Padding(
                         padding: EdgeInsets.symmetric(horizontal: 8.0),
-                        child: Text('-', style: TextStyle(fontSize: 16))),
-                    Expanded(
-                      child: CommonFormFields.buildDatePickerTile(
-                        context: context,
-                        selectedDate: _selectedEndDate,
-                        label: 'End Date *',
-                        onTap: () => _selectDate(context, false)
-                            .then((_) => formFieldState.didChange(true)),
-                        onClear: () => setState(() {
-                          _selectedEndDate = null;
-                          formFieldState.didChange(false);
-                        }),
+                        child: Text('-', style: TextStyle(fontSize: 16)),
                       ),
-                    ),
-                  ]),
+                      Expanded(
+                        child: CommonFormFields.buildDatePickerTile(
+                          context: context,
+                          selectedDate: _selectedEndDate,
+                          label: 'End Date *',
+                          onTap: () => _selectDate(
+                            context,
+                            false,
+                          ).then((_) => formFieldState.didChange(true)),
+                          onClear: () => setState(() {
+                            _selectedEndDate = null;
+                            formFieldState.didChange(false);
+                          }),
+                        ),
+                      ),
+                    ],
+                  ),
                   // Error Text display for Date Range FormField
                   if (formFieldState.hasError)
                     Padding(
                       padding: const EdgeInsets.only(left: 12.0, top: 8.0),
-                      child: Text(formFieldState.errorText!,
-                          style: theme.textTheme.bodySmall
-                              ?.copyWith(color: theme.colorScheme.error)),
+                      child: Text(
+                        formFieldState.errorText!,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.error,
+                        ),
+                      ),
                     ),
                 ],
               ),
@@ -405,19 +457,25 @@ class _BudgetFormState extends State<BudgetForm> {
 
           // Notes
           CommonFormFields.buildNotesField(
-              context: context, controller: _notesController),
+            context: context,
+            controller: _notesController,
+          ),
           const SizedBox(height: 32),
 
           // Submit Button
           ElevatedButton.icon(
-            icon: Icon(widget.initialBudget == null
-                ? Icons.add_circle_outline
-                : Icons.save_outlined),
+            icon: Icon(
+              widget.initialBudget == null
+                  ? Icons.add_circle_outline
+                  : Icons.save_outlined,
+            ),
             label: Text(
-                widget.initialBudget == null ? 'Add Budget' : 'Update Budget'),
+              widget.initialBudget == null ? 'Add Budget' : 'Update Budget',
+            ),
             style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                textStyle: theme.textTheme.titleMedium),
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              textStyle: theme.textTheme.titleMedium,
+            ),
             onPressed: _submitForm,
           ),
         ],

--- a/lib/features/categories/presentation/pages/add_edit_category_screen.dart
+++ b/lib/features/categories/presentation/pages/add_edit_category_screen.dart
@@ -34,15 +34,17 @@ class AddEditCategoryScreen extends StatelessWidget {
     final forcedInitialType = routeArgs?['initialType'] as CategoryType?;
 
     log.info(
-        "[AddEditCategoryScreen] Building. Editing: $isEditing. Category: ${initialCategory?.name}. Forced Initial Type: ${forcedInitialType?.name}");
+      "[AddEditCategoryScreen] Building. Editing: $isEditing. Category: ${initialCategory?.name}. Forced Initial Type: ${forcedInitialType?.name}",
+    );
 
     return Scaffold(
       appBar: AppBar(
         title: Text(isEditing ? 'Edit Category' : 'Add Category'),
         leading: IconButton(
-            icon: const Icon(Icons.close),
-            tooltip: 'Cancel',
-            onPressed: () => Navigator.of(context).pop()),
+          icon: const Icon(Icons.close),
+          tooltip: 'Cancel',
+          onPressed: () => Navigator.of(context).pop(),
+        ),
       ),
       body: SafeArea(
         // Ensure CategoryManagementBloc is provided up the tree or provide here
@@ -51,18 +53,22 @@ class AddEditCategoryScreen extends StatelessWidget {
           initialType: forcedInitialType ?? initialCategory?.type,
           onSubmit: (name, iconName, colorHex, type, parentId, categoryObject) {
             log.info(
-                "[AddEditCategoryScreen] Form submitted. Name: $name, Type: ${type.name}");
+              "[AddEditCategoryScreen] Form submitted. Name: $name, Type: ${type.name}",
+            );
             final bloc = context.read<CategoryManagementBloc>();
             if (isEditing) {
               bloc.add(UpdateCategory(category: categoryObject));
               Navigator.of(context).pop();
             } else {
-              bloc.add(AddCategory(
+              bloc.add(
+                AddCategory(
                   name: name,
                   iconName: iconName,
                   colorHex: colorHex,
                   type: type,
-                  parentId: parentId));
+                  parentId: parentId,
+                ),
+              );
               Navigator.of(context).pop(categoryObject);
             }
           },
@@ -76,8 +82,15 @@ class AddEditCategoryScreen extends StatelessWidget {
 class CategoryForm extends StatefulWidget {
   final Category? initialCategory;
   final CategoryType? initialType;
-  final Function(String name, String iconName, String colorHex,
-      CategoryType type, String? parentId, Category categoryObject) onSubmit;
+  final Function(
+    String name,
+    String iconName,
+    String colorHex,
+    CategoryType type,
+    String? parentId,
+    Category categoryObject,
+  )
+  onSubmit;
 
   const CategoryForm({
     super.key,
@@ -105,14 +118,16 @@ class _CategoryFormState extends State<CategoryForm> {
     final initial = widget.initialCategory;
     _nameController = TextEditingController(text: initial?.name ?? '');
     _selectedIconName = initial?.iconName ?? 'category';
-    _selectedColor =
-        initial != null ? ColorUtils.fromHex(initial.colorHex) : Colors.blue;
+    _selectedColor = initial != null
+        ? ColorUtils.fromHex(initial.colorHex)
+        : Colors.blue;
     _selectedType = widget.initialType ?? initial?.type ?? CategoryType.expense;
     _selectedParentId = initial?.parentCategoryId;
     _isTypeChangeAllowed =
         widget.initialCategory == null && widget.initialType == null;
     log.info(
-        "[CategoryForm] initState. Initial Type: ${_selectedType.name}, AllowChange: $_isTypeChangeAllowed");
+      "[CategoryForm] initState. Initial Type: ${_selectedType.name}, AllowChange: $_isTypeChangeAllowed",
+    );
   }
 
   @override
@@ -124,7 +139,8 @@ class _CategoryFormState extends State<CategoryForm> {
   void _submitForm() {
     if (_formKey.currentState!.validate()) {
       log.info(
-          "[CategoryForm] Form validated. Submitting with Type: ${_selectedType.name}");
+        "[CategoryForm] Form validated. Submitting with Type: ${_selectedType.name}",
+      );
       final categoryObject = Category(
         id: widget.initialCategory?.id ?? sl<Uuid>().v4(),
         name: _nameController.text.trim(),
@@ -135,24 +151,29 @@ class _CategoryFormState extends State<CategoryForm> {
         parentCategoryId: _selectedParentId,
       );
       widget.onSubmit(
-          categoryObject.name,
-          categoryObject.iconName,
-          categoryObject.colorHex,
-          categoryObject.type,
-          categoryObject.parentCategoryId,
-          categoryObject);
+        categoryObject.name,
+        categoryObject.iconName,
+        categoryObject.colorHex,
+        categoryObject.type,
+        categoryObject.parentCategoryId,
+        categoryObject,
+      );
     } else {
       log.warning("[CategoryForm] Form validation failed.");
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
           content: Text('Please correct the errors in the form.'),
-          backgroundColor: Colors.orangeAccent));
+          backgroundColor: Colors.orangeAccent,
+        ),
+      );
     }
   }
 
   void _showParentPicker() {
     log.warning("[CategoryForm] Parent Category Picker not implemented yet.");
     ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Sub-category selection coming soon!")));
+      const SnackBar(content: Text("Sub-category selection coming soon!")),
+    );
   }
 
   // Removed _getPrefixIcon
@@ -165,18 +186,23 @@ class _CategoryFormState extends State<CategoryForm> {
 
     final List<Color> expenseColors = [
       theme.colorScheme.errorContainer.withOpacity(0.7),
-      theme.colorScheme.errorContainer
+      theme.colorScheme.errorContainer,
     ];
     final List<Color> incomeColors = [
       theme.colorScheme.primaryContainer,
-      theme.colorScheme.primaryContainer.withOpacity(0.7)
+      theme.colorScheme.primaryContainer.withOpacity(0.7),
     ];
 
     return Form(
       key: _formKey,
       child: ListView(
-        padding: modeTheme?.pagePadding
-                .copyWith(left: 16, right: 16, bottom: 40, top: 16) ??
+        padding:
+            modeTheme?.pagePadding.copyWith(
+              left: 16,
+              right: 16,
+              bottom: 40,
+              top: 16,
+            ) ??
             const EdgeInsets.all(16.0).copyWith(bottom: 40),
         children: [
           // Category Type Toggle
@@ -188,12 +214,14 @@ class _CategoryFormState extends State<CategoryForm> {
             disabled: !_isTypeChangeAllowed,
             onToggle: (index) {
               if (index != null) {
-                final newType =
-                    index == 0 ? CategoryType.expense : CategoryType.income;
+                final newType = index == 0
+                    ? CategoryType.expense
+                    : CategoryType.income;
                 if (_selectedType != newType) {
                   setState(() => _selectedType = newType);
                   log.info(
-                      "[CategoryForm] Type toggled to: ${_selectedType.name}");
+                    "[CategoryForm] Type toggled to: ${_selectedType.name}",
+                  );
                   // Reset parent on type change
                   // setState(() => _selectedParentId = null);
                 }
@@ -214,14 +242,19 @@ class _CategoryFormState extends State<CategoryForm> {
 
           // Parent Category Picker
           ListTile(
-            leading: CommonFormFields.getPrefixIcon(context, 'parent',
-                Icons.account_tree_outlined), // Use public helper
+            leading: CommonFormFields.getPrefixIcon(
+              context,
+              'parent',
+              Icons.account_tree_outlined,
+            ), // Use public helper
             title: const Text("Parent Category"),
             subtitle: Text(_selectedParentId ?? "None (Top Level)"),
-            trailing: const Icon(Icons.chevron_right), onTap: _showParentPicker,
+            trailing: const Icon(Icons.chevron_right),
+            onTap: _showParentPicker,
             shape: RoundedRectangleBorder(
-                side: BorderSide(color: theme.dividerColor),
-                borderRadius: BorderRadius.circular(8)),
+              side: BorderSide(color: theme.dividerColor),
+              borderRadius: BorderRadius.circular(8),
+            ),
             tileColor: theme.colorScheme.surfaceContainerHighest,
           ),
           const SizedBox(height: 20),
@@ -240,23 +273,17 @@ class _CategoryFormState extends State<CategoryForm> {
           // Submit Button
           ElevatedButton.icon(
             icon: Icon(
-                isEditing ? Icons.save_outlined : Icons.add_circle_outline),
+              isEditing ? Icons.save_outlined : Icons.add_circle_outline,
+            ),
             label: Text(isEditing ? 'Update Category' : 'Add Category'),
             style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                textStyle: theme.textTheme.titleMedium),
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              textStyle: theme.textTheme.titleMedium,
+            ),
             onPressed: _submitForm,
           ),
         ],
       ),
     );
-  }
-}
-
-// Helper extension
-extension StringCapExtension on String {
-  String capitalize() {
-    if (isEmpty) return this;
-    return "${this[0].toUpperCase()}${substring(1)}";
   }
 }

--- a/lib/features/goals/presentation/bloc/contribution_list/contribution_list_bloc.dart
+++ b/lib/features/goals/presentation/bloc/contribution_list/contribution_list_bloc.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:expense_tracker/core/events/data_change_event.dart';
+import 'package:expense_tracker/features/goals/domain/entities/goal_contribution.dart';
+import 'package:expense_tracker/features/goals/domain/usecases/get_contributions_for_goal.dart';
+import 'package:expense_tracker/main.dart';
+
+part 'contribution_list_event.dart';
+part 'contribution_list_state.dart';
+
+class ContributionListBloc
+    extends Bloc<ContributionListEvent, ContributionListState> {
+  final GetContributionsForGoalUseCase _getContributionsUseCase;
+  final String goalId;
+  late final StreamSubscription<DataChangedEvent> _dataChangeSubscription;
+
+  ContributionListBloc({
+    required this.goalId,
+    required GetContributionsForGoalUseCase getContributionsUseCase,
+    required Stream<DataChangedEvent> dataChangeStream,
+  }) : _getContributionsUseCase = getContributionsUseCase,
+       super(const ContributionListState()) {
+    on<LoadContributions>(_onLoadContributions);
+    on<_ContributionsDataChanged>(_onDataChanged);
+
+    _dataChangeSubscription = dataChangeStream.listen((event) {
+      if (event.type == DataChangeType.goalContribution) {
+        add(const _ContributionsDataChanged());
+      }
+    });
+
+    log.info('[ContributionListBloc] Initialized for goal $goalId');
+  }
+
+  Future<void> _onLoadContributions(
+    LoadContributions event,
+    Emitter<ContributionListState> emit,
+  ) async {
+    if (state.status == ContributionListStatus.loading && !event.forceReload) {
+      log.fine(
+        '[ContributionListBloc] LoadContributions ignored, already loading.',
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(status: ContributionListStatus.loading, clearError: true),
+    );
+    final result = await _getContributionsUseCase(
+      GetContributionsParams(goalId: goalId),
+    );
+    result.fold(
+      (failure) {
+        log.warning(
+          '[ContributionListBloc] Failed to load contributions: ${failure.message}',
+        );
+        emit(
+          state.copyWith(
+            status: ContributionListStatus.error,
+            errorMessage: failure.message,
+          ),
+        );
+      },
+      (contributions) {
+        log.info(
+          '[ContributionListBloc] Loaded ${contributions.length} contributions for goal $goalId.',
+        );
+        emit(
+          state.copyWith(
+            status: ContributionListStatus.success,
+            contributions: contributions,
+          ),
+        );
+      },
+    );
+  }
+
+  void _onDataChanged(
+    _ContributionsDataChanged event,
+    Emitter<ContributionListState> emit,
+  ) {
+    if (state.status != ContributionListStatus.loading) {
+      add(const LoadContributions(forceReload: true));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _dataChangeSubscription.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/goals/presentation/bloc/contribution_list/contribution_list_event.dart
+++ b/lib/features/goals/presentation/bloc/contribution_list/contribution_list_event.dart
@@ -1,0 +1,20 @@
+part of 'contribution_list_bloc.dart';
+
+abstract class ContributionListEvent extends Equatable {
+  const ContributionListEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadContributions extends ContributionListEvent {
+  final bool forceReload;
+  const LoadContributions({this.forceReload = false});
+
+  @override
+  List<Object?> get props => [forceReload];
+}
+
+class _ContributionsDataChanged extends ContributionListEvent {
+  const _ContributionsDataChanged();
+}

--- a/lib/features/goals/presentation/bloc/contribution_list/contribution_list_state.dart
+++ b/lib/features/goals/presentation/bloc/contribution_list/contribution_list_state.dart
@@ -1,0 +1,31 @@
+part of 'contribution_list_bloc.dart';
+
+enum ContributionListStatus { initial, loading, success, error }
+
+class ContributionListState extends Equatable {
+  final ContributionListStatus status;
+  final List<GoalContribution> contributions;
+  final String? errorMessage;
+
+  const ContributionListState({
+    this.status = ContributionListStatus.initial,
+    this.contributions = const [],
+    this.errorMessage,
+  });
+
+  ContributionListState copyWith({
+    ContributionListStatus? status,
+    List<GoalContribution>? contributions,
+    String? errorMessage,
+    bool clearError = false,
+  }) {
+    return ContributionListState(
+      status: status ?? this.status,
+      contributions: contributions ?? this.contributions,
+      errorMessage: clearError ? null : errorMessage ?? this.errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, contributions, errorMessage];
+}

--- a/lib/features/goals/presentation/pages/goal_detail_page.dart
+++ b/lib/features/goals/presentation/pages/goal_detail_page.dart
@@ -1,5 +1,4 @@
 // lib/features/goals/presentation/pages/goal_detail_page.dart
-import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:expense_tracker/core/constants/route_names.dart';
 import 'package:expense_tracker/core/di/service_locator.dart';
@@ -10,10 +9,9 @@ import 'package:expense_tracker/core/utils/date_formatter.dart';
 import 'package:expense_tracker/core/widgets/section_header.dart';
 import 'package:expense_tracker/features/goals/domain/entities/goal.dart';
 import 'package:expense_tracker/features/goals/domain/entities/goal_contribution.dart';
-import 'package:expense_tracker/features/goals/domain/usecases/get_contributions_for_goal.dart';
-import 'package:expense_tracker/features/goals/domain/repositories/goal_repository.dart';
 import 'package:expense_tracker/features/goals/presentation/bloc/goal_list/goal_list_bloc.dart';
 import 'package:expense_tracker/features/goals/presentation/bloc/log_contribution/log_contribution_bloc.dart';
+import 'package:expense_tracker/features/goals/presentation/bloc/contribution_list/contribution_list_bloc.dart';
 import 'package:expense_tracker/features/goals/presentation/widgets/contribution_list_item.dart';
 import 'package:expense_tracker/features/goals/presentation/widgets/log_contribution_sheet.dart';
 import 'package:expense_tracker/features/reports/presentation/widgets/charts/goal_contribution_chart.dart'; // Import chart
@@ -30,195 +28,90 @@ import 'package:percent_indicator/circular_percent_indicator.dart';
 
 class GoalDetailPage extends StatefulWidget {
   final String goalId;
-  final Goal? initialGoal;
 
-  const GoalDetailPage({
-    super.key,
-    required this.goalId,
-    this.initialGoal,
-  });
+  const GoalDetailPage({super.key, required this.goalId});
 
   @override
   State<GoalDetailPage> createState() => _GoalDetailPageState();
 }
 
 class _GoalDetailPageState extends State<GoalDetailPage> {
-  final GetContributionsForGoalUseCase _getContributionsUseCase = sl();
-  final GoalRepository _goalRepository = sl();
-
-  Goal? _currentGoal;
-  List<GoalContribution> _contributions = [];
-  bool _isLoadingGoal = true;
-  bool _isLoadingContributions = true;
-  String? _error;
   late ConfettiController _confettiController;
-  StreamSubscription? _goalListSubscription;
-  // --- ADDED State for chart/list view ---
   bool _showContributionChart = true;
-  // --- END ADD ---
+  bool _wasAchieved = false;
+  late final ContributionListBloc _contributionBloc;
 
   @override
   void initState() {
     super.initState();
-    _currentGoal = widget.initialGoal;
-    _confettiController =
-        ConfettiController(duration: const Duration(seconds: 3));
-    _loadData();
-    _goalListSubscription =
-        context.read<GoalListBloc>().stream.listen(_handleBlocStateChange);
+    _confettiController = ConfettiController(
+      duration: const Duration(seconds: 3),
+    );
+    _contributionBloc = sl<ContributionListBloc>(param1: widget.goalId)
+      ..add(const LoadContributions());
   }
 
   @override
   void dispose() {
     _confettiController.dispose();
-    _goalListSubscription?.cancel();
+    _contributionBloc.close();
     super.dispose();
   }
 
-  void _handleBlocStateChange(dynamic state) {
-    if (mounted && !_isLoadingGoal) {
-      log.fine("[GoalDetail] Received Bloc update, reloading detail data.");
-      _loadData();
-    }
+  void _navigateToEdit(BuildContext context, Goal goal) {
+    context.pushNamed(
+      RouteNames.editGoal,
+      pathParameters: {'id': goal.id},
+      extra: goal,
+    );
   }
 
-  Future<void> _loadData() async {
-    // ... (goal loading logic remains the same) ...
-    if (!mounted) return;
-    bool wasLoadingBefore = _isLoadingGoal || _isLoadingContributions;
-    if (!wasLoadingBefore) {
-      log.fine("[GoalDetail] _loadData potentially refreshing.");
-    }
-
-    setState(() {
-      _isLoadingGoal = _currentGoal == null;
-      _isLoadingContributions = true;
-      _error = null;
-    });
-
-    bool goalAlreadyAchievedBeforeLoad = _currentGoal?.isAchieved ?? false;
-
-    // Fetch Goal Detail
-    final goalResult = await _goalRepository.getGoalById(widget.goalId);
-    Goal? loadedGoal;
-
-    await goalResult.fold((failure) async {
-      log.severe(
-          "[GoalDetail] Failed to load goal details: ${failure.message}");
-      if (mounted) {
-        setState(() {
-          _error = "Failed to load goal details.";
-          _isLoadingGoal = false;
-          _isLoadingContributions = false;
-        });
-      }
-    }, (goal) async {
-      if (goal == null) {
-        log.severe("[GoalDetail] Goal ${widget.goalId} not found.");
-        if (mounted) {
-          setState(() {
-            _error = "Goal not found.";
-            _isLoadingGoal = false;
-            _isLoadingContributions = false;
-          });
-        }
-      } else {
-        loadedGoal = goal;
-        if (mounted) {
-          setState(() {
-            _currentGoal = loadedGoal;
-            _isLoadingGoal = false;
-          });
-
-          final uiMode = context.read<SettingsBloc>().state.uiMode;
-          if (_currentGoal!.isAchieved &&
-              !goalAlreadyAchievedBeforeLoad &&
-              uiMode != UIMode.quantum) {
-            log.info(
-                "[GoalDetail] Goal ${widget.goalId} newly achieved! Playing confetti.");
-            _confettiController.play();
-          } else if (!_currentGoal!.isAchieved &&
-              goalAlreadyAchievedBeforeLoad) {
-            log.info("[GoalDetail] Goal ${widget.goalId} no longer achieved.");
-          }
-        }
-      }
-    });
-
-    if (_error != null || _currentGoal == null) {
-      return; // Stop if goal loading failed
-    }
-
-    // Fetch Contributions
-    final contributionsResult = await _getContributionsUseCase(
-        GetContributionsParams(goalId: widget.goalId));
-    if (!mounted) return;
-
-    contributionsResult.fold((failure) {
-      log.warning(
-          "[GoalDetail] Failed to load contributions: ${failure.message}");
-      setState(() {
-        _error = "${_error ?? ""}\nFailed to load contribution history.";
-        _isLoadingContributions = false;
-      });
-    }, (contributions) {
-      log.info("[GoalDetail] Loaded ${contributions.length} contributions.");
-      // Optimization: Only update state if the list content actually changed
-      if (!const DeepCollectionEquality()
-          .equals(_contributions, contributions)) {
-        setState(() {
-          _contributions = contributions;
-        });
-      }
-      setState(() {
-        _isLoadingContributions = false;
-      });
-    });
-  }
-
-  void _navigateToEdit(BuildContext context) {
-    // ... (no change needed) ...
-    if (_currentGoal == null) return;
-    context.pushNamed(RouteNames.editGoal,
-        pathParameters: {'id': _currentGoal!.id}, extra: _currentGoal);
-  }
-
-  void _handleArchive(BuildContext context) async {
-    // ... (no change needed) ...
-    if (_currentGoal == null) return;
-    final confirmed = await AppDialogs.showConfirmation(context,
-        title: "Confirm Archive",
-        content:
-            'Archive "${_currentGoal!.name}"? Contributions will be kept, but the goal will be hidden from the active list.',
-        confirmText: "Archive",
-        confirmColor: Colors.orange[700]);
+  void _handleArchive(BuildContext context, Goal goal) async {
+    final confirmed = await AppDialogs.showConfirmation(
+      context,
+      title: "Confirm Archive",
+      content:
+          'Archive "${goal.name}"? Contributions will be kept, but the goal will be hidden from the active list.',
+      confirmText: "Archive",
+      confirmColor: Colors.orange[700],
+    );
     if (confirmed == true && context.mounted) {
-      context.read<GoalListBloc>().add(ArchiveGoal(goalId: _currentGoal!.id));
+      context.read<GoalListBloc>().add(ArchiveGoal(goalId: goal.id));
       if (context.canPop()) {
         context.pop();
       } else {
-        context.go(RouteNames.budgetsAndCats,
-            extra: {'initialTabIndex': 1}); // Navigate to goals tab
+        context.go(
+          RouteNames.budgetsAndCats,
+          extra: {'initialTabIndex': 1},
+        ); // Navigate to goals tab
       }
     }
   }
 
   Future<bool?> _handleDeleteContribution(
-      BuildContext context, GoalContribution contribution) async {
+    BuildContext context,
+    GoalContribution contribution,
+  ) async {
     // ... (no change needed) ...
     final settings = context.read<SettingsBloc>().state;
-    final confirmed = await AppDialogs.showConfirmation(context,
-        title: "Delete Contribution?",
-        content:
-            "Delete contribution of ${CurrencyFormatter.format(contribution.amount, settings.currencySymbol)} made on ${DateFormatter.formatDate(contribution.date)}?",
-        confirmText: "Delete",
-        confirmColor: Theme.of(context).colorScheme.error);
+    final confirmed = await AppDialogs.showConfirmation(
+      context,
+      title: "Delete Contribution?",
+      content:
+          "Delete contribution of ${CurrencyFormatter.format(contribution.amount, settings.currencySymbol)} made on ${DateFormatter.formatDate(contribution.date)}?",
+      confirmText: "Delete",
+      confirmColor: Theme.of(context).colorScheme.error,
+    );
     if (confirmed == true && context.mounted) {
       // Use sl directly if context is problematic across async gaps
       final logContribBloc = sl<LogContributionBloc>();
       // Initialize the bloc with the contribution to be deleted
-      logContribBloc.add(InitializeContribution(
-          goalId: contribution.goalId, initialContribution: contribution));
+      logContribBloc.add(
+        InitializeContribution(
+          goalId: contribution.goalId,
+          initialContribution: contribution,
+        ),
+      );
       logContribBloc.add(const DeleteContribution());
       return true; // Indicate dialog should close
     }
@@ -226,54 +119,67 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
   }
 
   Widget _buildProgressIndicatorWidget(
-      BuildContext context, AppModeTheme? modeTheme, UIMode uiMode) {
-    // ... (no change needed) ...
+    BuildContext context,
+    Goal goal,
+    AppModeTheme? modeTheme,
+    UIMode uiMode,
+  ) {
     final theme = Theme.of(context);
-    if (_currentGoal == null) return const SizedBox(height: 90);
-    final goal = _currentGoal!;
     final progress = goal.percentageComplete;
-    final color =
-        goal.isAchieved ? Colors.green.shade600 : theme.colorScheme.primary;
-    final backgroundColor =
-        theme.colorScheme.surfaceContainerHighest.withOpacity(0.5);
+    final color = goal.isAchieved
+        ? Colors.green.shade600
+        : theme.colorScheme.primary;
+    final backgroundColor = theme.colorScheme.surfaceContainerHighest
+        .withOpacity(0.5);
     final bool isQuantum = uiMode == UIMode.quantum;
 
     final double radius = isQuantum ? 60.0 : 70.0;
     final double lineWidth = isQuantum ? 8.0 : 12.0;
-    final TextStyle centerTextStyle = (isQuantum
+    final TextStyle centerTextStyle =
+        (isQuantum
                 ? theme.textTheme.headlineSmall
                 : theme.textTheme.headlineMedium)
             ?.copyWith(fontWeight: FontWeight.bold, color: color) ??
         TextStyle(color: color);
 
     return CircularPercentIndicator(
-        radius: radius,
-        lineWidth: lineWidth,
-        animation: !isQuantum,
-        animationDuration: isQuantum ? 0 : 1000,
-        percent: progress,
-        center: Text("${(progress * 100).toStringAsFixed(0)}%",
-            style: centerTextStyle),
-        circularStrokeCap: CircularStrokeCap.round,
-        progressColor: color,
-        backgroundColor: backgroundColor);
+      radius: radius,
+      lineWidth: lineWidth,
+      animation: !isQuantum,
+      animationDuration: isQuantum ? 0 : 1000,
+      percent: progress,
+      center: Text(
+        "${(progress * 100).toStringAsFixed(0)}%",
+        style: centerTextStyle,
+      ),
+      circularStrokeCap: CircularStrokeCap.round,
+      progressColor: color,
+      backgroundColor: backgroundColor,
+    );
   }
 
   // REFINED: Contribution List/Chart Widget
   Widget _buildContributionWidget(
-      BuildContext context, AppModeTheme? modeTheme, UIMode uiMode) {
+    BuildContext context,
+    List<GoalContribution> contributions,
+    ContributionListStatus status,
+    AppModeTheme? modeTheme,
+    UIMode uiMode,
+  ) {
     final theme = Theme.of(context);
     final settings = context.watch<SettingsBloc>().state;
 
-    if (_isLoadingContributions) {
+    if (status == ContributionListStatus.loading) {
       return const Padding(
-          padding: EdgeInsets.symmetric(vertical: 20.0),
-          child: Center(child: CircularProgressIndicator(strokeWidth: 2)));
+        padding: EdgeInsets.symmetric(vertical: 20.0),
+        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+      );
     }
-    if (_contributions.isEmpty) {
+    if (contributions.isEmpty) {
       return const Padding(
-          padding: EdgeInsets.symmetric(vertical: 24.0),
-          child: Center(child: Text("No contributions logged yet.")));
+        padding: EdgeInsets.symmetric(vertical: 24.0),
+        child: Center(child: Text("No contributions logged yet.")),
+      );
     }
 
     return Column(
@@ -302,16 +208,19 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
           },
           child: _showContributionChart
               ? KeyedSubtree(
-                  // Use key to help AnimatedSwitcher
                   key: const ValueKey('contrib_chart'),
                   child: SizedBox(
-                    height: 200, // Fixed height for chart
-                    child: GoalContributionChart(contributions: _contributions),
+                    height: 200,
+                    child: GoalContributionChart(contributions: contributions),
                   ),
                 )
               : KeyedSubtree(
                   key: const ValueKey('contrib_list'),
-                  child: _buildContributionList(context, settings),
+                  child: _buildContributionList(
+                    context,
+                    settings,
+                    contributions,
+                  ),
                 ),
         ),
       ],
@@ -319,29 +228,38 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
   }
 
   // Helper for Contribution List Items (with Drill-Down)
-  Widget _buildContributionList(BuildContext context, SettingsState settings) {
+  Widget _buildContributionList(
+    BuildContext context,
+    SettingsState settings,
+    List<GoalContribution> contributions,
+  ) {
     final bool isAether = settings.uiMode == UIMode.aether;
     final modeTheme = context.modeTheme;
-    final itemDelay =
-        isAether ? (modeTheme?.listAnimationDelay ?? 80.ms) : 50.ms;
-    final itemDuration =
-        isAether ? (modeTheme?.listAnimationDuration ?? 450.ms) : 300.ms;
+    final itemDelay = isAether
+        ? (modeTheme?.listAnimationDelay ?? 80.ms)
+        : 50.ms;
+    final itemDuration = isAether
+        ? (modeTheme?.listAnimationDuration ?? 450.ms)
+        : 300.ms;
     final theme = Theme.of(context);
 
     return ListView.separated(
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
-      itemCount: _contributions.length,
+      itemCount: contributions.length,
       itemBuilder: (ctx, index) {
-        final contribution = _contributions[index];
+        final contribution = contributions[index];
         Widget item = ContributionListItem(
-            contribution: contribution, goalId: widget.goalId);
+          contribution: contribution,
+          goalId: widget.goalId,
+        );
 
         // --- ADDED: InkWell for Drill Down ---
         item = InkWell(
           onTap: () {
             log.info(
-                "[GoalDetail] Tapped contribution item ID: ${contribution.id}");
+              "[GoalDetail] Tapped contribution item ID: ${contribution.id}",
+            );
             showLogContributionSheet(
               context,
               contribution.goalId,
@@ -359,17 +277,21 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
             .slideY(begin: 0.1, curve: Curves.easeOut);
 
         return Dismissible(
-            key: Key('contrib_dismiss_detail_${contribution.id}'),
-            direction: DismissDirection.endToStart,
-            background: Container(
-                color: theme.colorScheme.errorContainer,
-                alignment: Alignment.centerRight,
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: Icon(Icons.delete_sweep_outlined,
-                    color: theme.colorScheme.onErrorContainer)),
-            confirmDismiss: (_) =>
-                _handleDeleteContribution(context, contribution),
-            child: item);
+          key: Key('contrib_dismiss_detail_${contribution.id}'),
+          direction: DismissDirection.endToStart,
+          background: Container(
+            color: theme.colorScheme.errorContainer,
+            alignment: Alignment.centerRight,
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Icon(
+              Icons.delete_sweep_outlined,
+              color: theme.colorScheme.onErrorContainer,
+            ),
+          ),
+          confirmDismiss: (_) =>
+              _handleDeleteContribution(context, contribution),
+          child: item,
+        );
       },
       separatorBuilder: (_, __) => const Divider(height: 1, thickness: 0.5),
     );
@@ -378,162 +300,229 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    // ... (rest of build method including loading/error checks remains the same) ...
-    final theme = Theme.of(context);
-    final settings = context.watch<SettingsBloc>().state;
-    final uiMode = settings.uiMode;
-    final modeTheme = context.modeTheme;
+    return BlocProvider.value(
+      value: _contributionBloc,
+      child: BlocConsumer<GoalListBloc, GoalListState>(
+        listenWhen: (prev, curr) {
+          final prevGoal = prev.goals.firstWhereOrNull(
+            (g) => g.id == widget.goalId,
+          );
+          final currGoal = curr.goals.firstWhereOrNull(
+            (g) => g.id == widget.goalId,
+          );
+          return prevGoal?.isAchieved != currGoal?.isAchieved;
+        },
+        listener: (context, state) {
+          final goal = state.goals.firstWhereOrNull(
+            (g) => g.id == widget.goalId,
+          );
+          if (goal != null && goal.isAchieved && !_wasAchieved) {
+            _wasAchieved = true;
+            final uiMode = context.read<SettingsBloc>().state.uiMode;
+            if (uiMode != UIMode.quantum) {
+              _confettiController.play();
+            }
+          } else if (goal != null && !goal.isAchieved) {
+            _wasAchieved = false;
+          }
+        },
+        builder: (context, goalListState) {
+          final theme = Theme.of(context);
+          final settings = context.watch<SettingsBloc>().state;
+          final uiMode = settings.uiMode;
+          final modeTheme = context.modeTheme;
 
-    if (_isLoadingGoal) {
-      return Scaffold(
-          appBar: AppBar(),
-          body: const Center(child: CircularProgressIndicator()));
-    }
-    if (_error != null || _currentGoal == null) {
-      return Scaffold(
-          appBar: AppBar(title: const Text("Error")),
-          body: Center(
-              child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Text(_error ?? "Goal could not be loaded.",
-                      style: TextStyle(color: theme.colorScheme.error)))));
-    }
-
-    final goal = _currentGoal!;
-    final isAether = uiMode == UIMode.aether;
-    final String? bgPath = isAether
-        ? (Theme.of(context).brightness == Brightness.dark
-            ? modeTheme?.assets.mainBackgroundDark
-            : modeTheme?.assets.mainBackgroundLight)
-        : null;
-
-    Widget mainContent = ListView(
-      padding: modeTheme?.pagePadding.copyWith(
-              bottom: 100, // Increased padding for FAB
-              top: isAether
-                  ? (modeTheme.pagePadding.top +
-                      kToolbarHeight +
-                      MediaQuery.of(context).padding.top)
-                  : modeTheme.pagePadding.top) ??
-          const EdgeInsets.all(16.0).copyWith(bottom: 100),
-      children: [
-        Center(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 16.0),
-            child: _buildProgressIndicatorWidget(context, modeTheme, uiMode),
-          ),
-        ),
-        Center(
-          child: Padding(
-            padding: const EdgeInsets.only(bottom: 8.0),
-            child: Text(
-              '${CurrencyFormatter.format(goal.totalSaved, settings.currencySymbol)} / ${CurrencyFormatter.format(goal.targetAmount, settings.currencySymbol)}',
-              style: theme.textTheme.titleLarge
-                  ?.copyWith(fontWeight: FontWeight.bold),
-            ),
-          ),
-        ),
-        Center(
-          child: Padding(
-            padding: const EdgeInsets.only(bottom: 24.0),
-            child: Text(
-              goal.isAchieved
-                  ? 'Goal Achieved!'
-                  : '${CurrencyFormatter.format(goal.amountRemaining, settings.currencySymbol)} remaining',
-              style: theme.textTheme.bodyMedium?.copyWith(
-                  color: goal.isAchieved
-                      ? Colors.green
-                      : theme.colorScheme.onSurfaceVariant),
-            ),
-          ),
-        ),
-        if (goal.targetDate != null)
-          Center(
-            child: Padding(
-              padding: const EdgeInsets.only(bottom: 16.0),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.flag_outlined,
-                      size: 16,
-                      color:
-                          theme.colorScheme.onSurfaceVariant.withOpacity(0.7)),
-                  const SizedBox(width: 4),
-                  Text('Target: ${DateFormatter.formatDate(goal.targetDate!)}',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant)),
-                ],
+          final goal = goalListState.goals.firstWhereOrNull(
+            (g) => g.id == widget.goalId,
+          );
+          if (goal == null) {
+            if (goalListState.status == GoalListStatus.loading ||
+                goalListState.status == GoalListStatus.initial) {
+              return Scaffold(
+                appBar: AppBar(),
+                body: const Center(child: CircularProgressIndicator()),
+              );
+            }
+            return Scaffold(
+              appBar: AppBar(title: const Text('Error')),
+              body: Center(
+                child: Text(
+                  'Goal not found.',
+                  style: TextStyle(color: theme.colorScheme.error),
+                ),
               ),
-            ),
-          ),
-        if (goal.description != null && goal.description!.isNotEmpty)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 24.0),
-            child: Text(goal.description!,
-                style: theme.textTheme.bodyMedium, textAlign: TextAlign.center),
-          ),
-        const SectionHeader(title: "Contribution History"),
-        // --- REPLACED List with conditional Chart/List ---
-        _buildContributionWidget(context, modeTheme, uiMode),
-        // --- END REPLACED ---
-      ],
-    );
+            );
+          }
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(goal.name, overflow: TextOverflow.ellipsis),
-        backgroundColor: isAether ? Colors.transparent : null,
-        elevation: isAether ? 0 : null,
-        actions: [
-          if (!goal.isArchived)
-            IconButton(
-                icon: const Icon(Icons.edit_outlined),
-                onPressed: () => _navigateToEdit(context),
-                tooltip: "Edit Goal"),
-          if (!goal.isArchived)
-            IconButton(
-                icon: const Icon(Icons.archive_outlined),
-                onPressed: () => _handleArchive(context),
-                tooltip: "Archive Goal"),
-        ],
-      ),
-      extendBodyBehindAppBar: isAether,
-      body: Stack(alignment: Alignment.topCenter, children: [
-        if (isAether && bgPath != null && bgPath.isNotEmpty)
-          Positioned.fill(child: SvgPicture.asset(bgPath, fit: BoxFit.cover)),
-        mainContent,
-        Align(
-          alignment: Alignment.topCenter,
-          child: ConfettiWidget(
-            confettiController: _confettiController,
-            blastDirectionality: BlastDirectionality.explosive,
-            shouldLoop: false,
-            numberOfParticles: 25,
-            gravity: 0.1,
-            emissionFrequency: 0.03,
-            maxBlastForce: 7,
-            minBlastForce: 3,
-            particleDrag: 0.05,
-            colors: const [
-              Colors.green,
-              Colors.blue,
-              Colors.pink,
-              Colors.orange,
-              Colors.purple
+          final contributionState = context.watch<ContributionListBloc>().state;
+          final contributions = contributionState.contributions;
+
+          final isAether = uiMode == UIMode.aether;
+          final String? bgPath = isAether
+              ? (Theme.of(context).brightness == Brightness.dark
+                    ? modeTheme?.assets.mainBackgroundDark
+                    : modeTheme?.assets.mainBackgroundLight)
+              : null;
+
+          Widget mainContent = ListView(
+            padding:
+                modeTheme?.pagePadding.copyWith(
+                  bottom: 100,
+                  top: isAether
+                      ? (modeTheme.pagePadding.top +
+                            kToolbarHeight +
+                            MediaQuery.of(context).padding.top)
+                      : modeTheme.pagePadding.top,
+                ) ??
+                const EdgeInsets.all(16.0).copyWith(bottom: 100),
+            children: [
+              Center(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 16.0),
+                  child: _buildProgressIndicatorWidget(
+                    context,
+                    goal,
+                    modeTheme,
+                    uiMode,
+                  ),
+                ),
+              ),
+              Center(
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 8.0),
+                  child: Text(
+                    '${CurrencyFormatter.format(goal.totalSaved, settings.currencySymbol)} / ${CurrencyFormatter.format(goal.targetAmount, settings.currencySymbol)}',
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+              Center(
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 24.0),
+                  child: Text(
+                    goal.isAchieved
+                        ? 'Goal Achieved!'
+                        : '${CurrencyFormatter.format(goal.amountRemaining, settings.currencySymbol)} remaining',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: goal.isAchieved
+                          ? Colors.green
+                          : theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ),
+              if (goal.targetDate != null)
+                Center(
+                  child: Padding(
+                    padding: const EdgeInsets.only(bottom: 16.0),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.flag_outlined,
+                          size: 16,
+                          color: theme.colorScheme.onSurfaceVariant.withOpacity(
+                            0.7,
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          'Target: ${DateFormatter.formatDate(goal.targetDate!)}',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              if (goal.description != null && goal.description!.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 24.0),
+                  child: Text(
+                    goal.description!,
+                    style: theme.textTheme.bodyMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              const SectionHeader(title: 'Contribution History'),
+              _buildContributionWidget(
+                context,
+                contributions,
+                contributionState.status,
+                modeTheme,
+                uiMode,
+              ),
             ],
-          ),
-        ),
-      ]),
-      floatingActionButton: goal.isAchieved || goal.isArchived
-          ? null
-          : FloatingActionButton.extended(
-              heroTag: 'add_contribution_fab',
-              icon: const Icon(Icons.add),
-              label: const Text("Log Contribution"),
-              onPressed: () {
-                showLogContributionSheet(context, goal.id);
-              },
+          );
+
+          return Scaffold(
+            appBar: AppBar(
+              title: Text(goal.name, overflow: TextOverflow.ellipsis),
+              backgroundColor: isAether ? Colors.transparent : null,
+              elevation: isAether ? 0 : null,
+              actions: [
+                if (!goal.isArchived)
+                  IconButton(
+                    icon: const Icon(Icons.edit_outlined),
+                    onPressed: () => _navigateToEdit(context, goal),
+                    tooltip: 'Edit Goal',
+                  ),
+                if (!goal.isArchived)
+                  IconButton(
+                    icon: const Icon(Icons.archive_outlined),
+                    onPressed: () => _handleArchive(context, goal),
+                    tooltip: 'Archive Goal',
+                  ),
+              ],
             ),
+            extendBodyBehindAppBar: isAether,
+            body: Stack(
+              alignment: Alignment.topCenter,
+              children: [
+                if (isAether && bgPath != null && bgPath.isNotEmpty)
+                  Positioned.fill(
+                    child: SvgPicture.asset(bgPath, fit: BoxFit.cover),
+                  ),
+                mainContent,
+                Align(
+                  alignment: Alignment.topCenter,
+                  child: ConfettiWidget(
+                    confettiController: _confettiController,
+                    blastDirectionality: BlastDirectionality.explosive,
+                    shouldLoop: false,
+                    numberOfParticles: 25,
+                    gravity: 0.1,
+                    emissionFrequency: 0.03,
+                    maxBlastForce: 7,
+                    minBlastForce: 3,
+                    particleDrag: 0.05,
+                    colors: const [
+                      Colors.green,
+                      Colors.blue,
+                      Colors.pink,
+                      Colors.orange,
+                      Colors.purple,
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            floatingActionButton: goal.isAchieved || goal.isArchived
+                ? null
+                : FloatingActionButton.extended(
+                    heroTag: 'add_contribution_fab',
+                    icon: const Icon(Icons.add),
+                    label: const Text('Log Contribution'),
+                    onPressed: () {
+                      showLogContributionSheet(context, goal.id);
+                    },
+                  ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
+++ b/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
@@ -75,7 +75,7 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
             isRecurring: true,
           );
           transactionResult =
-              (await addExpense(AddExpenseParams(newExpense))).map((_) => null);
+              (await addExpense(AddExpenseParams(newExpense))).map((_) {});
         } else {
           final newIncome = Income(
             id: uuid.v4(),
@@ -88,7 +88,7 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
             isRecurring: true,
           );
           transactionResult =
-              (await addIncome(AddIncomeParams(newIncome))).map((_) => null);
+              (await addIncome(AddIncomeParams(newIncome))).map((_) {});
         }
 
         return await transactionResult.fold<Future<Either<Failure, void>>>(

--- a/lib/features/reports/presentation/pages/income_vs_expense_page.dart
+++ b/lib/features/reports/presentation/pages/income_vs_expense_page.dart
@@ -15,6 +15,7 @@ import 'package:expense_tracker/features/settings/presentation/bloc/settings_blo
 import 'package:expense_tracker/features/transactions/domain/entities/transaction_entity.dart'; // For TransactionType
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:expense_tracker/core/utils/string_extensions.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
@@ -33,27 +34,34 @@ class _IncomeVsExpensePageState extends State<IncomeVsExpensePage> {
   void _toggleComparison() {
     final newComparisonState = !_showComparison;
     setState(
-        () => _showComparison = newComparisonState); // Update local state first
+      () => _showComparison = newComparisonState,
+    ); // Update local state first
 
     // Get current period type from BLoC state
     final currentState = context.read<IncomeExpenseReportBloc>().state;
     final currentPeriod = currentState is IncomeExpenseReportLoaded
         ? currentState.reportData.periodType
         : (currentState is IncomeExpenseReportLoading)
-            ? currentState.periodType
-            : IncomeExpensePeriodType.monthly; // Default
+        ? currentState.periodType
+        : IncomeExpensePeriodType.monthly; // Default
 
     // Dispatch event with the NEW comparison state
-    context.read<IncomeExpenseReportBloc>().add(LoadIncomeExpenseReport(
-          compareToPrevious: newComparisonState, // Pass the toggled value
-          periodType: currentPeriod,
-        ));
+    context.read<IncomeExpenseReportBloc>().add(
+      LoadIncomeExpenseReport(
+        compareToPrevious: newComparisonState, // Pass the toggled value
+        periodType: currentPeriod,
+      ),
+    );
     log.info(
-        "[IncomeVsExpensePage] Toggled comparison to: $newComparisonState");
+      "[IncomeVsExpensePage] Toggled comparison to: $newComparisonState",
+    );
   }
 
-  void _navigateToFilteredTransactions(BuildContext context,
-      IncomeExpensePeriodData periodData, TransactionType type) {
+  void _navigateToFilteredTransactions(
+    BuildContext context,
+    IncomeExpensePeriodData periodData,
+    TransactionType type,
+  ) {
     final filterBlocState = context.read<ReportFilterBloc>().state;
     final reportState = context.read<IncomeExpenseReportBloc>().state;
     // Ensure state is loaded before proceeding
@@ -64,8 +72,14 @@ class _IncomeVsExpensePageState extends State<IncomeVsExpensePage> {
     DateTime periodStart = periodData.periodStart;
     DateTime periodEnd;
     if (periodType == IncomeExpensePeriodType.monthly) {
-      periodEnd =
-          DateTime(periodStart.year, periodStart.month + 1, 0, 23, 59, 59);
+      periodEnd = DateTime(
+        periodStart.year,
+        periodStart.month + 1,
+        0,
+        23,
+        59,
+        59,
+      );
     } else {
       // Yearly
       periodEnd = DateTime(periodStart.year, 12, 31, 23, 59, 59);
@@ -81,7 +95,8 @@ class _IncomeVsExpensePageState extends State<IncomeVsExpensePage> {
     }
 
     log.info(
-        "[IncomeVsExpensePage] Navigating to transactions with filters: $filters");
+      "[IncomeVsExpensePage] Navigating to transactions with filters: $filters",
+    );
     context.push(RouteNames.transactionsList, extra: {'filters': filters});
   }
 
@@ -96,36 +111,44 @@ class _IncomeVsExpensePageState extends State<IncomeVsExpensePage> {
       title: 'Income vs Expense',
       actions: [
         IconButton(
-            icon: Icon(_showComparison
+          icon: Icon(
+            _showComparison
                 ? Icons.compare_arrows_rounded
-                : Icons.compare_arrows_outlined),
-            tooltip: _showComparison ? "Hide Comparison" : "Compare Period",
-            color: _showComparison ? theme.colorScheme.primary : null,
-            onPressed: _toggleComparison),
+                : Icons.compare_arrows_outlined,
+          ),
+          tooltip: _showComparison ? "Hide Comparison" : "Compare Period",
+          color: _showComparison ? theme.colorScheme.primary : null,
+          onPressed: _toggleComparison,
+        ),
         BlocBuilder<IncomeExpenseReportBloc, IncomeExpenseReportState>(
           builder: (context, state) {
             final currentPeriod = (state is IncomeExpenseReportLoaded)
                 ? state.reportData.periodType
                 : (state is IncomeExpenseReportLoading)
-                    ? state.periodType
-                    : IncomeExpensePeriodType.monthly;
+                ? state.periodType
+                : IncomeExpensePeriodType.monthly;
             return PopupMenuButton<IncomeExpensePeriodType>(
-                initialValue: currentPeriod,
-                onSelected: (p) {
-                  // When period changes, also pass current comparison state
-                  context
-                      .read<IncomeExpenseReportBloc>()
-                      .add(LoadIncomeExpenseReport(
-                        periodType: p,
-                        compareToPrevious: _showComparison,
-                      ));
-                },
-                icon: const Icon(Icons.calendar_view_month_outlined),
-                tooltip: "Change Period Aggregation",
-                itemBuilder: (_) => IncomeExpensePeriodType.values
-                    .map((p) => PopupMenuItem<IncomeExpensePeriodType>(
-                        value: p, child: Text(p.name.capitalize())))
-                    .toList());
+              initialValue: currentPeriod,
+              onSelected: (p) {
+                // When period changes, also pass current comparison state
+                context.read<IncomeExpenseReportBloc>().add(
+                  LoadIncomeExpenseReport(
+                    periodType: p,
+                    compareToPrevious: _showComparison,
+                  ),
+                );
+              },
+              icon: const Icon(Icons.calendar_view_month_outlined),
+              tooltip: "Change Period Aggregation",
+              itemBuilder: (_) => IncomeExpensePeriodType.values
+                  .map(
+                    (p) => PopupMenuItem<IncomeExpensePeriodType>(
+                      value: p,
+                      child: Text(p.name.capitalize()),
+                    ),
+                  )
+                  .toList(),
+            );
           },
         ),
       ],
@@ -134,8 +157,10 @@ class _IncomeVsExpensePageState extends State<IncomeVsExpensePage> {
         if (state is IncomeExpenseReportLoaded) {
           final helper = sl<CsvExportHelper>();
           return helper.exportIncomeExpenseReport(
-              state.reportData, currencySymbol,
-              showComparison: _showComparison);
+            state.reportData,
+            currencySymbol,
+            showComparison: _showComparison,
+          );
         }
         return const Right(ExportFailure("Report data not loaded yet."));
       },
@@ -145,46 +170,62 @@ class _IncomeVsExpensePageState extends State<IncomeVsExpensePage> {
             return const Center(child: CircularProgressIndicator());
           if (state is IncomeExpenseReportError)
             return Center(
-                child: Text("Error: ${state.message}",
-                    style: TextStyle(color: theme.colorScheme.error)));
+              child: Text(
+                "Error: ${state.message}",
+                style: TextStyle(color: theme.colorScheme.error),
+              ),
+            );
           if (state is IncomeExpenseReportLoaded) {
             final reportData = state.reportData;
             if (reportData.periodData.isEmpty)
               return const Center(
-                  child: Text("No income or expense data for this period."));
+                child: Text("No income or expense data for this period."),
+              );
 
             Widget chartWidget = IncomeExpenseBarChart(
-                data: reportData.periodData,
-                showComparison: _showComparison,
-                onTapBar: (groupIndex, rodIndex) {
-                  TransactionType type;
-                  if (_showComparison) {
-                    // PrevIncome=0, CurrIncome=1, PrevExpense=2, CurrExpense=3
-                    type = (rodIndex <= 1)
-                        ? TransactionType.income
-                        : TransactionType.expense;
-                  } else {
-                    // CurrIncome=0, CurrExpense=1
-                    type = (rodIndex == 0)
-                        ? TransactionType.income
-                        : TransactionType.expense;
-                  }
-                  _navigateToFilteredTransactions(
-                      context, reportData.periodData[groupIndex], type);
-                });
+              data: reportData.periodData,
+              showComparison: _showComparison,
+              onTapBar: (groupIndex, rodIndex) {
+                TransactionType type;
+                if (_showComparison) {
+                  // PrevIncome=0, CurrIncome=1, PrevExpense=2, CurrExpense=3
+                  type = (rodIndex <= 1)
+                      ? TransactionType.income
+                      : TransactionType.expense;
+                } else {
+                  // CurrIncome=0, CurrExpense=1
+                  type = (rodIndex == 0)
+                      ? TransactionType.income
+                      : TransactionType.expense;
+                }
+                _navigateToFilteredTransactions(
+                  context,
+                  reportData.periodData[groupIndex],
+                  type,
+                );
+              },
+            );
 
-            final bool showTable = settingsState.uiMode == UIMode.quantum &&
+            final bool showTable =
+                settingsState.uiMode == UIMode.quantum &&
                 (modeTheme?.preferDataTableForLists ?? false);
 
             return ListView(
               children: [
                 Padding(
-                    padding: const EdgeInsets.symmetric(
-                        vertical: 16.0, horizontal: 8.0),
-                    child: SizedBox(height: 250, child: chartWidget)),
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 16.0,
+                    horizontal: 8.0,
+                  ),
+                  child: SizedBox(height: 250, child: chartWidget),
+                ),
                 const Divider(),
                 _buildDataTable(
-                    context, reportData, settingsState, _showComparison),
+                  context,
+                  reportData,
+                  settingsState,
+                  _showComparison,
+                ),
                 const SizedBox(height: 80),
               ],
             );
@@ -196,7 +237,9 @@ class _IncomeVsExpensePageState extends State<IncomeVsExpensePage> {
   }
 
   String _formatPeriodHeader(
-      DateTime date, IncomeExpensePeriodType periodType) {
+    DateTime date,
+    IncomeExpensePeriodType periodType,
+  ) {
     switch (periodType) {
       case IncomeExpensePeriodType.monthly:
         return DateFormat('MMM yyyy').format(date);
@@ -205,8 +248,12 @@ class _IncomeVsExpensePageState extends State<IncomeVsExpensePage> {
     }
   }
 
-  Widget _buildDataTable(BuildContext context, IncomeExpenseReportData data,
-      SettingsState settings, bool showComparison) {
+  Widget _buildDataTable(
+    BuildContext context,
+    IncomeExpenseReportData data,
+    SettingsState settings,
+    bool showComparison,
+  ) {
     final theme = Theme.of(context);
     final currencySymbol = settings.currencySymbol;
 
@@ -214,12 +261,12 @@ class _IncomeVsExpensePageState extends State<IncomeVsExpensePage> {
       const DataColumn(label: Text('Period')),
       const DataColumn(label: Text('Income'), numeric: true),
       const DataColumn(label: Text('Expense'), numeric: true),
-      const DataColumn(label: Text('Net Flow'), numeric: true)
+      const DataColumn(label: Text('Net Flow'), numeric: true),
     ];
     if (showComparison) {
       columns.addAll([
         const DataColumn(label: Text('Prev Net'), numeric: true),
-        const DataColumn(label: Text('Net Δ%'), numeric: true)
+        const DataColumn(label: Text('Net Δ%'), numeric: true),
       ]);
     }
 
@@ -258,40 +305,62 @@ class _IncomeVsExpensePageState extends State<IncomeVsExpensePage> {
           return DataRow(
             cells: [
               DataCell(
-                  Text(_formatPeriodHeader(item.periodStart, data.periodType))),
+                Text(_formatPeriodHeader(item.periodStart, data.periodType)),
+              ),
               DataCell(
-                  Text(CurrencyFormatter.format(
-                      item.currentTotalIncome, currencySymbol)),
-                  onTap: () => _navigateToFilteredTransactions(
-                      context, item, TransactionType.income)),
+                Text(
+                  CurrencyFormatter.format(
+                    item.currentTotalIncome,
+                    currencySymbol,
+                  ),
+                ),
+                onTap: () => _navigateToFilteredTransactions(
+                  context,
+                  item,
+                  TransactionType.income,
+                ),
+              ),
               DataCell(
-                  Text(CurrencyFormatter.format(
-                      item.currentTotalExpense, currencySymbol)),
-                  onTap: () => _navigateToFilteredTransactions(
-                      context, item, TransactionType.expense)),
-              DataCell(Text(
+                Text(
+                  CurrencyFormatter.format(
+                    item.currentTotalExpense,
+                    currencySymbol,
+                  ),
+                ),
+                onTap: () => _navigateToFilteredTransactions(
+                  context,
+                  item,
+                  TransactionType.expense,
+                ),
+              ),
+              DataCell(
+                Text(
                   CurrencyFormatter.format(item.currentNetFlow, currencySymbol),
                   style: TextStyle(
-                      color: netFlowColor, fontWeight: FontWeight.w500))),
-              if (showComparison)
-                DataCell(Text(netFlow.previousValue != null
-                    ? CurrencyFormatter.format(
-                        netFlow.previousValue!, currencySymbol)
-                    : 'N/A')),
+                    color: netFlowColor,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
               if (showComparison)
                 DataCell(
-                    Text(changeText, style: TextStyle(color: changeColor))),
+                  Text(
+                    netFlow.previousValue != null
+                        ? CurrencyFormatter.format(
+                            netFlow.previousValue!,
+                            currencySymbol,
+                          )
+                        : 'N/A',
+                  ),
+                ),
+              if (showComparison)
+                DataCell(
+                  Text(changeText, style: TextStyle(color: changeColor)),
+                ),
             ],
           );
         }).toList(),
       ),
     );
-  }
-}
-
-extension StringCapExtension on String {
-  String capitalize() {
-    if (isEmpty) return this;
-    return "${this[0].toUpperCase()}${substring(1)}";
   }
 }

--- a/lib/features/reports/presentation/pages/spending_over_time_page.dart
+++ b/lib/features/reports/presentation/pages/spending_over_time_page.dart
@@ -14,6 +14,7 @@ import 'package:expense_tracker/features/reports/presentation/widgets/report_pag
 import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:expense_tracker/features/transactions/domain/entities/transaction_entity.dart'; // For TransactionType
 import 'package:flutter/material.dart';
+import 'package:expense_tracker/core/utils/string_extensions.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
@@ -33,29 +34,35 @@ class _SpendingOverTimePageState extends State<SpendingOverTimePage> {
     final newComparisonState = !_showComparison;
     setState(() => _showComparison = newComparisonState);
     // Get current granularity from state
-    final currentGranularity = context.read<SpendingTimeReportBloc>().state
-            is SpendingTimeReportLoaded
+    final currentGranularity =
+        context.read<SpendingTimeReportBloc>().state is SpendingTimeReportLoaded
         ? (context.read<SpendingTimeReportBloc>().state
-                as SpendingTimeReportLoaded)
-            .reportData
-            .granularity
+                  as SpendingTimeReportLoaded)
+              .reportData
+              .granularity
         : (context.read<SpendingTimeReportBloc>().state
-                is SpendingTimeReportLoading)
-            ? (context.read<SpendingTimeReportBloc>().state
-                    as SpendingTimeReportLoading)
-                .granularity
-            : TimeSeriesGranularity.daily; // Default
+              is SpendingTimeReportLoading)
+        ? (context.read<SpendingTimeReportBloc>().state
+                  as SpendingTimeReportLoading)
+              .granularity
+        : TimeSeriesGranularity.daily; // Default
 
-    context.read<SpendingTimeReportBloc>().add(LoadSpendingTimeReport(
-          compareToPrevious: newComparisonState, // Pass new comparison state
-          granularity: currentGranularity,
-        ));
+    context.read<SpendingTimeReportBloc>().add(
+      LoadSpendingTimeReport(
+        compareToPrevious: newComparisonState, // Pass new comparison state
+        granularity: currentGranularity,
+      ),
+    );
     log.info(
-        "[SpendingOverTimePage] Toggled comparison to: $newComparisonState");
+      "[SpendingOverTimePage] Toggled comparison to: $newComparisonState",
+    );
   }
 
-  void _navigateToFilteredTransactions(BuildContext context,
-      TimeSeriesDataPoint dataPoint, TimeSeriesGranularity granularity) {
+  void _navigateToFilteredTransactions(
+    BuildContext context,
+    TimeSeriesDataPoint dataPoint,
+    TimeSeriesGranularity granularity,
+  ) {
     // ... (implementation unchanged) ...
     final filterBlocState = context.read<ReportFilterBloc>().state;
     DateTime periodStart = dataPoint.date;
@@ -63,21 +70,35 @@ class _SpendingOverTimePageState extends State<SpendingOverTimePage> {
     switch (granularity) {
       case TimeSeriesGranularity.daily:
         periodEnd = DateTime(
-            periodStart.year, periodStart.month, periodStart.day, 23, 59, 59);
+          periodStart.year,
+          periodStart.month,
+          periodStart.day,
+          23,
+          59,
+          59,
+        );
         break;
       case TimeSeriesGranularity.weekly:
-        periodEnd = periodStart
-            .add(const Duration(days: 6, hours: 23, minutes: 59, seconds: 59));
+        periodEnd = periodStart.add(
+          const Duration(days: 6, hours: 23, minutes: 59, seconds: 59),
+        );
         break;
       case TimeSeriesGranularity.monthly:
-        periodEnd =
-            DateTime(periodStart.year, periodStart.month + 1, 0, 23, 59, 59);
+        periodEnd = DateTime(
+          periodStart.year,
+          periodStart.month + 1,
+          0,
+          23,
+          59,
+          59,
+        );
         break;
     }
     final Map<String, String> filters = {
       'startDate': periodStart.toIso8601String(),
       'endDate': periodEnd.toIso8601String(),
-      'type': filterBlocState.selectedTransactionType?.name ??
+      'type':
+          filterBlocState.selectedTransactionType?.name ??
           TransactionType.expense.name, // Use filter or default
     };
     if (filterBlocState.selectedAccountIds.isNotEmpty) {
@@ -87,7 +108,8 @@ class _SpendingOverTimePageState extends State<SpendingOverTimePage> {
       filters['categoryId'] = filterBlocState.selectedCategoryIds.join(',');
     }
     log.info(
-        "[SpendingOverTimePage] Navigating to transactions with filters: $filters");
+      "[SpendingOverTimePage] Navigating to transactions with filters: $filters",
+    );
     context.push(RouteNames.transactionsList, extra: {'filters': filters});
   }
 
@@ -102,36 +124,44 @@ class _SpendingOverTimePageState extends State<SpendingOverTimePage> {
       title: 'Spending Over Time',
       actions: [
         IconButton(
-            icon: Icon(_showComparison
+          icon: Icon(
+            _showComparison
                 ? Icons.compare_arrows_rounded
-                : Icons.compare_arrows_outlined),
-            tooltip: _showComparison ? "Hide Comparison" : "Compare Period",
-            color: _showComparison ? theme.colorScheme.primary : null,
-            onPressed: _toggleComparison),
+                : Icons.compare_arrows_outlined,
+          ),
+          tooltip: _showComparison ? "Hide Comparison" : "Compare Period",
+          color: _showComparison ? theme.colorScheme.primary : null,
+          onPressed: _toggleComparison,
+        ),
         BlocBuilder<SpendingTimeReportBloc, SpendingTimeReportState>(
           builder: (context, state) {
             final currentGranularity = (state is SpendingTimeReportLoaded)
                 ? state.reportData.granularity
                 : (state is SpendingTimeReportLoading)
-                    ? state.granularity
-                    : TimeSeriesGranularity.daily;
+                ? state.granularity
+                : TimeSeriesGranularity.daily;
             return PopupMenuButton<TimeSeriesGranularity>(
-                initialValue: currentGranularity,
-                onSelected: (g) {
-                  // When granularity changes, also pass current comparison state
-                  context
-                      .read<SpendingTimeReportBloc>()
-                      .add(LoadSpendingTimeReport(
-                        granularity: g,
-                        compareToPrevious: _showComparison,
-                      ));
-                },
-                icon: const Icon(Icons.timeline_outlined),
-                tooltip: "Change Granularity",
-                itemBuilder: (_) => TimeSeriesGranularity.values
-                    .map((g) => PopupMenuItem<TimeSeriesGranularity>(
-                        value: g, child: Text(g.name.capitalize())))
-                    .toList());
+              initialValue: currentGranularity,
+              onSelected: (g) {
+                // When granularity changes, also pass current comparison state
+                context.read<SpendingTimeReportBloc>().add(
+                  LoadSpendingTimeReport(
+                    granularity: g,
+                    compareToPrevious: _showComparison,
+                  ),
+                );
+              },
+              icon: const Icon(Icons.timeline_outlined),
+              tooltip: "Change Granularity",
+              itemBuilder: (_) => TimeSeriesGranularity.values
+                  .map(
+                    (g) => PopupMenuItem<TimeSeriesGranularity>(
+                      value: g,
+                      child: Text(g.name.capitalize()),
+                    ),
+                  )
+                  .toList(),
+            );
           },
         ),
       ],
@@ -140,8 +170,10 @@ class _SpendingOverTimePageState extends State<SpendingOverTimePage> {
         if (state is SpendingTimeReportLoaded) {
           final helper = sl<CsvExportHelper>();
           return helper.exportSpendingTimeReport(
-              state.reportData, currencySymbol,
-              showComparison: _showComparison);
+            state.reportData,
+            currencySymbol,
+            showComparison: _showComparison,
+          );
         }
         return const Right(ExportFailure("Report data not loaded yet."));
       },
@@ -151,40 +183,59 @@ class _SpendingOverTimePageState extends State<SpendingOverTimePage> {
             return const Center(child: CircularProgressIndicator());
           if (state is SpendingTimeReportError) {
             return Center(
-                child: Text("Error: ${state.message}",
-                    style: TextStyle(color: theme.colorScheme.error)));
+              child: Text(
+                "Error: ${state.message}",
+                style: TextStyle(color: theme.colorScheme.error),
+              ),
+            );
           }
           if (state is SpendingTimeReportLoaded) {
             final reportData = state.reportData;
             if (reportData.spendingData.isEmpty) {
               return const Center(
-                  child: Text("No spending data for this period."));
+                child: Text("No spending data for this period."),
+              );
             }
 
             Widget chartWidget = TimeSeriesLineChart(
               data: reportData.spendingData,
               granularity: reportData.granularity,
               showComparison: _showComparison,
-              onTapSpot: (index) => _navigateToFilteredTransactions(context,
-                  reportData.spendingData[index], reportData.granularity),
+              onTapSpot: (index) => _navigateToFilteredTransactions(
+                context,
+                reportData.spendingData[index],
+                reportData.granularity,
+              ),
             );
 
-            final bool showTable = settingsState.uiMode == UIMode.quantum &&
+            final bool showTable =
+                settingsState.uiMode == UIMode.quantum &&
                 (modeTheme?.preferDataTableForLists ?? false);
 
             return ListView(
               children: [
                 Padding(
-                    padding: const EdgeInsets.symmetric(
-                        vertical: 16.0, horizontal: 8.0),
-                    child: SizedBox(height: 250, child: chartWidget)),
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 16.0,
+                    horizontal: 8.0,
+                  ),
+                  child: SizedBox(height: 250, child: chartWidget),
+                ),
                 const Divider(),
                 if (showTable)
                   _buildDataTable(
-                      context, reportData, settingsState, _showComparison)
+                    context,
+                    reportData,
+                    settingsState,
+                    _showComparison,
+                  )
                 else
                   _buildDataList(
-                      context, reportData, settingsState, _showComparison),
+                    context,
+                    reportData,
+                    settingsState,
+                    _showComparison,
+                  ),
                 const SizedBox(height: 80),
               ],
             );
@@ -206,8 +257,12 @@ class _SpendingOverTimePageState extends State<SpendingOverTimePage> {
     }
   }
 
-  Widget _buildDataList(BuildContext context, SpendingTimeReportData data,
-      SettingsState settings, bool showComparison) {
+  Widget _buildDataList(
+    BuildContext context,
+    SpendingTimeReportData data,
+    SettingsState settings,
+    bool showComparison,
+  ) {
     final theme = Theme.of(context);
     final currencySymbol = settings.currencySymbol;
 
@@ -240,15 +295,23 @@ class _SpendingOverTimePageState extends State<SpendingOverTimePage> {
         return ListTile(
           dense: true,
           title: Text(_formatDateHeader(item.date, data.granularity)),
-          trailing: Row(mainAxisSize: MainAxisSize.min, children: [
-            if (showComparison && changeText.isNotEmpty)
-              Text(changeText,
-                  style:
-                      theme.textTheme.labelSmall?.copyWith(color: changeColor)),
-            if (showComparison && changeText.isNotEmpty)
-              const SizedBox(width: 8),
-            Text(CurrencyFormatter.format(item.currentAmount, currencySymbol)),
-          ]),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (showComparison && changeText.isNotEmpty)
+                Text(
+                  changeText,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: changeColor,
+                  ),
+                ),
+              if (showComparison && changeText.isNotEmpty)
+                const SizedBox(width: 8),
+              Text(
+                CurrencyFormatter.format(item.currentAmount, currencySymbol),
+              ),
+            ],
+          ),
           onTap: () =>
               _navigateToFilteredTransactions(context, item, data.granularity),
         );
@@ -257,20 +320,24 @@ class _SpendingOverTimePageState extends State<SpendingOverTimePage> {
     );
   }
 
-  Widget _buildDataTable(BuildContext context, SpendingTimeReportData data,
-      SettingsState settings, bool showComparison) {
+  Widget _buildDataTable(
+    BuildContext context,
+    SpendingTimeReportData data,
+    SettingsState settings,
+    bool showComparison,
+  ) {
     final theme = Theme.of(context);
     final currencySymbol = settings.currencySymbol;
 
     List<DataColumn> columns = [
       const DataColumn(label: Text('Period')),
-      DataColumn(label: const Text('Total Spent'), numeric: true)
+      DataColumn(label: const Text('Total Spent'), numeric: true),
     ];
     // Add comparison columns dynamically
     if (showComparison) {
       columns.addAll([
         DataColumn(label: const Text('Prev Spent'), numeric: true),
-        DataColumn(label: const Text('Change %'), numeric: true)
+        DataColumn(label: const Text('Change %'), numeric: true),
       ]);
     }
 
@@ -305,34 +372,40 @@ class _SpendingOverTimePageState extends State<SpendingOverTimePage> {
           return DataRow(
             cells: [
               DataCell(Text(_formatDateHeader(item.date, data.granularity))),
-              DataCell(Text(CurrencyFormatter.format(
-                  item.currentAmount, currencySymbol))),
+              DataCell(
+                Text(
+                  CurrencyFormatter.format(item.currentAmount, currencySymbol),
+                ),
+              ),
               // Conditionally add comparison cells
               if (showComparison)
-                DataCell(Text(item.amount.previousValue != null
-                    ? CurrencyFormatter.format(
-                        item.amount.previousValue!, currencySymbol)
-                    : 'N/A')),
+                DataCell(
+                  Text(
+                    item.amount.previousValue != null
+                        ? CurrencyFormatter.format(
+                            item.amount.previousValue!,
+                            currencySymbol,
+                          )
+                        : 'N/A',
+                  ),
+                ),
               if (showComparison)
                 DataCell(
-                    Text(changeText, style: TextStyle(color: changeColor))),
+                  Text(changeText, style: TextStyle(color: changeColor)),
+                ),
             ],
             onSelectChanged: (selected) {
               if (selected == true) {
                 _navigateToFilteredTransactions(
-                    context, item, data.granularity);
+                  context,
+                  item,
+                  data.granularity,
+                );
               }
             },
           );
         }).toList(),
       ),
     );
-  }
-}
-
-extension StringCapExtension on String {
-  String capitalize() {
-    if (isEmpty) return this;
-    return "${this[0].toUpperCase()}${substring(1)}";
   }
 }

--- a/lib/features/settings/presentation/widgets/appearance_settings_section.dart
+++ b/lib/features/settings/presentation/widgets/appearance_settings_section.dart
@@ -5,6 +5,7 @@ import 'package:expense_tracker/features/settings/presentation/bloc/settings_blo
 import 'package:expense_tracker/features/settings/presentation/widgets/settings_list_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:expense_tracker/core/utils/string_extensions.dart';
 
 class AppearanceSettingsSection extends StatelessWidget {
   final SettingsState state;
@@ -23,21 +24,21 @@ class AppearanceSettingsSection extends StatelessWidget {
           AppTheme.elementalPalette1,
           AppTheme.elementalPalette2,
           AppTheme.elementalPalette3,
-          AppTheme.elementalPalette4
+          AppTheme.elementalPalette4,
         ];
       case UIMode.quantum:
         return [
           AppTheme.quantumPalette1,
           AppTheme.quantumPalette2,
           AppTheme.quantumPalette3,
-          AppTheme.quantumPalette4
+          AppTheme.quantumPalette4,
         ];
       case UIMode.aether:
         return [
           AppTheme.aetherPalette1,
           AppTheme.aetherPalette2,
           AppTheme.aetherPalette3,
-          AppTheme.aetherPalette4
+          AppTheme.aetherPalette4,
         ];
     }
   }
@@ -45,8 +46,9 @@ class AppearanceSettingsSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final relevantPaletteIdentifiers =
-        _getRelevantPaletteIdentifiers(state.uiMode);
+    final relevantPaletteIdentifiers = _getRelevantPaletteIdentifiers(
+      state.uiMode,
+    );
     // --- Check Demo Mode ---
     final bool isEnabled = !isLoading && !state.isInDemoMode;
     // --- End Check ---
@@ -61,8 +63,9 @@ class AppearanceSettingsSection extends StatelessWidget {
           // --- End Use ---
           leadingIcon: Icons.view_quilt_outlined,
           title: 'UI Mode',
-          subtitle: AppTheme.uiModeNames[state.uiMode] ??
-              StringExtension(state.uiMode.name).capitalize(),
+          subtitle:
+              AppTheme.uiModeNames[state.uiMode] ??
+              state.uiMode.name.capitalize(),
           trailing: PopupMenuButton<UIMode>(
             enabled: isEnabled, // Use combined state
             icon: const Icon(Icons.arrow_drop_down),
@@ -71,13 +74,15 @@ class AppearanceSettingsSection extends StatelessWidget {
             onSelected: (UIMode newMode) =>
                 context.read<SettingsBloc>().add(UpdateUIMode(newMode)),
             itemBuilder: (context) => UIMode.values
-                .map((mode) => PopupMenuItem<UIMode>(
-                      value: mode,
-                      child: Text(
-                          AppTheme.uiModeNames[mode] ??
-                              StringExtension(mode.name).capitalize(),
-                          style: theme.textTheme.bodyMedium),
-                    ))
+                .map(
+                  (mode) => PopupMenuItem<UIMode>(
+                    value: mode,
+                    child: Text(
+                      AppTheme.uiModeNames[mode] ?? mode.name.capitalize(),
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                  ),
+                )
                 .toList(),
           ),
         ),
@@ -87,7 +92,8 @@ class AppearanceSettingsSection extends StatelessWidget {
           // --- End Use ---
           leadingIcon: Icons.palette_outlined,
           title: 'Palette / Variant',
-          subtitle: AppTheme.paletteNames[state.paletteIdentifier] ??
+          subtitle:
+              AppTheme.paletteNames[state.paletteIdentifier] ??
               state.paletteIdentifier,
           trailing: relevantPaletteIdentifiers.isEmpty
               ? null
@@ -100,11 +106,15 @@ class AppearanceSettingsSection extends StatelessWidget {
                       .read<SettingsBloc>()
                       .add(UpdatePaletteIdentifier(newIdentifier)),
                   itemBuilder: (context) => relevantPaletteIdentifiers
-                      .map((id) => PopupMenuItem<String>(
-                            value: id,
-                            child: Text(AppTheme.paletteNames[id] ?? id,
-                                style: theme.textTheme.bodyMedium),
-                          ))
+                      .map(
+                        (id) => PopupMenuItem<String>(
+                          value: id,
+                          child: Text(
+                            AppTheme.paletteNames[id] ?? id,
+                            style: theme.textTheme.bodyMedium,
+                          ),
+                        ),
+                      )
                       .toList(),
                 ),
         ),
@@ -114,7 +124,7 @@ class AppearanceSettingsSection extends StatelessWidget {
           // --- End Use ---
           leadingIcon: Icons.brightness_6_outlined,
           title: 'Brightness Mode',
-          subtitle: StringExtension(state.themeMode.name).capitalize(),
+          subtitle: state.themeMode.name.capitalize(),
           trailing: PopupMenuButton<ThemeMode>(
             enabled: isEnabled, // Use combined state
             icon: const Icon(Icons.arrow_drop_down),
@@ -123,23 +133,19 @@ class AppearanceSettingsSection extends StatelessWidget {
             onSelected: (ThemeMode newMode) =>
                 context.read<SettingsBloc>().add(UpdateTheme(newMode)),
             itemBuilder: (context) => ThemeMode.values
-                .map((mode) => PopupMenuItem<ThemeMode>(
-                      value: mode,
-                      child: Text(StringExtension(mode.name).capitalize(),
-                          style: theme.textTheme.bodyMedium),
-                    ))
+                .map(
+                  (mode) => PopupMenuItem<ThemeMode>(
+                    value: mode,
+                    child: Text(
+                      mode.name.capitalize(),
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                  ),
+                )
                 .toList(),
           ),
         ),
       ],
     );
-  }
-}
-
-// Helper extension
-extension StringExtension on String {
-  String capitalize() {
-    if (isEmpty) return this;
-    return "${this[0].toUpperCase()}${substring(1)}";
   }
 }

--- a/lib/features/transactions/presentation/widgets/transaction_sort_sheet.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_sort_sheet.dart
@@ -1,8 +1,9 @@
 import 'package:expense_tracker/features/transactions/domain/usecases/get_transactions_usecase.dart';
 import 'package:flutter/material.dart';
+import 'package:expense_tracker/core/utils/string_extensions.dart';
 
-typedef ApplySortCallback = void Function(
-    TransactionSortBy sortBy, SortDirection sortDirection);
+typedef ApplySortCallback =
+    void Function(TransactionSortBy sortBy, SortDirection sortDirection);
 
 class TransactionSortSheet extends StatelessWidget {
   final TransactionSortBy currentSortBy;
@@ -24,26 +25,28 @@ class TransactionSortSheet extends StatelessWidget {
       final bool isSelected = currentSortBy == sortBy;
       final IconData directionIcon = isSelected
           ? (currentSortDirection == SortDirection.descending
-              ? Icons.arrow_downward_rounded
-              : Icons.arrow_upward_rounded)
+                ? Icons.arrow_downward_rounded
+                : Icons.arrow_upward_rounded)
           : Icons.swap_vert_rounded; // Indicate sortable but not selected
 
       return RadioListTile<TransactionSortBy>(
         title: Text(
-            sortBy.name.capitalize()), // Assuming capitalize extension exists
+          sortBy.name.capitalize(),
+        ), // Assuming capitalize extension exists
         value: sortBy,
         groupValue: currentSortBy,
-        secondary: Icon(directionIcon,
-            color:
-                isSelected ? theme.colorScheme.primary : theme.disabledColor),
+        secondary: Icon(
+          directionIcon,
+          color: isSelected ? theme.colorScheme.primary : theme.disabledColor,
+        ),
         activeColor: theme.colorScheme.primary,
         onChanged: (TransactionSortBy? value) {
           if (value != null) {
             // If selecting the same criteria, toggle direction, otherwise default to descending
             final newDirection = isSelected
                 ? (currentSortDirection == SortDirection.descending
-                    ? SortDirection.ascending
-                    : SortDirection.descending)
+                      ? SortDirection.ascending
+                      : SortDirection.descending)
                 : SortDirection.descending;
             onApplySort(value, newDirection);
             Navigator.pop(context); // Close sheet after selection
@@ -59,23 +62,19 @@ class TransactionSortSheet extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-            child:
-                Text('Sort Transactions By', style: theme.textTheme.titleLarge),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16.0,
+              vertical: 8.0,
+            ),
+            child: Text(
+              'Sort Transactions By',
+              style: theme.textTheme.titleLarge,
+            ),
           ),
           ...sortOptions,
           const SizedBox(height: 8), // Padding at bottom
         ],
       ),
     );
-  }
-}
-
-// Helper extension (if not already in utils)
-extension StringCapExtension on String {
-  String capitalize() {
-    if (isEmpty) return this;
-    return "${this[0].toUpperCase()}${substring(1)}";
   }
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -63,8 +63,9 @@ class GoRouterRefreshStream extends ChangeNotifier {
 }
 
 // --- Navigator Keys ---
-final GlobalKey<NavigatorState> _rootNavigatorKey =
-    GlobalKey<NavigatorState>(debugLabel: 'root');
+final GlobalKey<NavigatorState> _rootNavigatorKey = GlobalKey<NavigatorState>(
+  debugLabel: 'root',
+);
 final GlobalKey<NavigatorState> _shellNavigatorKeyDashboard =
     GlobalKey<NavigatorState>(debugLabel: 'shellDashboard');
 final GlobalKey<NavigatorState> _shellNavigatorKeyTransactions =
@@ -83,305 +84,329 @@ class AppRouter {
   static final SettingsBloc _settingsBloc = sl<SettingsBloc>();
 
   static final GoRouter router = GoRouter(
-      // --- FIXED: Set initialLocation to /setup ---
-      initialLocation: RouteNames.initialSetup,
-      // --- END FIXED ---
-      navigatorKey: _rootNavigatorKey,
-      debugLogDiagnostics: kDebugMode,
-      observers: [GoRouterObserver()],
-      refreshListenable: GoRouterRefreshStream(_settingsBloc.stream),
-      redirect: (BuildContext context, GoRouterState state) {
-        final settingsState = _settingsBloc.state;
-        final bool isInDemo = settingsState.isInDemoMode;
-        final bool isInitialized =
-            settingsState.status == SettingsStatus.loaded ||
-                settingsState.status == SettingsStatus.error;
-        final bool setupSkipped = settingsState.setupSkipped;
+    // --- FIXED: Set initialLocation to /setup ---
+    initialLocation: RouteNames.initialSetup,
+    // --- END FIXED ---
+    navigatorKey: _rootNavigatorKey,
+    debugLogDiagnostics: kDebugMode,
+    observers: [GoRouterObserver()],
+    refreshListenable: GoRouterRefreshStream(_settingsBloc.stream),
+    redirect: (BuildContext context, GoRouterState state) {
+      final settingsState = _settingsBloc.state;
+      final bool isInDemo = settingsState.isInDemoMode;
+      final bool isInitialized =
+          settingsState.status == SettingsStatus.loaded ||
+          settingsState.status == SettingsStatus.error;
+      final bool setupSkipped = settingsState.setupSkipped;
 
-        const bool isAuthenticated = false; // MOCK
+      const bool isAuthenticated = false; // MOCK
 
-        final String currentRoute = state.matchedLocation;
-        final bool isGoingToInitialSetup =
-            currentRoute == RouteNames.initialSetup;
-        final bool isGoingToShellRoute = currentRoute == RouteNames.dashboard ||
-            currentRoute == RouteNames.transactionsList ||
-            currentRoute == RouteNames.budgetsAndCats ||
-            currentRoute == RouteNames.accounts ||
-            currentRoute == RouteNames.settings ||
-            currentRoute.startsWith(RouteNames.recurring);
+      final String currentRoute = state.matchedLocation;
+      final bool isGoingToInitialSetup =
+          currentRoute == RouteNames.initialSetup;
+      final bool isGoingToShellRoute =
+          currentRoute == RouteNames.dashboard ||
+          currentRoute == RouteNames.transactionsList ||
+          currentRoute == RouteNames.budgetsAndCats ||
+          currentRoute == RouteNames.accounts ||
+          currentRoute == RouteNames.settings ||
+          currentRoute.startsWith(RouteNames.recurring);
 
+      log.info(
+        "[RouterRedirect] To: $currentRoute, IsInDemo: $isInDemo, IsAuth: $isAuthenticated, IsInit: $isInitialized, SetupSkipped: $setupSkipped",
+      );
+
+      // Don't redirect if settings aren't initialized unless going to setup
+      if (!isInitialized && !isGoingToInitialSetup) {
         log.info(
-            "[RouterRedirect] To: $currentRoute, IsInDemo: $isInDemo, IsAuth: $isAuthenticated, IsInit: $isInitialized, SetupSkipped: $setupSkipped");
+          "[RouterRedirect] Settings not initialized, staying put (or default).",
+        );
+        return null;
+      }
 
-        // Don't redirect if settings aren't initialized unless going to setup
-        if (!isInitialized && !isGoingToInitialSetup) {
+      // If in demo mode, allow access to shell routes, redirect away from setup
+      if (isInDemo) {
+        if (isGoingToInitialSetup) {
           log.info(
-              "[RouterRedirect] Settings not initialized, staying put (or default).");
+            "[RouterRedirect] In Demo Mode, redirecting from InitialSetup to Dashboard.",
+          );
+          return RouteNames.dashboard;
+        }
+        log.info(
+          "[RouterRedirect] In Demo Mode, allowing access to $currentRoute.",
+        );
+        return null; // No redirection needed
+      }
+
+      // If NOT authenticated AND NOT in demo mode
+      if (!isAuthenticated && !isInDemo) {
+        // If already on the setup page, allow it
+        if (isGoingToInitialSetup) {
+          log.info(
+            "[RouterRedirect] Not authenticated, already on InitialSetup. Allowing.",
+          );
           return null;
         }
-
-        // If in demo mode, allow access to shell routes, redirect away from setup
-        if (isInDemo) {
-          if (isGoingToInitialSetup) {
-            log.info(
-                "[RouterRedirect] In Demo Mode, redirecting from InitialSetup to Dashboard.");
-            return RouteNames.dashboard;
-          }
+        // If setup was skipped AND trying to access a shell route, allow it
+        else if (setupSkipped && isGoingToShellRoute) {
           log.info(
-              "[RouterRedirect] In Demo Mode, allowing access to $currentRoute.");
-          return null; // No redirection needed
+            "[RouterRedirect] Not authenticated, but setup was skipped. Allowing navigation to $currentRoute.",
+          );
+          return null; // Allow navigation
         }
-
-        // If NOT authenticated AND NOT in demo mode
-        if (!isAuthenticated && !isInDemo) {
-          // If already on the setup page, allow it
-          if (isGoingToInitialSetup) {
-            log.info(
-                "[RouterRedirect] Not authenticated, already on InitialSetup. Allowing.");
-            return null;
-          }
-          // If setup was skipped AND trying to access a shell route, allow it
-          else if (setupSkipped && isGoingToShellRoute) {
-            log.info(
-                "[RouterRedirect] Not authenticated, but setup was skipped. Allowing navigation to $currentRoute.");
-            return null; // Allow navigation
-          }
-          // Otherwise, redirect to InitialSetup
-          else {
-            log.info(
-                "[RouterRedirect] Not authenticated & setup not skipped/not going to setup, redirecting to InitialSetup.");
-            return RouteNames.initialSetup;
-          }
+        // Otherwise, redirect to InitialSetup
+        else {
+          log.info(
+            "[RouterRedirect] Not authenticated & setup not skipped/not going to setup, redirecting to InitialSetup.",
+          );
+          return RouteNames.initialSetup;
         }
+      }
 
-        // Default: Allow navigation to the intended route (if reached here, conditions are met)
-        log.info("[RouterRedirect] Allowing access to $currentRoute.");
-        return null;
-      },
-      routes: [
-        // Initial Setup Route - This is the route for the initial screen
-        GoRoute(
-          path: RouteNames.initialSetup,
-          name: RouteNames.initialSetup,
-          builder: (context, state) => const InitialSetupScreen(),
-        ),
+      // Default: Allow navigation to the intended route (if reached here, conditions are met)
+      log.info("[RouterRedirect] Allowing access to $currentRoute.");
+      return null;
+    },
+    routes: [
+      // Initial Setup Route - This is the route for the initial screen
+      GoRoute(
+        path: RouteNames.initialSetup,
+        name: RouteNames.initialSetup,
+        builder: (context, state) => const InitialSetupScreen(),
+      ),
 
-        // Main App Shell Routes - These are the main screens accessible after setup/login
-        StatefulShellRoute.indexedStack(
-          builder: (context, state, navigationShell) {
-            return BlocProvider.value(
-              value: sl<ReportFilterBloc>(),
-              child: MainShell(navigationShell: navigationShell),
-            );
-          },
-          branches: [
-            // --- Branch 0: Dashboard ---
-            StatefulShellBranch(
-              navigatorKey: _shellNavigatorKeyDashboard,
-              routes: [
-                GoRoute(
-                  path: RouteNames.dashboard,
-                  name: RouteNames.dashboard,
-                  pageBuilder: (context, state) =>
-                      const NoTransitionPage(child: DashboardPage()),
-                  routes: _buildReportSubRoutes(_rootNavigatorKey),
-                ),
-              ],
-            ),
-            // --- Branch 1: Transactions ---
-            StatefulShellBranch(
-              navigatorKey: _shellNavigatorKeyTransactions,
-              routes: [
-                GoRoute(
-                  path: RouteNames.transactionsList,
-                  name: RouteNames.transactionsList,
-                  pageBuilder: (context, state) {
-                    final Map<String, dynamic> queryParams =
-                        state.uri.queryParameters;
-                    final Map<String, dynamic>? extra =
-                        state.extra as Map<String, dynamic>?;
-                    Map<String, dynamic>? filtersFromExtra =
-                        extra?['filters'] as Map<String, dynamic>?;
-                    log.fine(
-                        "[Router] TransactionsListPage: queryParams=$queryParams, extra=$extra, filtersFromExtra=$filtersFromExtra");
-                    return NoTransitionPage(
-                        child: TransactionListPage(
+      // Main App Shell Routes - These are the main screens accessible after setup/login
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, navigationShell) {
+          return BlocProvider.value(
+            value: sl<ReportFilterBloc>(),
+            child: MainShell(navigationShell: navigationShell),
+          );
+        },
+        branches: [
+          // --- Branch 0: Dashboard ---
+          StatefulShellBranch(
+            navigatorKey: _shellNavigatorKeyDashboard,
+            routes: [
+              GoRoute(
+                path: RouteNames.dashboard,
+                name: RouteNames.dashboard,
+                pageBuilder: (context, state) =>
+                    const NoTransitionPage(child: DashboardPage()),
+                routes: _buildReportSubRoutes(_rootNavigatorKey),
+              ),
+            ],
+          ),
+          // --- Branch 1: Transactions ---
+          StatefulShellBranch(
+            navigatorKey: _shellNavigatorKeyTransactions,
+            routes: [
+              GoRoute(
+                path: RouteNames.transactionsList,
+                name: RouteNames.transactionsList,
+                pageBuilder: (context, state) {
+                  final Map<String, dynamic> queryParams =
+                      state.uri.queryParameters;
+                  final Map<String, dynamic>? extra =
+                      state.extra as Map<String, dynamic>?;
+                  Map<String, dynamic>? filtersFromExtra =
+                      extra?['filters'] as Map<String, dynamic>?;
+                  log.fine(
+                    "[Router] TransactionsListPage: queryParams=$queryParams, extra=$extra, filtersFromExtra=$filtersFromExtra",
+                  );
+                  return NoTransitionPage(
+                    child: TransactionListPage(
                       initialFilters: filtersFromExtra ?? queryParams,
-                    ));
-                  },
-                  routes: [
-                    GoRoute(
-                        path: RouteNames.addTransaction,
-                        name: RouteNames.addTransaction,
-                        parentNavigatorKey: _rootNavigatorKey,
-                        builder: (context, state) =>
-                            const AddEditTransactionPage(
-                                initialTransactionData: null)),
-                    GoRoute(
-                        path:
-                            '${RouteNames.editTransaction}/:${RouteNames.paramTransactionId}',
-                        name: RouteNames.editTransaction,
-                        parentNavigatorKey: _rootNavigatorKey,
-                        builder: _buildEditTransactionPage),
-                    GoRoute(
-                        path:
-                            '${RouteNames.transactionDetail}/:${RouteNames.paramTransactionId}',
-                        name: RouteNames.transactionDetail,
-                        parentNavigatorKey: _rootNavigatorKey,
-                        builder: _buildTransactionDetailPage),
-                  ],
-                ),
-              ],
-            ),
-            // --- Branch 2: Budgets/Goals ---
-            StatefulShellBranch(
-              navigatorKey: _shellNavigatorKeyBudgetsCats,
-              routes: [
-                GoRoute(
-                  path: RouteNames.budgetsAndCats,
-                  name: RouteNames.budgetsAndCats,
-                  pageBuilder: (context, state) =>
-                      const NoTransitionPage(child: BudgetsAndCatsTabPage()),
-                  routes: [
-                    GoRoute(
-                      path: RouteNames.manageCategories,
-                      name: RouteNames.manageCategories,
-                      parentNavigatorKey: _rootNavigatorKey,
-                      builder: (context, state) =>
-                          const CategoryManagementScreen(),
-                      routes: [
-                        GoRoute(
-                            path: RouteNames.addCategory,
-                            name: RouteNames.addCategory,
-                            parentNavigatorKey: _rootNavigatorKey,
-                            builder: (context, state) {
-                              final Map<String, dynamic>? extra =
-                                  state.extra as Map<String, dynamic>?;
-                              final CategoryType? initialType =
-                                  extra?['initialType'] as CategoryType?;
-                              return AddEditCategoryScreen(
-                                  initialType: initialType);
-                            }),
-                        GoRoute(
-                            path:
-                                '${RouteNames.editCategory}/:${RouteNames.paramId}',
-                            name: RouteNames.editCategory,
-                            parentNavigatorKey: _rootNavigatorKey,
-                            builder: _buildEditCategoryPage),
-                      ],
                     ),
-                    GoRoute(
-                        path: RouteNames.addBudget,
-                        name: RouteNames.addBudget,
-                        parentNavigatorKey: _rootNavigatorKey,
-                        builder: (context, state) =>
-                            const AddEditBudgetPage(initialBudget: null)),
-                    GoRoute(
-                        path: '${RouteNames.editBudget}/:${RouteNames.paramId}',
-                        name: RouteNames.editBudget,
-                        parentNavigatorKey: _rootNavigatorKey,
-                        builder: _buildEditBudgetPage),
-                    GoRoute(
-                        path:
-                            '${RouteNames.budgetDetail}/:${RouteNames.paramId}',
-                        name: RouteNames.budgetDetail,
-                        parentNavigatorKey: _rootNavigatorKey,
-                        builder: _buildBudgetDetailPage),
-                    GoRoute(
-                        path: RouteNames.addGoal,
-                        name: RouteNames.addGoal,
-                        parentNavigatorKey: _rootNavigatorKey,
-                        builder: (context, state) =>
-                            const AddEditGoalPage(initialGoal: null)),
-                    GoRoute(
-                        path: '${RouteNames.editGoal}/:${RouteNames.paramId}',
-                        name: RouteNames.editGoal,
-                        parentNavigatorKey: _rootNavigatorKey,
-                        builder: _buildEditGoalPage),
-                    GoRoute(
-                        path: '${RouteNames.goalDetail}/:${RouteNames.paramId}',
-                        name: RouteNames.goalDetail,
-                        parentNavigatorKey: _rootNavigatorKey,
-                        builder: _buildGoalDetailPage),
-                  ],
-                ),
-              ],
-            ),
-            // --- Branch 3: Accounts ---
-            StatefulShellBranch(
-              navigatorKey: _shellNavigatorKeyAccounts,
-              routes: [
-                GoRoute(
-                  path: RouteNames.accounts,
-                  name: RouteNames.accounts,
-                  pageBuilder: (context, state) =>
-                      const NoTransitionPage(child: AccountsTabPage()),
-                  routes: [
-                    GoRoute(
-                        path: RouteNames.addAccount,
-                        name: RouteNames.addAccount,
-                        parentNavigatorKey: _rootNavigatorKey,
-                        builder: (context, state) =>
-                            const AddEditAccountPage()),
-                    GoRoute(
-                        path:
-                            '${RouteNames.editAccount}/:${RouteNames.paramAccountId}',
-                        name: RouteNames.editAccount,
-                        parentNavigatorKey: _rootNavigatorKey,
-                        builder: _buildEditAccountPage),
-                  ],
-                ),
-              ],
-            ),
-            // --- Branch 4: Recurring ---
-            StatefulShellBranch(
-              navigatorKey: _shellNavigatorKeyRecurring,
-              routes: [
-                GoRoute(
-                  path: RouteNames.recurring,
-                  name: RouteNames.recurring,
-                  pageBuilder: (context, state) =>
-                      const NoTransitionPage(child: RecurringRuleListPage()),
-                  routes: [
-                    GoRoute(
-                      path: RouteNames.addRecurring,
-                      name: RouteNames.addRecurring,
-                      parentNavigatorKey: _rootNavigatorKey,
-                      builder: (context, state) =>
-                          const AddEditRecurringRulePage(),
+                  );
+                },
+                routes: [
+                  GoRoute(
+                    path: RouteNames.addTransaction,
+                    name: RouteNames.addTransaction,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (context, state) => const AddEditTransactionPage(
+                      initialTransactionData: null,
                     ),
-                    GoRoute(
-                      path: '${RouteNames.editRecurring}/:${RouteNames.paramId}',
-                      name: RouteNames.editRecurring,
-                      parentNavigatorKey: _rootNavigatorKey,
-                      builder: (context, state) {
-                        final rule = state.extra as RecurringRule?;
-                        return AddEditRecurringRulePage(initialRule: rule);
-                      },
-                    ),
-                  ],
-                ),
-              ],
-            ),
-            // --- Branch 5: Settings ---
-            StatefulShellBranch(
-              navigatorKey: _shellNavigatorKeySettings,
-              routes: [
-                GoRoute(
-                  path: RouteNames.settings,
-                  name: RouteNames.settings,
-                  pageBuilder: (context, state) =>
-                      const NoTransitionPage(child: SettingsPage()),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ]);
+                  ),
+                  GoRoute(
+                    path:
+                        '${RouteNames.editTransaction}/:${RouteNames.paramTransactionId}',
+                    name: RouteNames.editTransaction,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: _buildEditTransactionPage,
+                  ),
+                  GoRoute(
+                    path:
+                        '${RouteNames.transactionDetail}/:${RouteNames.paramTransactionId}',
+                    name: RouteNames.transactionDetail,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: _buildTransactionDetailPage,
+                  ),
+                ],
+              ),
+            ],
+          ),
+          // --- Branch 2: Budgets/Goals ---
+          StatefulShellBranch(
+            navigatorKey: _shellNavigatorKeyBudgetsCats,
+            routes: [
+              GoRoute(
+                path: RouteNames.budgetsAndCats,
+                name: RouteNames.budgetsAndCats,
+                pageBuilder: (context, state) =>
+                    const NoTransitionPage(child: BudgetsAndCatsTabPage()),
+                routes: [
+                  GoRoute(
+                    path: RouteNames.manageCategories,
+                    name: RouteNames.manageCategories,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (context, state) =>
+                        const CategoryManagementScreen(),
+                    routes: [
+                      GoRoute(
+                        path: RouteNames.addCategory,
+                        name: RouteNames.addCategory,
+                        parentNavigatorKey: _rootNavigatorKey,
+                        builder: (context, state) {
+                          final Map<String, dynamic>? extra =
+                              state.extra as Map<String, dynamic>?;
+                          final CategoryType? initialType =
+                              extra?['initialType'] as CategoryType?;
+                          return AddEditCategoryScreen(
+                            initialType: initialType,
+                          );
+                        },
+                      ),
+                      GoRoute(
+                        path:
+                            '${RouteNames.editCategory}/:${RouteNames.paramId}',
+                        name: RouteNames.editCategory,
+                        parentNavigatorKey: _rootNavigatorKey,
+                        builder: _buildEditCategoryPage,
+                      ),
+                    ],
+                  ),
+                  GoRoute(
+                    path: RouteNames.addBudget,
+                    name: RouteNames.addBudget,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (context, state) =>
+                        const AddEditBudgetPage(initialBudget: null),
+                  ),
+                  GoRoute(
+                    path: '${RouteNames.editBudget}/:${RouteNames.paramId}',
+                    name: RouteNames.editBudget,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: _buildEditBudgetPage,
+                  ),
+                  GoRoute(
+                    path: '${RouteNames.budgetDetail}/:${RouteNames.paramId}',
+                    name: RouteNames.budgetDetail,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: _buildBudgetDetailPage,
+                  ),
+                  GoRoute(
+                    path: RouteNames.addGoal,
+                    name: RouteNames.addGoal,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (context, state) =>
+                        const AddEditGoalPage(initialGoal: null),
+                  ),
+                  GoRoute(
+                    path: '${RouteNames.editGoal}/:${RouteNames.paramId}',
+                    name: RouteNames.editGoal,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: _buildEditGoalPage,
+                  ),
+                  GoRoute(
+                    path: '${RouteNames.goalDetail}/:${RouteNames.paramId}',
+                    name: RouteNames.goalDetail,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: _buildGoalDetailPage,
+                  ),
+                ],
+              ),
+            ],
+          ),
+          // --- Branch 3: Accounts ---
+          StatefulShellBranch(
+            navigatorKey: _shellNavigatorKeyAccounts,
+            routes: [
+              GoRoute(
+                path: RouteNames.accounts,
+                name: RouteNames.accounts,
+                pageBuilder: (context, state) =>
+                    const NoTransitionPage(child: AccountsTabPage()),
+                routes: [
+                  GoRoute(
+                    path: RouteNames.addAccount,
+                    name: RouteNames.addAccount,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (context, state) => const AddEditAccountPage(),
+                  ),
+                  GoRoute(
+                    path:
+                        '${RouteNames.editAccount}/:${RouteNames.paramAccountId}',
+                    name: RouteNames.editAccount,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: _buildEditAccountPage,
+                  ),
+                ],
+              ),
+            ],
+          ),
+          // --- Branch 4: Recurring ---
+          StatefulShellBranch(
+            navigatorKey: _shellNavigatorKeyRecurring,
+            routes: [
+              GoRoute(
+                path: RouteNames.recurring,
+                name: RouteNames.recurring,
+                pageBuilder: (context, state) =>
+                    const NoTransitionPage(child: RecurringRuleListPage()),
+                routes: [
+                  GoRoute(
+                    path: RouteNames.addRecurring,
+                    name: RouteNames.addRecurring,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (context, state) =>
+                        const AddEditRecurringRulePage(),
+                  ),
+                  GoRoute(
+                    path: '${RouteNames.editRecurring}/:${RouteNames.paramId}',
+                    name: RouteNames.editRecurring,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (context, state) {
+                      final rule = state.extra as RecurringRule?;
+                      return AddEditRecurringRulePage(initialRule: rule);
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+          // --- Branch 5: Settings ---
+          StatefulShellBranch(
+            navigatorKey: _shellNavigatorKeySettings,
+            routes: [
+              GoRoute(
+                path: RouteNames.settings,
+                name: RouteNames.settings,
+                pageBuilder: (context, state) =>
+                    const NoTransitionPage(child: SettingsPage()),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
 
   // --- Report Sub-Routes Builder (Unchanged) ---
   static List<RouteBase> _buildReportSubRoutes(
-      GlobalKey<NavigatorState> parentKey) {
+    GlobalKey<NavigatorState> parentKey,
+  ) {
     return [
       GoRoute(
         path: RouteNames.reportSpendingCategory, // Relative path
@@ -413,8 +438,7 @@ class AppRouter {
             child: BlocProvider<ReportFilterBloc>(
               create: (_) => filterBloc,
               child: BlocProvider<SpendingTimeReportBloc>(
-                create: (_) =>
-                    sl<SpendingTimeReportBloc>(param1: filterBloc),
+                create: (_) => sl<SpendingTimeReportBloc>(param1: filterBloc),
                 child: const SpendingOverTimePage(),
               ),
             ),
@@ -432,8 +456,7 @@ class AppRouter {
             child: BlocProvider<ReportFilterBloc>(
               create: (_) => filterBloc,
               child: BlocProvider<IncomeExpenseReportBloc>(
-                create: (_) =>
-                    sl<IncomeExpenseReportBloc>(param1: filterBloc),
+                create: (_) => sl<IncomeExpenseReportBloc>(param1: filterBloc),
                 child: const IncomeVsExpensePage(),
               ),
             ),
@@ -470,8 +493,7 @@ class AppRouter {
             child: BlocProvider<ReportFilterBloc>(
               create: (_) => filterBloc,
               child: BlocProvider<GoalProgressReportBloc>(
-                create: (_) =>
-                    sl<GoalProgressReportBloc>(param1: filterBloc),
+                create: (_) => sl<GoalProgressReportBloc>(param1: filterBloc),
                 child: const GoalProgressPage(),
               ),
             ),
@@ -483,28 +505,36 @@ class AppRouter {
 
   // --- Helper Builder Functions (Unchanged) ---
   static Widget _buildTransactionDetailPage(
-      BuildContext context, GoRouterState state) {
+    BuildContext context,
+    GoRouterState state,
+  ) {
     final id = state.pathParameters[RouteNames.paramTransactionId];
     TransactionEntity? transaction;
     if (state.extra is TransactionEntity) {
       transaction = state.extra as TransactionEntity;
     } else {
       log.warning(
-          "[AppRouter] Txn Detail route received 'extra' of unexpected type or null. Extra: ${state.extra?.runtimeType}");
+        "[AppRouter] Txn Detail route received 'extra' of unexpected type or null. Extra: ${state.extra?.runtimeType}",
+      );
     }
     if (id == null || transaction == null) {
       log.severe(
-          "[AppRouter] Txn Detail route missing ID or valid transaction data!");
+        "[AppRouter] Txn Detail route missing ID or valid transaction data!",
+      );
       return Scaffold(
-          appBar: AppBar(),
-          body: const Center(
-              child: Text("Error: Could not load transaction details")));
+        appBar: AppBar(),
+        body: const Center(
+          child: Text("Error: Could not load transaction details"),
+        ),
+      );
     }
     return TransactionDetailPage(transaction: transaction);
   }
 
   static Widget _buildEditTransactionPage(
-      BuildContext context, GoRouterState state) {
+    BuildContext context,
+    GoRouterState state,
+  ) {
     final transactionId = state.pathParameters[RouteNames.paramTransactionId];
     dynamic initialData = state.extra;
     if (initialData != null &&
@@ -512,24 +542,30 @@ class AppRouter {
             initialData is Income ||
             initialData is TransactionEntity)) {
       log.warning(
-          "[AppRouter] Edit Txn route received 'extra' of unexpected type: ${state.extra?.runtimeType}. Ignoring.");
+        "[AppRouter] Edit Txn route received 'extra' of unexpected type: ${state.extra?.runtimeType}. Ignoring.",
+      );
       initialData = null;
     }
     if (transactionId == null && initialData == null) {
       log.severe(
-          "[AppRouter] Edit Txn route called without transaction ID or initial data!");
+        "[AppRouter] Edit Txn route called without transaction ID or initial data!",
+      );
       return const Scaffold(
-          appBar: null,
-          body: Center(child: Text("Error: Missing Transaction Data")));
+        appBar: null,
+        body: Center(child: Text("Error: Missing Transaction Data")),
+      );
     }
     return AddEditTransactionPage(initialTransactionData: initialData);
   }
 
   static Widget _buildEditCategoryPage(
-      BuildContext context, GoRouterState state) {
+    BuildContext context,
+    GoRouterState state,
+  ) {
     final categoryId = state.pathParameters[RouteNames.paramId];
-    final Category? category =
-        state.extra is Category ? state.extra as Category : null;
+    final Category? category = state.extra is Category
+        ? state.extra as Category
+        : null;
     final Map<String, dynamic>? extraMap = state.extra is Map<String, dynamic>
         ? state.extra as Map<String, dynamic>
         : null;
@@ -538,45 +574,61 @@ class AppRouter {
     if (categoryId == null) {
       log.severe("[AppRouter] Edit Category route called without ID!");
       return const Scaffold(
-          appBar: null,
-          body: Center(child: Text("Error: Missing Category ID")));
+        appBar: null,
+        body: Center(child: Text("Error: Missing Category ID")),
+      );
     }
     return AddEditCategoryScreen(
-        initialCategory: category, initialType: initialType);
+      initialCategory: category,
+      initialType: initialType,
+    );
   }
 
   static Widget _buildEditAccountPage(
-      BuildContext context, GoRouterState state) {
+    BuildContext context,
+    GoRouterState state,
+  ) {
     final accountId = state.pathParameters[RouteNames.paramAccountId];
-    final AssetAccount? account =
-        state.extra is AssetAccount ? state.extra as AssetAccount : null;
+    final AssetAccount? account = state.extra is AssetAccount
+        ? state.extra as AssetAccount
+        : null;
     if (accountId == null) {
       log.severe("[AppRouter] Edit Account route called without ID!");
       return const Scaffold(
-          appBar: null, body: Center(child: Text("Error: Missing Account ID")));
+        appBar: null,
+        body: Center(child: Text("Error: Missing Account ID")),
+      );
     }
     return AddEditAccountPage(accountId: accountId, account: account);
   }
 
   static Widget _buildEditBudgetPage(
-      BuildContext context, GoRouterState state) {
+    BuildContext context,
+    GoRouterState state,
+  ) {
     final budgetId = state.pathParameters[RouteNames.paramId];
     final Budget? budget = state.extra is Budget ? state.extra as Budget : null;
     if (budgetId == null) {
       log.severe("[AppRouter] Edit Budget route called without ID!");
       return const Scaffold(
-          appBar: null, body: Center(child: Text("Error: Missing Budget ID")));
+        appBar: null,
+        body: Center(child: Text("Error: Missing Budget ID")),
+      );
     }
     return AddEditBudgetPage(initialBudget: budget);
   }
 
   static Widget _buildBudgetDetailPage(
-      BuildContext context, GoRouterState state) {
+    BuildContext context,
+    GoRouterState state,
+  ) {
     final budgetId = state.pathParameters[RouteNames.paramId];
     if (budgetId == null) {
       log.severe("[AppRouter] Budget Detail route called without ID!");
       return const Scaffold(
-          appBar: null, body: Center(child: Text("Error: Missing Budget ID")));
+        appBar: null,
+        body: Center(child: Text("Error: Missing Budget ID")),
+      );
     }
     return BudgetDetailPage(budgetId: budgetId);
   }
@@ -587,21 +639,26 @@ class AppRouter {
     if (goalId == null) {
       log.severe("[AppRouter] Edit Goal route called without ID!");
       return const Scaffold(
-          appBar: null, body: Center(child: Text("Error: Missing Goal ID")));
+        appBar: null,
+        body: Center(child: Text("Error: Missing Goal ID")),
+      );
     }
     return AddEditGoalPage(initialGoal: goal);
   }
 
   static Widget _buildGoalDetailPage(
-      BuildContext context, GoRouterState state) {
+    BuildContext context,
+    GoRouterState state,
+  ) {
     final goalId = state.pathParameters[RouteNames.paramId];
-    final Goal? goal = state.extra is Goal ? state.extra as Goal : null;
     if (goalId == null) {
       log.severe("[AppRouter] Goal Detail route called without ID!");
       return const Scaffold(
-          appBar: null, body: Center(child: Text("Error: Missing Goal ID")));
+        appBar: null,
+        body: Center(child: Text("Error: Missing Goal ID")),
+      );
     }
-    return GoalDetailPage(goalId: goalId, initialGoal: goal);
+    return GoalDetailPage(goalId: goalId);
   }
 }
 
@@ -610,42 +667,52 @@ class GoRouterObserver extends NavigatorObserver {
   // ... (Implementation unchanged) ...
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    final String pushedRoute = route.settings.name ??
+    final String pushedRoute =
+        route.settings.name ??
         route.settings.arguments?.toString() ??
         route.toString();
-    final String? previousRouteName = previousRoute?.settings.name ??
+    final String? previousRouteName =
+        previousRoute?.settings.name ??
         previousRoute?.settings.arguments?.toString();
     log.fine('GoRouter Pushed: ${previousRouteName ?? 'null'} -> $pushedRoute');
   }
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    final String poppedRoute = route.settings.name ??
+    final String poppedRoute =
+        route.settings.name ??
         route.settings.arguments?.toString() ??
         route.toString();
-    final String? previousRouteName = previousRoute?.settings.name ??
+    final String? previousRouteName =
+        previousRoute?.settings.name ??
         previousRoute?.settings.arguments?.toString();
     log.fine(
-        'GoRouter Popped: $poppedRoute -> Returning to ${previousRouteName ?? 'null'}');
+      'GoRouter Popped: $poppedRoute -> Returning to ${previousRouteName ?? 'null'}',
+    );
   }
 
   @override
   void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    final String removedRoute = route.settings.name ??
+    final String removedRoute =
+        route.settings.name ??
         route.settings.arguments?.toString() ??
         route.toString();
-    final String? previousRouteName = previousRoute?.settings.name ??
+    final String? previousRouteName =
+        previousRoute?.settings.name ??
         previousRoute?.settings.arguments?.toString();
     log.fine(
-        'GoRouter Removed: $removedRoute (Previous was: ${previousRouteName ?? 'null'})');
+      'GoRouter Removed: $removedRoute (Previous was: ${previousRouteName ?? 'null'})',
+    );
   }
 
   @override
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
-    final String oldRouteName = oldRoute?.settings.name ??
+    final String oldRouteName =
+        oldRoute?.settings.name ??
         oldRoute?.settings.arguments?.toString() ??
         'null';
-    final String newRouteName = newRoute?.settings.name ??
+    final String newRouteName =
+        newRoute?.settings.name ??
         newRoute?.settings.arguments?.toString() ??
         'null';
     log.fine('GoRouter Replaced: $oldRouteName with $newRouteName');
@@ -653,9 +720,3 @@ class GoRouterObserver extends NavigatorObserver {
 }
 
 // Keep StringExtension
-extension StringExtension on String {
-  String capitalize() {
-    if (isEmpty) return this;
-    return "${this[0].toUpperCase()}${substring(1)}";
-  }
-}

--- a/test/core/utils/string_extensions_test.dart
+++ b/test/core/utils/string_extensions_test.dart
@@ -1,0 +1,14 @@
+import 'package:expense_tracker/core/utils/string_extensions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('StringCapitalization.capitalize', () {
+    test('capitalizes first letter of lowercase word', () {
+      expect('hello'.capitalize(), 'Hello');
+    });
+
+    test('returns empty string unchanged', () {
+      expect(''.capitalize(), '');
+    });
+  });
+}

--- a/test/features/accounts/data/models/asset_account_model_test.dart
+++ b/test/features/accounts/data/models/asset_account_model_test.dart
@@ -1,0 +1,31 @@
+import 'package:expense_tracker/features/accounts/data/models/asset_account_model.dart';
+import 'package:expense_tracker/features/accounts/domain/entities/asset_account.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('toEntity uses typeIndex when valid', () {
+    final model = AssetAccountModel(
+      id: '1',
+      name: 'Bank',
+      typeIndex: AssetType.bank.index,
+      initialBalance: 0,
+    );
+
+    final entity = model.toEntity(100);
+
+    expect(entity.type, AssetType.bank);
+  });
+
+  test('toEntity defaults to other on invalid typeIndex', () {
+    final model = AssetAccountModel(
+      id: '1',
+      name: 'Unknown',
+      typeIndex: 999,
+      initialBalance: 0,
+    );
+
+    final entity = model.toEntity(50);
+
+    expect(entity.type, AssetType.other);
+  });
+}

--- a/test/features/categories/domain/usecases/delete_custom_category_test.dart
+++ b/test/features/categories/domain/usecases/delete_custom_category_test.dart
@@ -1,0 +1,56 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
+import 'package:expense_tracker/features/categories/domain/usecases/delete_custom_category.dart';
+import 'package:expense_tracker/features/expenses/domain/repositories/expense_repository.dart';
+import 'package:expense_tracker/features/income/domain/repositories/income_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockCategoryRepository extends Mock implements CategoryRepository {}
+
+class MockExpenseRepository extends Mock implements ExpenseRepository {}
+
+class MockIncomeRepository extends Mock implements IncomeRepository {}
+
+void main() {
+  late DeleteCustomCategoryUseCase usecase;
+  late MockCategoryRepository mockCategoryRepo;
+  late MockExpenseRepository mockExpenseRepo;
+  late MockIncomeRepository mockIncomeRepo;
+
+  setUp(() {
+    mockCategoryRepo = MockCategoryRepository();
+    mockExpenseRepo = MockExpenseRepository();
+    mockIncomeRepo = MockIncomeRepository();
+    usecase = DeleteCustomCategoryUseCase(
+      mockCategoryRepo,
+      mockExpenseRepo,
+      mockIncomeRepo,
+    );
+  });
+
+  test(
+    'returns ValidationFailure when categoryId equals fallbackCategoryId',
+    () async {
+      const params = DeleteCustomCategoryParams(
+        categoryId: 'cat1',
+        fallbackCategoryId: 'cat1',
+      );
+
+      final result = await usecase(params);
+
+      expect(
+        result,
+        equals(
+          const Left(
+            ValidationFailure('Category and fallback cannot be the same.'),
+          ),
+        ),
+      );
+      verifyZeroInteractions(mockCategoryRepo);
+      verifyZeroInteractions(mockExpenseRepo);
+      verifyZeroInteractions(mockIncomeRepo);
+    },
+  );
+}

--- a/test/features/goals/presentation/bloc/contribution_list_bloc_test.dart
+++ b/test/features/goals/presentation/bloc/contribution_list_bloc_test.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/core/events/data_change_event.dart';
+import 'package:expense_tracker/features/goals/domain/entities/goal_contribution.dart';
+import 'package:expense_tracker/features/goals/domain/usecases/get_contributions_for_goal.dart';
+import 'package:expense_tracker/features/goals/presentation/bloc/contribution_list/contribution_list_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockGetContributionsUseCase extends Mock
+    implements GetContributionsForGoalUseCase {}
+
+void main() {
+  late MockGetContributionsUseCase mockGetContributionsUseCase;
+  late StreamController<DataChangedEvent> dataChangeController;
+
+  setUp(() {
+    mockGetContributionsUseCase = MockGetContributionsUseCase();
+    dataChangeController = StreamController<DataChangedEvent>.broadcast();
+    registerFallbackValue(const GetContributionsParams(goalId: 'g1'));
+  });
+
+  tearDown(() async {
+    await dataChangeController.close();
+  });
+
+  final tContribution = GoalContribution(
+    id: 'c1',
+    goalId: 'g1',
+    amount: 50,
+    date: DateTime(2024, 1, 1),
+    createdAt: DateTime(2024, 1, 1),
+  );
+
+  group('LoadContributions', () {
+    blocTest<ContributionListBloc, ContributionListState>(
+      'emits [loading, success] when data fetched',
+      build: () {
+        when(
+          () => mockGetContributionsUseCase(any()),
+        ).thenAnswer((_) async => Right([tContribution]));
+        return ContributionListBloc(
+          goalId: 'g1',
+          getContributionsUseCase: mockGetContributionsUseCase,
+          dataChangeStream: dataChangeController.stream,
+        );
+      },
+      act: (bloc) => bloc.add(const LoadContributions()),
+      expect: () => [
+        const ContributionListState(status: ContributionListStatus.loading),
+        ContributionListState(
+          status: ContributionListStatus.success,
+          contributions: [tContribution],
+        ),
+      ],
+    );
+
+    blocTest<ContributionListBloc, ContributionListState>(
+      'emits [loading, error] when fetch fails',
+      build: () {
+        when(
+          () => mockGetContributionsUseCase(any()),
+        ).thenAnswer((_) async => const Left(ServerFailure('oops')));
+        return ContributionListBloc(
+          goalId: 'g1',
+          getContributionsUseCase: mockGetContributionsUseCase,
+          dataChangeStream: dataChangeController.stream,
+        );
+      },
+      act: (bloc) => bloc.add(const LoadContributions()),
+      expect: () => [
+        const ContributionListState(status: ContributionListStatus.loading),
+        const ContributionListState(
+          status: ContributionListStatus.error,
+          errorMessage: 'oops',
+        ),
+      ],
+    );
+  });
+}

--- a/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
+++ b/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
@@ -6,7 +6,6 @@ import 'package:expense_tracker/features/categories/domain/entities/category_typ
 import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
 import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
 import 'package:expense_tracker/features/expenses/domain/usecases/add_expense.dart';
-import 'package:expense_tracker/features/income/domain/entities/income.dart';
 import 'package:expense_tracker/features/income/domain/usecases/add_income.dart';
 import 'package:expense_tracker/features/income/domain/entities/income.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule.dart';
@@ -271,7 +270,8 @@ void main() {
         () => mockRecurringTransactionRepository.updateRecurringRule(any()));
   });
 
-  test('should handle monthly rule without dayOfMonth by defaulting to current day',
+  test(
+      'should handle monthly rule without dayOfMonth by defaulting to current day',
       () async {
     // Arrange
     final ruleWithoutDayOfMonth = RecurringRule(
@@ -306,10 +306,8 @@ void main() {
     await usecase(const NoParams());
 
     // Assert
-    final captured = verify(() =>
-            mockRecurringTransactionRepository.updateRecurringRule(captureAny()))
-        .captured
-        .single as RecurringRule;
+    final captured = verify(() => mockRecurringTransactionRepository
+        .updateRecurringRule(captureAny())).captured.single as RecurringRule;
     expect(captured.nextOccurrenceDate, expectedNextDate);
   });
 
@@ -349,10 +347,8 @@ void main() {
     await usecase(const NoParams());
 
     // Assert
-    final captured = verify(() =>
-            mockRecurringTransactionRepository.updateRecurringRule(captureAny()))
-        .captured
-        .single as RecurringRule;
+    final captured = verify(() => mockRecurringTransactionRepository
+        .updateRecurringRule(captureAny())).captured.single as RecurringRule;
     expect(captured.nextOccurrenceDate, expectedNextDate);
   });
 }

--- a/test/features/transactions/presentation/transaction_list_page_test.dart
+++ b/test/features/transactions/presentation/transaction_list_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:expense_tracker/features/categories/domain/entities/category.dart';
 import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
+import 'package:expense_tracker/features/income/domain/entities/income.dart';
 import 'package:expense_tracker/features/transactions/domain/entities/transaction_entity.dart';
 import 'package:expense_tracker/features/transactions/presentation/bloc/transaction_list_bloc.dart';
 import 'package:expense_tracker/features/transactions/presentation/pages/transaction_list_page.dart';
@@ -25,6 +26,70 @@ void main() {
       final result = getDominantTransactionTypeForTesting(state);
 
       expect(result, isNull);
+    });
+
+    test('returns null when mixed transaction types are selected', () {
+      final expense = Expense(
+        id: '1',
+        title: 'Lunch',
+        amount: 10.0,
+        date: DateTime(2024, 1, 1),
+        category: Category.uncategorized,
+        accountId: 'acc1',
+      );
+
+      final income = Income(
+        id: '2',
+        title: 'Salary',
+        amount: 100.0,
+        date: DateTime(2024, 1, 2),
+        category: Category.uncategorized,
+        accountId: 'acc1',
+      );
+
+      final state = TransactionListState(
+        transactions: [
+          TransactionEntity.fromExpense(expense),
+          TransactionEntity.fromIncome(income),
+        ],
+        selectedTransactionIds: const {'1', '2'},
+      );
+
+      final result = getDominantTransactionTypeForTesting(state);
+
+      expect(result, isNull);
+    });
+
+    test('returns type when all selected transactions share the same type', () {
+      final expense1 = Expense(
+        id: '1',
+        title: 'Lunch',
+        amount: 10.0,
+        date: DateTime(2024, 1, 1),
+        category: Category.uncategorized,
+        accountId: 'acc1',
+      );
+
+      final expense2 = Expense(
+        id: '2',
+        title: 'Dinner',
+        amount: 20.0,
+        date: DateTime(2024, 1, 2),
+        category: Category.uncategorized,
+        accountId: 'acc1',
+      );
+
+      final state = TransactionListState(
+        transactions: [
+          TransactionEntity.fromExpense(expense1),
+          TransactionEntity.fromExpense(expense2),
+        ],
+        selectedTransactionIds: const {'1', '2'},
+      );
+
+      final result = getDominantTransactionTypeForTesting(state);
+
+      expect(result, equals(TransactionType.expense));
     });
   });
 }


### PR DESCRIPTION
## Summary
- validate DeleteCustomCategory to prevent same fallback id
- show error when batch categorizing mixed transactions
- centralize String.capitalize extension
- guard against invalid asset account type indices
- drive GoalDetailPage from GoalList and Contribution blocs

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689dc61b3204832095ed5d4fbcace307