### PR TITLE
refactor: inject dependencies and remove app lock logic

### DIFF
--- a/android/app/src/main/kotlin/com/example/expense_tracking/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/expense_tracking/MainActivity.kt
@@ -1,17 +1,5 @@
-package com.example.expense_tracking // <<<--- Make sure this matches your actual package name
+package com.example.expense_tracking
 
-// Import FlutterFragmentActivity instead of FlutterActivity
-import io.flutter.embedding.android.FlutterFragmentActivity
-import io.flutter.plugins.GeneratedPluginRegistrant
-import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.android.FlutterActivity
 
-// Extend FlutterFragmentActivity instead of FlutterActivity
-class MainActivity: FlutterFragmentActivity() {
-    // This method registers plugins.
-    // It's optional if you don't have platform channels defined directly in MainActivity,
-    // but generally good practice to keep for GeneratedPluginRegistrant.
-    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
-        GeneratedPluginRegistrant.registerWith(flutterEngine)
-        // You can register other platform channels here if needed
-    }
-}
+class MainActivity: FlutterActivity()

--- a/lib/core/di/service_configurations/expenses_dependencies.dart
+++ b/lib/core/di/service_configurations/expenses_dependencies.dart
@@ -16,14 +16,19 @@ class ExpensesDependencies {
     // --- MODIFIED: Register Proxy ---
     // Data Source (Proxy that wraps the real one)
     sl.registerLazySingleton<ExpenseLocalDataSource>(
-        () => DemoAwareExpenseDataSource(
-              hiveDataSource: sl<HiveExpenseLocalDataSource>(), // Get real DS
-              demoModeService: sl<DemoModeService>(),
-            ));
+      () => DemoAwareExpenseDataSource(
+        hiveDataSource: sl<HiveExpenseLocalDataSource>(), // Get real DS
+        demoModeService: sl<DemoModeService>(),
+      ),
+    );
     // --- END MODIFIED ---
 
     sl.registerLazySingleton<ExpenseRepository>(
-        () => ExpenseRepositoryImpl(localDataSource: sl()));
+      () => ExpenseRepositoryImpl(
+        localDataSource: sl(),
+        categoryRepository: sl(),
+      ),
+    );
     // Domain
     sl.registerLazySingleton(() => AddExpenseUseCase(sl()));
     sl.registerLazySingleton(() => UpdateExpenseUseCase(sl()));

--- a/lib/core/di/service_configurations/goal_dependencies.dart
+++ b/lib/core/di/service_configurations/goal_dependencies.dart
@@ -35,41 +35,51 @@ import 'package:expense_tracker/features/goals/presentation/bloc/log_contributio
 // External
 import 'package:uuid/uuid.dart';
 import 'dart:async'; // For Stream
+import 'package:expense_tracker/core/services/clock.dart';
 
 class GoalDependencies {
   static void register() {
     // --- Data Sources (Proxies) ---
     if (!sl.isRegistered<GoalLocalDataSource>()) {
       sl.registerLazySingleton<GoalLocalDataSource>(
-          () => DemoAwareGoalDataSource(
-                hiveDataSource: sl<HiveGoalLocalDataSource>(),
-                demoModeService: sl<DemoModeService>(),
-              ));
+        () => DemoAwareGoalDataSource(
+          hiveDataSource: sl<HiveGoalLocalDataSource>(),
+          demoModeService: sl<DemoModeService>(),
+        ),
+      );
     }
     if (!sl.isRegistered<GoalContributionLocalDataSource>()) {
       sl.registerLazySingleton<GoalContributionLocalDataSource>(
-          () => DemoAwareGoalContributionDataSource(
-                hiveDataSource: sl<HiveContributionLocalDataSource>(),
-                demoModeService: sl<DemoModeService>(),
-              ));
+        () => DemoAwareGoalContributionDataSource(
+          hiveDataSource: sl<HiveContributionLocalDataSource>(),
+          demoModeService: sl<DemoModeService>(),
+        ),
+      );
     }
 
     // --- Repositories ---
     if (!sl.isRegistered<GoalRepository>()) {
       sl.registerLazySingleton<GoalRepository>(
-          () => GoalRepositoryImpl(localDataSource: sl()));
+        () => GoalRepositoryImpl(
+          localDataSource: sl(),
+          contributionDataSource: sl(),
+        ),
+      );
     }
     if (!sl.isRegistered<GoalContributionRepository>()) {
       sl.registerLazySingleton<GoalContributionRepository>(
-          () => GoalContributionRepositoryImpl(
-                contributionDataSource: sl(),
-                goalDataSource: sl(), // Goal DS needed for cache update
-              ));
+        () => GoalContributionRepositoryImpl(
+          contributionDataSource: sl(),
+          goalDataSource: sl(), // Goal DS needed for cache update
+        ),
+      );
     }
 
     // --- Use Cases ---
     if (!sl.isRegistered<AddGoalUseCase>()) {
-      sl.registerLazySingleton(() => AddGoalUseCase(sl(), sl<Uuid>()));
+      sl.registerLazySingleton(
+        () => AddGoalUseCase(sl(), sl<Uuid>(), sl<Clock>()),
+      );
     }
     if (!sl.isRegistered<GetGoalsUseCase>()) {
       sl.registerLazySingleton(() => GetGoalsUseCase(sl()));
@@ -84,7 +94,9 @@ class GoalDependencies {
       sl.registerLazySingleton(() => DeleteGoalUseCase(sl()));
     }
     if (!sl.isRegistered<AddContributionUseCase>()) {
-      sl.registerLazySingleton(() => AddContributionUseCase(sl(), sl<Uuid>()));
+      sl.registerLazySingleton(
+        () => AddContributionUseCase(sl(), sl<Uuid>(), sl<Clock>()),
+      );
     }
     if (!sl.isRegistered<GetContributionsForGoalUseCase>()) {
       sl.registerLazySingleton(() => GetContributionsForGoalUseCase(sl()));
@@ -104,28 +116,33 @@ class GoalDependencies {
 
     // --- Blocs ---
     if (!sl.isRegistered<GoalListBloc>()) {
-      sl.registerFactory(() => GoalListBloc(
-            getGoalsUseCase: sl<GetGoalsUseCase>(),
-            archiveGoalUseCase: sl<ArchiveGoalUseCase>(),
-            dataChangeStream: sl<Stream<DataChangedEvent>>(),
-            deleteGoalUseCase: sl<DeleteGoalUseCase>(),
-          ));
+      sl.registerFactory(
+        () => GoalListBloc(
+          getGoalsUseCase: sl<GetGoalsUseCase>(),
+          archiveGoalUseCase: sl<ArchiveGoalUseCase>(),
+          dataChangeStream: sl<Stream<DataChangedEvent>>(),
+          deleteGoalUseCase: sl<DeleteGoalUseCase>(),
+        ),
+      );
     }
     if (!sl.isRegistered<AddEditGoalBloc>()) {
       sl.registerFactoryParam<AddEditGoalBloc, Goal?, void>(
-          (initialGoal, _) => AddEditGoalBloc(
-                addGoalUseCase: sl<AddGoalUseCase>(),
-                updateGoalUseCase: sl<UpdateGoalUseCase>(),
-                initialGoal: initialGoal,
-              ));
+        (initialGoal, _) => AddEditGoalBloc(
+          addGoalUseCase: sl<AddGoalUseCase>(),
+          updateGoalUseCase: sl<UpdateGoalUseCase>(),
+          initialGoal: initialGoal,
+        ),
+      );
     }
     if (!sl.isRegistered<LogContributionBloc>()) {
-      sl.registerFactory(() => LogContributionBloc(
-            addContributionUseCase: sl<AddContributionUseCase>(),
-            updateContributionUseCase: sl<UpdateContributionUseCase>(),
-            deleteContributionUseCase: sl<DeleteContributionUseCase>(),
-            checkGoalAchievementUseCase: sl<CheckGoalAchievementUseCase>(),
-          ));
+      sl.registerFactory(
+        () => LogContributionBloc(
+          addContributionUseCase: sl<AddContributionUseCase>(),
+          updateContributionUseCase: sl<UpdateContributionUseCase>(),
+          deleteContributionUseCase: sl<DeleteContributionUseCase>(),
+          checkGoalAchievementUseCase: sl<CheckGoalAchievementUseCase>(),
+        ),
+      );
     }
   }
 }

--- a/lib/core/di/service_configurations/settings_dependencies.dart
+++ b/lib/core/di/service_configurations/settings_dependencies.dart
@@ -5,20 +5,32 @@ import 'package:expense_tracker/features/settings/data/datasources/settings_loca
 import 'package:expense_tracker/features/settings/data/repositories/settings_repository_impl.dart';
 import 'package:expense_tracker/features/settings/domain/repositories/settings_repository.dart';
 import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:expense_tracker/features/settings/domain/usecases/toggle_app_lock.dart';
+import 'package:local_auth/local_auth.dart';
 
 class SettingsDependencies {
   static void register() {
     // Data Source
     sl.registerLazySingleton<SettingsLocalDataSource>(
-        () => SettingsLocalDataSourceImpl(prefs: sl()));
+      () => SettingsLocalDataSourceImpl(prefs: sl()),
+    );
     // Repository
     sl.registerLazySingleton<SettingsRepository>(
-        () => SettingsRepositoryImpl(localDataSource: sl()));
+      () => SettingsRepositoryImpl(localDataSource: sl()),
+    );
+    // Use Case and external deps
+    sl.registerLazySingleton<LocalAuthentication>(() => LocalAuthentication());
+    sl.registerLazySingleton<ToggleAppLockUseCase>(
+      () => ToggleAppLockUseCase(sl(), sl()),
+    );
     // BLoC
     // Provide a single instance so router and app share the same stream
-    sl.registerLazySingleton<SettingsBloc>(() => SettingsBloc(
-          settingsRepository: sl<SettingsRepository>(),
-          demoModeService: sl<DemoModeService>(), // Provide the dependency
-        ));
+    sl.registerLazySingleton<SettingsBloc>(
+      () => SettingsBloc(
+        settingsRepository: sl<SettingsRepository>(),
+        demoModeService: sl<DemoModeService>(), // Provide the dependency
+        toggleAppLockUseCase: sl<ToggleAppLockUseCase>(),
+      ),
+    );
   }
 }

--- a/lib/core/services/clock.dart
+++ b/lib/core/services/clock.dart
@@ -1,0 +1,8 @@
+abstract class Clock {
+  DateTime now();
+}
+
+class SystemClock implements Clock {
+  @override
+  DateTime now() => DateTime.now();
+}

--- a/lib/features/goals/domain/usecases/add_contribution.dart
+++ b/lib/features/goals/domain/usecases/add_contribution.dart
@@ -7,23 +7,28 @@ import 'package:expense_tracker/features/goals/domain/entities/goal_contribution
 import 'package:expense_tracker/features/goals/domain/repositories/goal_contribution_repository.dart';
 import 'package:expense_tracker/main.dart';
 import 'package:uuid/uuid.dart';
+import 'package:expense_tracker/core/services/clock.dart';
 
 class AddContributionUseCase
     implements UseCase<GoalContribution, AddContributionParams> {
   final GoalContributionRepository repository;
   final Uuid uuid;
+  final Clock clock;
 
-  AddContributionUseCase(this.repository, this.uuid);
+  AddContributionUseCase(this.repository, this.uuid, this.clock);
 
   @override
   Future<Either<Failure, GoalContribution>> call(
-      AddContributionParams params) async {
+    AddContributionParams params,
+  ) async {
     log.info(
-        "[AddContributionUseCase] Adding contribution to Goal ID: ${params.goalId}");
+      "[AddContributionUseCase] Adding contribution to Goal ID: ${params.goalId}",
+    );
 
     if (params.amount <= 0) {
       return const Left(
-          ValidationFailure("Contribution amount must be positive."));
+        ValidationFailure("Contribution amount must be positive."),
+      );
     }
     // Date validation usually handled by picker
 
@@ -33,7 +38,7 @@ class AddContributionUseCase
       amount: params.amount,
       date: params.date,
       note: params.note?.trim(),
-      createdAt: DateTime.now(),
+      createdAt: clock.now(),
     );
 
     return await repository.addContribution(newContribution);

--- a/lib/features/goals/domain/usecases/add_goal.dart
+++ b/lib/features/goals/domain/usecases/add_goal.dart
@@ -8,12 +8,14 @@ import 'package:expense_tracker/features/goals/domain/entities/goal_status.dart'
 import 'package:expense_tracker/features/goals/domain/repositories/goal_repository.dart';
 import 'package:expense_tracker/main.dart';
 import 'package:uuid/uuid.dart';
+import 'package:expense_tracker/core/services/clock.dart';
 
 class AddGoalUseCase implements UseCase<Goal, AddGoalParams> {
   final GoalRepository repository;
   final Uuid uuid;
+  final Clock clock;
 
-  AddGoalUseCase(this.repository, this.uuid);
+  AddGoalUseCase(this.repository, this.uuid, this.clock);
 
   @override
   Future<Either<Failure, Goal>> call(AddGoalParams params) async {
@@ -27,8 +29,9 @@ class AddGoalUseCase implements UseCase<Goal, AddGoalParams> {
       return const Left(ValidationFailure("Target amount must be positive."));
     }
     if (params.targetDate != null &&
-        params.targetDate!
-            .isBefore(DateTime.now().subtract(const Duration(days: 1)))) {
+        params.targetDate!.isBefore(
+          DateTime.now().subtract(const Duration(days: 1)),
+        )) {
       // Allow today, but not past days
       // return const Left(ValidationFailure("Target date cannot be in the past."));
       // Let's allow past dates for flexibility (e.g., logging a past goal)
@@ -47,7 +50,7 @@ class AddGoalUseCase implements UseCase<Goal, AddGoalParams> {
       description: params.description?.trim(),
       status: GoalStatus.active,
       totalSaved: 0.0, // Initial saved amount is 0
-      createdAt: DateTime.now(),
+      createdAt: clock.now(),
       achievedAt: null,
     );
 
@@ -71,6 +74,11 @@ class AddGoalParams extends Equatable {
   });
 
   @override
-  List<Object?> get props =>
-      [name, targetAmount, targetDate, iconName, description];
+  List<Object?> get props => [
+    name,
+    targetAmount,
+    targetDate,
+    iconName,
+    description,
+  ];
 }

--- a/lib/features/settings/domain/usecases/toggle_app_lock.dart
+++ b/lib/features/settings/domain/usecases/toggle_app_lock.dart
@@ -1,0 +1,34 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/settings/domain/repositories/settings_repository.dart';
+import 'package:flutter/services.dart';
+import 'package:local_auth/local_auth.dart';
+
+class ToggleAppLockUseCase {
+  final SettingsRepository repository;
+  final LocalAuthentication localAuth;
+
+  ToggleAppLockUseCase(this.repository, this.localAuth);
+
+  Future<Either<Failure, void>> call(bool enable) async {
+    try {
+      if (enable) {
+        final canCheck =
+            await localAuth.canCheckBiometrics ||
+            await localAuth.isDeviceSupported();
+        if (!canCheck) {
+          return Left(
+            ValidationFailure(
+              'Cannot enable App Lock. Biometrics or device lock not available.',
+            ),
+          );
+        }
+      }
+      return await repository.saveAppLockEnabled(enable);
+    } on PlatformException catch (e) {
+      return Left(UnexpectedFailure(e.message ?? e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(e.toString()));
+    }
+  }
+}

--- a/lib/features/settings/presentation/bloc/settings_bloc.dart
+++ b/lib/features/settings/presentation/bloc/settings_bloc.dart
@@ -5,6 +5,7 @@ import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
 import 'package:expense_tracker/core/error/failure.dart';
 import 'package:expense_tracker/features/settings/domain/repositories/settings_repository.dart';
+import 'package:expense_tracker/features/settings/domain/usecases/toggle_app_lock.dart';
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/events/data_change_event.dart';
 import 'package:expense_tracker/core/theme/app_theme.dart';
@@ -21,16 +22,21 @@ part 'settings_state.dart';
 class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   final SettingsRepository _settingsRepository;
   final DemoModeService _demoModeService;
+  final ToggleAppLockUseCase _toggleAppLockUseCase;
 
   SettingsBloc({
     required SettingsRepository settingsRepository,
     required DemoModeService demoModeService,
-  })  : _settingsRepository = settingsRepository,
-        _demoModeService = demoModeService,
-        super(SettingsState(
-          isInDemoMode: demoModeService.isDemoActive,
-          setupSkipped: false, // Ensure skip starts false
-        )) {
+    required ToggleAppLockUseCase toggleAppLockUseCase,
+  }) : _settingsRepository = settingsRepository,
+       _demoModeService = demoModeService,
+       _toggleAppLockUseCase = toggleAppLockUseCase,
+       super(
+         SettingsState(
+           isInDemoMode: demoModeService.isDemoActive,
+           setupSkipped: false, // Ensure skip starts false
+         ),
+       ) {
     on<LoadSettings>(_onLoadSettings);
     on<UpdateTheme>(_onUpdateTheme);
     on<UpdatePaletteIdentifier>(_onUpdatePaletteIdentifier);
@@ -53,7 +59,9 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   }
 
   void _onResetSkipSetupFlag(
-      ResetSkipSetupFlag event, Emitter<SettingsState> emit) {
+    ResetSkipSetupFlag event,
+    Emitter<SettingsState> emit,
+  ) {
     if (state.setupSkipped) {
       log.info("[SettingsBloc] Resetting setup skipped flag.");
       emit(state.copyWith(setupSkipped: false));
@@ -62,16 +70,20 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   // --- END ADDED ---
 
   Future<void> _onLoadSettings(
-      LoadSettings event, Emitter<SettingsState> emit) async {
+    LoadSettings event,
+    Emitter<SettingsState> emit,
+  ) async {
     log.info("[SettingsBloc] Received LoadSettings event.");
-    emit(state.copyWith(
-      status: SettingsStatus.loading,
-      packageInfoStatus: PackageInfoStatus.loading,
-      clearAllMessages: true,
-      // Ensure flags are reset on a full load (e.g., app start)
-      isInDemoMode: false,
-      setupSkipped: false,
-    ));
+    emit(
+      state.copyWith(
+        status: SettingsStatus.loading,
+        packageInfoStatus: PackageInfoStatus.loading,
+        clearAllMessages: true,
+        // Ensure flags are reset on a full load (e.g., app start)
+        isInDemoMode: false,
+        setupSkipped: false,
+      ),
+    );
     // ... (rest of loading logic unchanged) ...
     PackageInfo? packageInfo;
     String? packageInfoLoadError;
@@ -105,58 +117,68 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       final appLockResult = results[4] as Either<Failure, bool>;
 
       themeModeResult.fold(
-          (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
-          (mode) => loadedThemeMode = mode);
+        (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
+        (mode) => loadedThemeMode = mode,
+      );
       paletteIdResult.fold(
-          (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
-          (id) => loadedPaletteIdentifier = id);
+        (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
+        (id) => loadedPaletteIdentifier = id,
+      );
       uiModeResult.fold(
-          (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
-          (mode) => loadedUIMode = mode);
+        (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
+        (mode) => loadedUIMode = mode,
+      );
       countryResult.fold(
-          (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
-          (code) =>
-              loadedCountryCode = code ?? SettingsState.defaultCountryCode);
+        (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
+        (code) => loadedCountryCode = code ?? SettingsState.defaultCountryCode,
+      );
       appLockResult.fold(
-          (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
-          (enabled) => loadedLock = enabled);
+        (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
+        (enabled) => loadedLock = enabled,
+      );
 
-      emit(state.copyWith(
-        status: settingsLoadError != null
-            ? SettingsStatus.error
-            : SettingsStatus.loaded,
-        errorMessage: settingsLoadError,
-        themeMode: loadedThemeMode,
-        paletteIdentifier: loadedPaletteIdentifier,
-        uiMode: loadedUIMode,
-        selectedCountryCode: loadedCountryCode,
-        isAppLockEnabled: loadedLock,
-        packageInfoStatus: packageInfoLoadError != null
-            ? PackageInfoStatus.error
-            : PackageInfoStatus.loaded,
-        packageInfoError: packageInfoLoadError,
-        appVersion: packageInfo != null
-            ? '${packageInfo.version}+${packageInfo.buildNumber}'
-            : null,
-        // Ensure isInDemoMode stays false after loading real settings
-        isInDemoMode: false,
-        setupSkipped: false, // Ensure skip flag is reset on full load
-      ));
+      emit(
+        state.copyWith(
+          status: settingsLoadError != null
+              ? SettingsStatus.error
+              : SettingsStatus.loaded,
+          errorMessage: () => settingsLoadError,
+          themeMode: loadedThemeMode,
+          paletteIdentifier: loadedPaletteIdentifier,
+          uiMode: loadedUIMode,
+          selectedCountryCode: loadedCountryCode,
+          isAppLockEnabled: loadedLock,
+          packageInfoStatus: packageInfoLoadError != null
+              ? PackageInfoStatus.error
+              : PackageInfoStatus.loaded,
+          packageInfoError: () => packageInfoLoadError,
+          appVersion: () => packageInfo != null
+              ? '${packageInfo.version}+${packageInfo.buildNumber}'
+              : null,
+          // Ensure isInDemoMode stays false after loading real settings
+          isInDemoMode: false,
+          setupSkipped: false, // Ensure skip flag is reset on full load
+        ),
+      );
       log.info("[SettingsBloc] Emitted final loaded/error state.");
     } catch (e, s) {
       log.severe("[SettingsBloc] Unexpected error loading settings$e$s");
-      emit(state.copyWith(
-        status: SettingsStatus.error,
-        errorMessage: 'An unexpected error occurred loading settings.',
-        packageInfoStatus: state.packageInfoStatus == PackageInfoStatus.loading
-            ? PackageInfoStatus.error
-            : state.packageInfoStatus,
-        packageInfoError: state.packageInfoStatus == PackageInfoStatus.loading
-            ? 'Failed due to main settings error'
-            : state.packageInfoError,
-        isInDemoMode: false, // Ensure demo mode is off on error too
-        setupSkipped: false, // Ensure skip flag is reset on error too
-      ));
+      emit(
+        state.copyWith(
+          status: SettingsStatus.error,
+          errorMessage: () => 'An unexpected error occurred loading settings.',
+          packageInfoStatus:
+              state.packageInfoStatus == PackageInfoStatus.loading
+              ? PackageInfoStatus.error
+              : state.packageInfoStatus,
+          packageInfoError: () =>
+              state.packageInfoStatus == PackageInfoStatus.loading
+              ? 'Failed due to main settings error'
+              : state.packageInfoError,
+          isInDemoMode: false, // Ensure demo mode is off on error too
+          setupSkipped: false, // Ensure skip flag is reset on error too
+        ),
+      );
     }
   }
 
@@ -168,108 +190,158 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
 
   // --- Other Event Handlers (Unchanged but added demo checks) ---
   Future<void> _onUpdateTheme(
-      UpdateTheme event, Emitter<SettingsState> emit) async {
+    UpdateTheme event,
+    Emitter<SettingsState> emit,
+  ) async {
     if (_demoModeService.isDemoActive) {
       log.warning("[SettingsBloc] Ignoring UpdateTheme in Demo Mode.");
       return;
     }
     // ... rest of handler
     log.info(
-        "[SettingsBloc] Received UpdateTheme event: ${event.newMode.name}");
+      "[SettingsBloc] Received UpdateTheme event: ${event.newMode.name}",
+    );
     final result = await _settingsRepository.saveThemeMode(event.newMode);
-    result.fold((failure) {
-      log.warning(
-          "[SettingsBloc] Failed to save theme mode: ${failure.message}");
-      emit(state.copyWith(
-          status: SettingsStatus.error,
-          errorMessage: failure.message,
-          clearAllMessages: true));
-    }, (_) {
-      log.info("[SettingsBloc] Theme mode saved. Emitting new state.");
-      emit(state.copyWith(
-          themeMode: event.newMode,
-          status: SettingsStatus.loaded,
-          clearAllMessages: true));
-    });
+    result.fold(
+      (failure) {
+        log.warning(
+          "[SettingsBloc] Failed to save theme mode: ${failure.message}",
+        );
+        emit(
+          state.copyWith(
+            status: SettingsStatus.error,
+            errorMessage: () => failure.message,
+            clearAllMessages: true,
+          ),
+        );
+      },
+      (_) {
+        log.info("[SettingsBloc] Theme mode saved. Emitting new state.");
+        emit(
+          state.copyWith(
+            themeMode: event.newMode,
+            status: SettingsStatus.loaded,
+            clearAllMessages: true,
+          ),
+        );
+      },
+    );
   }
 
   Future<void> _onUpdatePaletteIdentifier(
-      UpdatePaletteIdentifier event, Emitter<SettingsState> emit) async {
+    UpdatePaletteIdentifier event,
+    Emitter<SettingsState> emit,
+  ) async {
     if (_demoModeService.isDemoActive) {
       log.warning(
-          "[SettingsBloc] Ignoring UpdatePaletteIdentifier in Demo Mode.");
+        "[SettingsBloc] Ignoring UpdatePaletteIdentifier in Demo Mode.",
+      );
       return;
     }
     // ... rest of handler
     log.info(
-        "[SettingsBloc] Received UpdatePaletteIdentifier event: ${event.newIdentifier}");
-    final result =
-        await _settingsRepository.savePaletteIdentifier(event.newIdentifier);
-    result.fold((failure) {
-      log.warning(
-          "[SettingsBloc] Failed to save palette identifier: ${failure.message}");
-      emit(state.copyWith(
-          status: SettingsStatus.error,
-          errorMessage: failure.message,
-          clearAllMessages: true));
-    }, (_) {
-      log.info("[SettingsBloc] Palette identifier saved. Emitting new state.");
-      emit(state.copyWith(
-          paletteIdentifier: event.newIdentifier,
-          status: SettingsStatus.loaded,
-          clearAllMessages: true));
-      publishDataChangedEvent(
-          type: DataChangeType.settings, reason: DataChangeReason.updated);
-    });
+      "[SettingsBloc] Received UpdatePaletteIdentifier event: ${event.newIdentifier}",
+    );
+    final result = await _settingsRepository.savePaletteIdentifier(
+      event.newIdentifier,
+    );
+    result.fold(
+      (failure) {
+        log.warning(
+          "[SettingsBloc] Failed to save palette identifier: ${failure.message}",
+        );
+        emit(
+          state.copyWith(
+            status: SettingsStatus.error,
+            errorMessage: () => failure.message,
+            clearAllMessages: true,
+          ),
+        );
+      },
+      (_) {
+        log.info(
+          "[SettingsBloc] Palette identifier saved. Emitting new state.",
+        );
+        emit(
+          state.copyWith(
+            paletteIdentifier: event.newIdentifier,
+            status: SettingsStatus.loaded,
+            clearAllMessages: true,
+          ),
+        );
+        publishDataChangedEvent(
+          type: DataChangeType.settings,
+          reason: DataChangeReason.updated,
+        );
+      },
+    );
   }
 
   Future<void> _onUpdateUIMode(
-      UpdateUIMode event, Emitter<SettingsState> emit) async {
+    UpdateUIMode event,
+    Emitter<SettingsState> emit,
+  ) async {
     if (_demoModeService.isDemoActive) {
       log.warning("[SettingsBloc] Ignoring UpdateUIMode in Demo Mode.");
       return;
     }
     // ... rest of handler
     log.info(
-        "[SettingsBloc] Received UpdateUIMode event: ${event.newMode.name}");
+      "[SettingsBloc] Received UpdateUIMode event: ${event.newMode.name}",
+    );
     final result = await _settingsRepository.saveUIMode(event.newMode);
-    result.fold((failure) {
-      log.warning("[SettingsBloc] Failed to save UI mode: ${failure.message}");
-      emit(state.copyWith(
-          status: SettingsStatus.error,
-          errorMessage: failure.message,
-          clearAllMessages: true));
-    }, (_) {
-      log.info("[SettingsBloc] UI mode saved. Determining default palette.");
-      String defaultPalette;
-      switch (event.newMode) {
-        case UIMode.elemental:
-          defaultPalette = AppTheme.elementalPalette1;
-          break;
-        case UIMode.quantum:
-          defaultPalette = AppTheme.quantumPalette1;
-          break;
-        case UIMode.aether:
-          defaultPalette = AppTheme.aetherPalette1;
-          break;
-      }
-      log.info("[SettingsBloc] Saving default palette: $defaultPalette");
-      _settingsRepository
-          .savePaletteIdentifier(defaultPalette); // Fire and forget is ok here
+    result.fold(
+      (failure) {
+        log.warning(
+          "[SettingsBloc] Failed to save UI mode: ${failure.message}",
+        );
+        emit(
+          state.copyWith(
+            status: SettingsStatus.error,
+            errorMessage: () => failure.message,
+            clearAllMessages: true,
+          ),
+        );
+      },
+      (_) {
+        log.info("[SettingsBloc] UI mode saved. Determining default palette.");
+        String defaultPalette;
+        switch (event.newMode) {
+          case UIMode.elemental:
+            defaultPalette = AppTheme.elementalPalette1;
+            break;
+          case UIMode.quantum:
+            defaultPalette = AppTheme.quantumPalette1;
+            break;
+          case UIMode.aether:
+            defaultPalette = AppTheme.aetherPalette1;
+            break;
+        }
+        log.info("[SettingsBloc] Saving default palette: $defaultPalette");
+        _settingsRepository.savePaletteIdentifier(
+          defaultPalette,
+        ); // Fire and forget is ok here
 
-      emit(state.copyWith(
-        uiMode: event.newMode,
-        paletteIdentifier: defaultPalette, // Update palette in state too
-        status: SettingsStatus.loaded,
-        clearAllMessages: true,
-      ));
-      publishDataChangedEvent(
-          type: DataChangeType.settings, reason: DataChangeReason.updated);
-    });
+        emit(
+          state.copyWith(
+            uiMode: event.newMode,
+            paletteIdentifier: defaultPalette, // Update palette in state too
+            status: SettingsStatus.loaded,
+            clearAllMessages: true,
+          ),
+        );
+        publishDataChangedEvent(
+          type: DataChangeType.settings,
+          reason: DataChangeReason.updated,
+        );
+      },
+    );
   }
 
   Future<void> _onUpdateCountry(
-      UpdateCountry event, Emitter<SettingsState> emit) async {
+    UpdateCountry event,
+    Emitter<SettingsState> emit,
+  ) async {
     // Currency *can* be changed before entering demo
     // if (_demoModeService.isDemoActive) {
     //   log.warning("[SettingsBloc] Ignoring UpdateCountry in Demo Mode.");
@@ -277,77 +349,110 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     // }
     // ... rest of handler
     log.info(
-        "[SettingsBloc] Received UpdateCountry event: ${event.newCountryCode}");
-    final result =
-        await _settingsRepository.saveSelectedCountryCode(event.newCountryCode);
-    result.fold((failure) {
-      log.warning(
-          "[SettingsBloc] Failed to save country code: ${failure.message}");
-      emit(state.copyWith(
-          status: SettingsStatus.error,
-          errorMessage: failure.message,
-          clearAllMessages: true));
-    }, (_) {
-      log.info("[SettingsBloc] Country code saved. Emitting new state.");
-      emit(state.copyWith(
-          selectedCountryCode: event.newCountryCode,
-          status: SettingsStatus.loaded,
-          clearAllMessages: true));
-      publishDataChangedEvent(
-          type: DataChangeType.settings, reason: DataChangeReason.updated);
-    });
+      "[SettingsBloc] Received UpdateCountry event: ${event.newCountryCode}",
+    );
+    final result = await _settingsRepository.saveSelectedCountryCode(
+      event.newCountryCode,
+    );
+    result.fold(
+      (failure) {
+        log.warning(
+          "[SettingsBloc] Failed to save country code: ${failure.message}",
+        );
+        emit(
+          state.copyWith(
+            status: SettingsStatus.error,
+            errorMessage: () => failure.message,
+            clearAllMessages: true,
+          ),
+        );
+      },
+      (_) {
+        log.info("[SettingsBloc] Country code saved. Emitting new state.");
+        emit(
+          state.copyWith(
+            selectedCountryCode: event.newCountryCode,
+            status: SettingsStatus.loaded,
+            clearAllMessages: true,
+          ),
+        );
+        publishDataChangedEvent(
+          type: DataChangeType.settings,
+          reason: DataChangeReason.updated,
+        );
+      },
+    );
   }
 
   Future<void> _onUpdateAppLock(
-      UpdateAppLock event, Emitter<SettingsState> emit) async {
+    UpdateAppLock event,
+    Emitter<SettingsState> emit,
+  ) async {
     if (_demoModeService.isDemoActive) {
       log.warning("[SettingsBloc] Ignoring UpdateAppLock in Demo Mode.");
       return;
     }
-    // ... rest of handler
+    emit(
+      state.copyWith(status: SettingsStatus.loading, clearAllMessages: true),
+    );
     log.info("[SettingsBloc] Received UpdateAppLock event: ${event.isEnabled}");
-    final result =
-        await _settingsRepository.saveAppLockEnabled(event.isEnabled);
-    result.fold((failure) {
-      log.warning(
-          "[SettingsBloc] Failed to save app lock setting: ${failure.message}");
-      emit(state.copyWith(
-          status: SettingsStatus.error,
-          errorMessage: failure.message,
-          clearAllMessages: true));
-    }, (_) {
-      log.info("[SettingsBloc] App lock setting saved. Emitting new state.");
-      emit(state.copyWith(
-          isAppLockEnabled: event.isEnabled,
-          status: SettingsStatus.loaded,
-          clearAllMessages: true));
-    });
+    final result = await _toggleAppLockUseCase(event.isEnabled);
+    result.fold(
+      (failure) {
+        log.warning(
+          "[SettingsBloc] Failed to save app lock setting: ${failure.message}",
+        );
+        emit(
+          state.copyWith(
+            status: SettingsStatus.error,
+            errorMessage: () => failure.message,
+            clearAllMessages: true,
+          ),
+        );
+      },
+      (_) {
+        log.info("[SettingsBloc] App lock setting saved. Emitting new state.");
+        emit(
+          state.copyWith(
+            isAppLockEnabled: event.isEnabled,
+            status: SettingsStatus.loaded,
+            clearAllMessages: true,
+          ),
+        );
+      },
+    );
   }
 
   // --- Demo Mode Handlers ---
   void _onEnterDemoMode(EnterDemoMode event, Emitter<SettingsState> emit) {
     log.info("[SettingsBloc] Entering Demo Mode.");
     _demoModeService.enterDemoMode();
-    emit(state.copyWith(
-        isInDemoMode: true,
-        setupSkipped: false)); // Entering demo clears skip flag
+    emit(
+      state.copyWith(isInDemoMode: true, setupSkipped: false),
+    ); // Entering demo clears skip flag
     publishDataChangedEvent(
-        type: DataChangeType.system, reason: DataChangeReason.updated);
+      type: DataChangeType.system,
+      reason: DataChangeReason.updated,
+    );
   }
 
   void _onExitDemoMode(ExitDemoMode event, Emitter<SettingsState> emit) {
     log.info("[SettingsBloc] Exiting Demo Mode.");
     _demoModeService.exitDemoMode();
-    emit(state.copyWith(
-        isInDemoMode: false,
-        setupSkipped: false)); // Exiting demo clears skip flag
+    emit(
+      state.copyWith(isInDemoMode: false, setupSkipped: false),
+    ); // Exiting demo clears skip flag
     publishDataChangedEvent(
-        type: DataChangeType.system, reason: DataChangeReason.reset);
+      type: DataChangeType.system,
+      reason: DataChangeReason.reset,
+    );
   }
 
   void _onClearMessage(
-      ClearSettingsMessage event, Emitter<SettingsState> emit) {
+    ClearSettingsMessage event,
+    Emitter<SettingsState> emit,
+  ) {
     log.info("[SettingsBloc] Clearing settings message.");
-    emit(state.copyWith(clearErrorMessage: true));
+    emit(state.copyWith(errorMessage: () => null));
   }
 }

--- a/lib/features/settings/presentation/bloc/settings_state.dart
+++ b/lib/features/settings/presentation/bloc/settings_state.dart
@@ -65,14 +65,12 @@ class SettingsState extends Equatable {
     UIMode? uiMode,
     String? selectedCountryCode,
     bool? isAppLockEnabled,
-    String? errorMessage,
+    ValueGetter<String?>? errorMessage,
     bool? isInDemoMode,
     bool? setupSkipped, // ADDED
     PackageInfoStatus? packageInfoStatus,
-    String? appVersion,
-    String? packageInfoError,
-    bool clearErrorMessage = false,
-    bool clearPackageInfoError = false,
+    ValueGetter<String?>? appVersion,
+    ValueGetter<String?>? packageInfoError,
     bool clearAllMessages = false,
   }) {
     return SettingsState(
@@ -82,34 +80,38 @@ class SettingsState extends Equatable {
       uiMode: uiMode ?? this.uiMode,
       selectedCountryCode: selectedCountryCode ?? this.selectedCountryCode,
       isAppLockEnabled: isAppLockEnabled ?? this.isAppLockEnabled,
-      errorMessage: clearAllMessages || clearErrorMessage
+      errorMessage: clearAllMessages
           ? null
-          : errorMessage ?? this.errorMessage,
+          : errorMessage != null
+          ? errorMessage()
+          : this.errorMessage,
       isInDemoMode: isInDemoMode ?? this.isInDemoMode,
       setupSkipped: setupSkipped ?? this.setupSkipped, // ADDED
       packageInfoStatus: packageInfoStatus ?? this.packageInfoStatus,
-      appVersion: appVersion ?? this.appVersion,
-      packageInfoError: clearAllMessages || clearPackageInfoError
+      appVersion: appVersion != null ? appVersion() : this.appVersion,
+      packageInfoError: clearAllMessages
           ? null
-          : packageInfoError ?? this.packageInfoError,
+          : packageInfoError != null
+          ? packageInfoError()
+          : this.packageInfoError,
     );
   }
 
   // --- props ---
   @override
   List<Object?> get props => [
-        status,
-        themeMode,
-        paletteIdentifier,
-        uiMode,
-        selectedCountryCode,
-        currencySymbol,
-        isAppLockEnabled,
-        errorMessage,
-        isInDemoMode,
-        setupSkipped, // ADDED
-        packageInfoStatus,
-        appVersion,
-        packageInfoError,
-      ];
+    status,
+    themeMode,
+    paletteIdentifier,
+    uiMode,
+    selectedCountryCode,
+    currencySymbol,
+    isAppLockEnabled,
+    errorMessage,
+    isInDemoMode,
+    setupSkipped, // ADDED
+    packageInfoStatus,
+    appVersion,
+    packageInfoError,
+  ];
 }


### PR DESCRIPTION
## Summary
- inject CategoryRepository and GoalContributionLocalDataSource via constructors and service config
- move app lock authentication logic into a dedicated use case and bloc, adopting ValueGetter copyWith
- add Clock service for deterministic timestamps and migrate Android embedding to FlutterActivity

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689dc80856c883208d1475a0d4e75bea