### PR TITLE
refactor: delegate app lock handling to bloc

### DIFF
--- a/lib/core/di/service_configurations/settings_dependencies.dart
+++ b/lib/core/di/service_configurations/settings_dependencies.dart
@@ -5,20 +5,26 @@ import 'package:expense_tracker/features/settings/data/datasources/settings_loca
 import 'package:expense_tracker/features/settings/data/repositories/settings_repository_impl.dart';
 import 'package:expense_tracker/features/settings/domain/repositories/settings_repository.dart';
 import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:local_auth/local_auth.dart';
 
 class SettingsDependencies {
   static void register() {
     // Data Source
     sl.registerLazySingleton<SettingsLocalDataSource>(
-        () => SettingsLocalDataSourceImpl(prefs: sl()));
+      () => SettingsLocalDataSourceImpl(prefs: sl()),
+    );
     // Repository
     sl.registerLazySingleton<SettingsRepository>(
-        () => SettingsRepositoryImpl(localDataSource: sl()));
+      () => SettingsRepositoryImpl(localDataSource: sl()),
+    );
     // BLoC
     // Provide a single instance so router and app share the same stream
-    sl.registerLazySingleton<SettingsBloc>(() => SettingsBloc(
-          settingsRepository: sl<SettingsRepository>(),
-          demoModeService: sl<DemoModeService>(), // Provide the dependency
-        ));
+    sl.registerLazySingleton<SettingsBloc>(
+      () => SettingsBloc(
+        settingsRepository: sl<SettingsRepository>(),
+        demoModeService: sl<DemoModeService>(), // Provide the dependency
+        localAuth: LocalAuthentication(),
+      ),
+    );
   }
 }

--- a/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
+++ b/lib/features/recurring_transactions/domain/usecases/generate_transactions_on_launch.dart
@@ -75,7 +75,7 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
             isRecurring: true,
           );
           transactionResult =
-              (await addExpense(AddExpenseParams(newExpense))).map((_) => null);
+              (await addExpense(AddExpenseParams(newExpense))).map((_) {});
         } else {
           final newIncome = Income(
             id: uuid.v4(),
@@ -88,7 +88,7 @@ class GenerateTransactionsOnLaunch implements UseCase<void, NoParams> {
             isRecurring: true,
           );
           transactionResult =
-              (await addIncome(AddIncomeParams(newIncome))).map((_) => null);
+              (await addIncome(AddIncomeParams(newIncome))).map((_) {});
         }
 
         return await transactionResult.fold<Future<Either<Failure, void>>>(

--- a/lib/features/settings/presentation/bloc/settings_bloc.dart
+++ b/lib/features/settings/presentation/bloc/settings_bloc.dart
@@ -85,7 +85,6 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
         setupSkipped: false,
       ),
     );
-    // ... (rest of loading logic unchanged) ...
     PackageInfo? packageInfo;
     String? packageInfoLoadError;
     try {
@@ -197,7 +196,6 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       log.warning("[SettingsBloc] Ignoring UpdateTheme in Demo Mode.");
       return;
     }
-    // ... rest of handler
     log.info(
       "[SettingsBloc] Received UpdateTheme event: ${event.newMode.name}",
     );
@@ -238,7 +236,6 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       );
       return;
     }
-    // ... rest of handler
     log.info(
       "[SettingsBloc] Received UpdatePaletteIdentifier event: ${event.newIdentifier}",
     );
@@ -285,7 +282,6 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       log.warning("[SettingsBloc] Ignoring UpdateUIMode in Demo Mode.");
       return;
     }
-    // ... rest of handler
     log.info(
       "[SettingsBloc] Received UpdateUIMode event: ${event.newMode.name}",
     );
@@ -347,7 +343,6 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     //   log.warning("[SettingsBloc] Ignoring UpdateCountry in Demo Mode.");
     //   return;
     // }
-    // ... rest of handler
     log.info(
       "[SettingsBloc] Received UpdateCountry event: ${event.newCountryCode}",
     );

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -15,9 +15,7 @@ import 'package:expense_tracker/features/settings/presentation/widgets/about_set
 import 'package:expense_tracker/features/settings/presentation/bloc/data_management/data_management_bloc.dart';
 // Other imports
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:local_auth/local_auth.dart';
 import 'package:expense_tracker/main.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:expense_tracker/core/utils/app_dialogs.dart'; // Import AppDialogs
@@ -38,84 +36,7 @@ class SettingsView extends StatefulWidget {
 }
 
 class _SettingsViewState extends State<SettingsView> {
-  final LocalAuthentication _localAuth = LocalAuthentication();
-  bool _isAuthenticating = false;
-
-  // --- App Lock Handler (Remains in View State) ---
-  Future<void> _handleAppLockToggle(BuildContext context, bool enable) async {
-    final settingsState = context.read<SettingsBloc>().state;
-    if (settingsState.isInDemoMode) {
-      log.warning("[SettingsPage] App Lock toggle blocked in Demo Mode.");
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-          content: Text("App Lock cannot be changed in Demo Mode.")));
-      return;
-    }
-
-    log.info("[SettingsPage] App Lock toggle requested. Enable: $enable");
-    if (_isAuthenticating) return;
-    setState(() => _isAuthenticating = true);
-    try {
-      bool canAuth = false;
-      if (enable) {
-        canAuth = await _localAuth.canCheckBiometrics ||
-            await _localAuth.isDeviceSupported();
-        if (!canAuth && mounted) {
-          log.warning(
-              "[SettingsPage] Cannot enable App Lock: Biometrics/Device lock not available/setup.");
-          ScaffoldMessenger.of(context)
-            ..hideCurrentSnackBar()
-            ..showSnackBar(SnackBar(
-              content: const Text(
-                  "Cannot enable App Lock. Please set up device screen lock or biometrics first."),
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ));
-          setState(() => _isAuthenticating = false);
-          return;
-        }
-      }
-      if (mounted) {
-        log.info(
-            "[SettingsPage] Dispatching UpdateAppLock event. IsEnabled: $enable");
-        context.read<SettingsBloc>().add(UpdateAppLock(enable));
-      }
-    } on PlatformException catch (e, s) {
-      log.severe(
-          "[SettingsPage] PlatformException checking/setting App Lock: $e\n$s");
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-          ..hideCurrentSnackBar()
-          ..showSnackBar(SnackBar(
-            content: Text("Error setting App Lock: ${e.message ?? e.code}"),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ));
-        setState(() => _isAuthenticating = false);
-      }
-    } catch (e, s) {
-      log.severe(
-          "[SettingsPage] Unexpected error checking/setting App Lock: $e\n$s");
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-          ..hideCurrentSnackBar()
-          ..showSnackBar(SnackBar(
-            content:
-                const Text("An unexpected error occurred setting App Lock."),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ));
-        setState(() => _isAuthenticating = false);
-      }
-    } finally {
-      if (mounted && _isAuthenticating) {
-        // Re-check BLoC state before setting authenticating back to false
-        final finalSettingsState = context.read<SettingsBloc>().state;
-        if (finalSettingsState.status != SettingsStatus.loading) {
-          // Ensure loading is finished before resetting flag
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (mounted) setState(() => _isAuthenticating = false);
-          });
-        }
-      }
-    }
-  }
+  // Local auth and app lock handling moved to SettingsBloc
 
   // --- URL Launcher (Remains in View State) ---
   void _launchURL(BuildContext context, String urlString) async {
@@ -123,17 +44,20 @@ class _SettingsViewState extends State<SettingsView> {
     try {
       if (!await launchUrl(url, mode: LaunchMode.externalApplication)) {
         log.warning(
-            "[SettingsPage] Could not launch URL (launchUrl returned false): $urlString");
+          "[SettingsPage] Could not launch URL (launchUrl returned false): $urlString",
+        );
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('Could not open link: $urlString')));
+            SnackBar(content: Text('Could not open link: $urlString')),
+          );
         }
       }
     } catch (e, s) {
       log.severe("[SettingsPage] Error launching URL $urlString: $e\n$s");
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Error opening link: ${e.toString()}')));
+          SnackBar(content: Text('Error opening link: ${e.toString()}')),
+        );
       }
     }
   }
@@ -152,9 +76,12 @@ class _SettingsViewState extends State<SettingsView> {
             if (state.status == SettingsStatus.error && errorMsg != null) {
               ScaffoldMessenger.of(context)
                 ..hideCurrentSnackBar()
-                ..showSnackBar(SnackBar(
+                ..showSnackBar(
+                  SnackBar(
                     content: Text("Settings Error: $errorMsg"),
-                    backgroundColor: theme.colorScheme.error));
+                    backgroundColor: theme.colorScheme.error,
+                  ),
+                );
               context.read<SettingsBloc>().add(const ClearSettingsMessage());
             }
             // Handle package info errors
@@ -163,9 +90,12 @@ class _SettingsViewState extends State<SettingsView> {
                 pkgErrorMsg != null) {
               ScaffoldMessenger.of(context)
                 ..hideCurrentSnackBar()
-                ..showSnackBar(SnackBar(
+                ..showSnackBar(
+                  SnackBar(
                     content: Text("Version Info Error: $pkgErrorMsg"),
-                    backgroundColor: theme.colorScheme.error));
+                    backgroundColor: theme.colorScheme.error,
+                  ),
+                );
               // Optionally clear the error message if needed
               // context.read<SettingsBloc>().add(const ClearPackageInfoErrorMessage());
             }
@@ -181,13 +111,16 @@ class _SettingsViewState extends State<SettingsView> {
               final isError = state.status == DataManagementStatus.error;
               ScaffoldMessenger.of(context)
                 ..hideCurrentSnackBar()
-                ..showSnackBar(SnackBar(
+                ..showSnackBar(
+                  SnackBar(
                     content: Text(dataMsg),
                     backgroundColor:
-                        isError ? theme.colorScheme.error : Colors.green));
-              context
-                  .read<DataManagementBloc>()
-                  .add(const ClearDataManagementMessage());
+                        isError ? theme.colorScheme.error : Colors.green,
+                  ),
+                );
+              context.read<DataManagementBloc>().add(
+                    const ClearDataManagementMessage(),
+                  );
             }
           },
         ),
@@ -205,9 +138,8 @@ class _SettingsViewState extends State<SettingsView> {
                 settingsState.packageInfoStatus == PackageInfoStatus.loading;
             final isDataManagementLoading =
                 dataManagementState.status == DataManagementStatus.loading;
-            final isOverallLoading = isDataManagementLoading ||
-                _isAuthenticating ||
-                isSettingsLoading;
+            final isOverallLoading =
+                isDataManagementLoading || isSettingsLoading;
 
             if (settingsState.status == SettingsStatus.initial) {
               return const Center(child: CircularProgressIndicator());
@@ -221,26 +153,32 @@ class _SettingsViewState extends State<SettingsView> {
                           const EdgeInsets.only(top: 8.0, bottom: 80.0),
                   children: [
                     AppearanceSettingsSection(
-                        state: settingsState, isLoading: isOverallLoading),
+                      state: settingsState,
+                      isLoading: isOverallLoading,
+                    ),
                     GeneralSettingsSection(
-                        state: settingsState, isLoading: isOverallLoading),
+                      state: settingsState,
+                      isLoading: isOverallLoading,
+                    ),
                     SecuritySettingsSection(
-                        state: settingsState,
-                        isLoading: isOverallLoading,
-                        onAppLockToggle: _handleAppLockToggle),
+                      state: settingsState,
+                      isLoading: isOverallLoading,
+                    ),
                     DataManagementSettingsSection(
                       isDataManagementLoading: isDataManagementLoading,
                       isSettingsLoading: isSettingsLoading,
                       onBackup: () {
                         log.info(
-                            "[SettingsPage] Backup requested via section.");
-                        context
-                            .read<DataManagementBloc>()
-                            .add(const BackupRequested());
+                          "[SettingsPage] Backup requested via section.",
+                        );
+                        context.read<DataManagementBloc>().add(
+                              const BackupRequested(),
+                            );
                       },
                       onRestore: () async {
                         log.info(
-                            "[SettingsPage] Restore requested via section.");
+                          "[SettingsPage] Restore requested via section.",
+                        );
                         final confirmed = await AppDialogs.showConfirmation(
                           context,
                           title: "Confirm Restore",
@@ -250,14 +188,15 @@ class _SettingsViewState extends State<SettingsView> {
                           confirmColor: Colors.orange[700],
                         );
                         if (confirmed == true && context.mounted) {
-                          context
-                              .read<DataManagementBloc>()
-                              .add(const RestoreRequested());
+                          context.read<DataManagementBloc>().add(
+                                const RestoreRequested(),
+                              );
                         }
                       },
                       onClearData: () async {
                         log.info(
-                            "[SettingsPage] Clear data requested via section.");
+                          "[SettingsPage] Clear data requested via section.",
+                        );
                         final confirmed =
                             await AppDialogs.showStrongConfirmation(
                           context,
@@ -269,20 +208,24 @@ class _SettingsViewState extends State<SettingsView> {
                           confirmColor: Theme.of(context).colorScheme.error,
                         );
                         if (confirmed == true && context.mounted) {
-                          context
-                              .read<DataManagementBloc>()
-                              .add(const ClearDataRequested());
+                          context.read<DataManagementBloc>().add(
+                                const ClearDataRequested(),
+                              );
                         }
                       },
                     ),
                     HelpSettingsSection(
-                        isLoading: isOverallLoading,
-                        launchUrlCallback: _launchURL),
+                      isLoading: isOverallLoading,
+                      launchUrlCallback: _launchURL,
+                    ),
                     LegalSettingsSection(
-                        isLoading: isOverallLoading,
-                        launchUrlCallback: _launchURL),
+                      isLoading: isOverallLoading,
+                      launchUrlCallback: _launchURL,
+                    ),
                     AboutSettingsSection(
-                        state: settingsState, isLoading: isOverallLoading),
+                      state: settingsState,
+                      isLoading: isOverallLoading,
+                    ),
                     const SizedBox(height: 40),
                   ],
                 ),
@@ -296,21 +239,22 @@ class _SettingsViewState extends State<SettingsView> {
                         child: Card(
                           elevation: 8,
                           shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12)),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
                           child: Padding(
                             padding: const EdgeInsets.symmetric(
-                                horizontal: 32.0, vertical: 24.0),
+                              horizontal: 32.0,
+                              vertical: 24.0,
+                            ),
                             child: Column(
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 const CircularProgressIndicator(),
                                 const SizedBox(height: 20),
                                 Text(
-                                  _isAuthenticating
-                                      ? "Authenticating..."
-                                      : isDataManagementLoading
-                                          ? "Processing data..."
-                                          : "Loading settings...",
+                                  isDataManagementLoading
+                                      ? "Processing data..."
+                                      : "Loading settings...",
                                   style: theme.textTheme.titleMedium,
                                   textAlign: TextAlign.center,
                                 ),

--- a/lib/features/settings/presentation/widgets/security_settings_section.dart
+++ b/lib/features/settings/presentation/widgets/security_settings_section.dart
@@ -3,17 +3,16 @@ import 'package:expense_tracker/core/widgets/section_header.dart';
 import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:expense_tracker/features/settings/presentation/widgets/settings_list_tile.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SecuritySettingsSection extends StatelessWidget {
   final SettingsState state;
   final bool isLoading;
-  final Function(BuildContext, bool) onAppLockToggle;
 
   const SecuritySettingsSection({
     super.key,
     required this.state,
     required this.isLoading,
-    required this.onAppLockToggle,
   });
 
   @override
@@ -28,24 +27,27 @@ class SecuritySettingsSection extends StatelessWidget {
       children: [
         const SectionHeader(title: 'Security'),
         SwitchListTile(
-          secondary: Icon(Icons.security_outlined,
-              color: !isEnabled // Use combined state
-                  ? theme.disabledColor
-                  : theme.listTileTheme.iconColor),
-          title: Text('App Lock',
-              style: TextStyle(
-                  color: !isEnabled
-                      ? theme.disabledColor
-                      : null)), // Use combined state
-          subtitle: Text('Require authentication on launch/resume',
-              style: TextStyle(
-                  color: !isEnabled
-                      ? theme.disabledColor
-                      : null)), // Use combined state
+          secondary: Icon(
+            Icons.security_outlined,
+            color:
+                !isEnabled // Use combined state
+                ? theme.disabledColor
+                : theme.listTileTheme.iconColor,
+          ),
+          title: Text(
+            'App Lock',
+            style: TextStyle(color: !isEnabled ? theme.disabledColor : null),
+          ), // Use combined state
+          subtitle: Text(
+            'Require authentication on launch/resume',
+            style: TextStyle(color: !isEnabled ? theme.disabledColor : null),
+          ), // Use combined state
           value: state.isAppLockEnabled,
-          onChanged: !isEnabled // Use combined state
+          onChanged:
+              !isEnabled // Use combined state
               ? null
-              : (bool value) => onAppLockToggle(context, value),
+              : (bool value) =>
+                    context.read<SettingsBloc>().add(UpdateAppLock(value)),
           activeColor: theme.colorScheme.primary,
         ),
         SettingsListTile(
@@ -55,8 +57,10 @@ class SecuritySettingsSection extends StatelessWidget {
           subtitle: state.isInDemoMode
               ? 'Disabled in Demo Mode'
               : 'Feature coming soon',
-          trailing: Icon(Icons.chevron_right,
-              color: theme.disabledColor), // Always disabled color
+          trailing: Icon(
+            Icons.chevron_right,
+            color: theme.disabledColor,
+          ), // Always disabled color
           onTap: null, // Always disabled
         ),
       ],

--- a/lib/features/settings/presentation/widgets/security_settings_section.dart
+++ b/lib/features/settings/presentation/widgets/security_settings_section.dart
@@ -29,8 +29,7 @@ class SecuritySettingsSection extends StatelessWidget {
         SwitchListTile(
           secondary: Icon(
             Icons.security_outlined,
-            color:
-                !isEnabled // Use combined state
+            color: !isEnabled // Use combined state
                 ? theme.disabledColor
                 : theme.listTileTheme.iconColor,
           ),
@@ -43,11 +42,10 @@ class SecuritySettingsSection extends StatelessWidget {
             style: TextStyle(color: !isEnabled ? theme.disabledColor : null),
           ), // Use combined state
           value: state.isAppLockEnabled,
-          onChanged:
-              !isEnabled // Use combined state
+          onChanged: !isEnabled // Use combined state
               ? null
               : (bool value) =>
-                    context.read<SettingsBloc>().add(UpdateAppLock(value)),
+                  context.read<SettingsBloc>().add(UpdateAppLock(value)),
           activeColor: theme.colorScheme.primary,
         ),
         SettingsListTile(

--- a/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
+++ b/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
@@ -6,7 +6,6 @@ import 'package:expense_tracker/features/categories/domain/entities/category_typ
 import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
 import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
 import 'package:expense_tracker/features/expenses/domain/usecases/add_expense.dart';
-import 'package:expense_tracker/features/income/domain/entities/income.dart';
 import 'package:expense_tracker/features/income/domain/usecases/add_income.dart';
 import 'package:expense_tracker/features/income/domain/entities/income.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule.dart';
@@ -271,7 +270,8 @@ void main() {
         () => mockRecurringTransactionRepository.updateRecurringRule(any()));
   });
 
-  test('should handle monthly rule without dayOfMonth by defaulting to current day',
+  test(
+      'should handle monthly rule without dayOfMonth by defaulting to current day',
       () async {
     // Arrange
     final ruleWithoutDayOfMonth = RecurringRule(
@@ -306,10 +306,8 @@ void main() {
     await usecase(const NoParams());
 
     // Assert
-    final captured = verify(() =>
-            mockRecurringTransactionRepository.updateRecurringRule(captureAny()))
-        .captured
-        .single as RecurringRule;
+    final captured = verify(() => mockRecurringTransactionRepository
+        .updateRecurringRule(captureAny())).captured.single as RecurringRule;
     expect(captured.nextOccurrenceDate, expectedNextDate);
   });
 
@@ -349,10 +347,8 @@ void main() {
     await usecase(const NoParams());
 
     // Assert
-    final captured = verify(() =>
-            mockRecurringTransactionRepository.updateRecurringRule(captureAny()))
-        .captured
-        .single as RecurringRule;
+    final captured = verify(() => mockRecurringTransactionRepository
+        .updateRecurringRule(captureAny())).captured.single as RecurringRule;
     expect(captured.nextOccurrenceDate, expectedNextDate);
   });
 }

--- a/test/features/settings/presentation/bloc/settings_bloc_test.dart
+++ b/test/features/settings/presentation/bloc/settings_bloc_test.dart
@@ -27,10 +27,10 @@ void main() {
   });
 
   SettingsBloc buildBloc() => SettingsBloc(
-    settingsRepository: repository,
-    demoModeService: demoModeService,
-    localAuth: localAuth,
-  );
+        settingsRepository: repository,
+        demoModeService: demoModeService,
+        localAuth: localAuth,
+      );
 
   group('UpdateAppLock', () {
     blocTest<SettingsBloc, SettingsState>(

--- a/test/features/settings/presentation/bloc/settings_bloc_test.dart
+++ b/test/features/settings/presentation/bloc/settings_bloc_test.dart
@@ -1,0 +1,90 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/settings/domain/repositories/settings_repository.dart';
+import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:expense_tracker/core/services/demo_mode_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:local_auth/local_auth.dart';
+
+class MockSettingsRepository extends Mock implements SettingsRepository {}
+
+class MockDemoModeService extends Mock implements DemoModeService {}
+
+class MockLocalAuthentication extends Mock implements LocalAuthentication {}
+
+void main() {
+  late MockSettingsRepository repository;
+  late MockDemoModeService demoModeService;
+  late MockLocalAuthentication localAuth;
+
+  setUp(() {
+    repository = MockSettingsRepository();
+    demoModeService = MockDemoModeService();
+    localAuth = MockLocalAuthentication();
+    when(() => demoModeService.isDemoActive).thenReturn(false);
+  });
+
+  SettingsBloc buildBloc() => SettingsBloc(
+    settingsRepository: repository,
+    demoModeService: demoModeService,
+    localAuth: localAuth,
+  );
+
+  group('UpdateAppLock', () {
+    blocTest<SettingsBloc, SettingsState>(
+      'emits error when device lacks authentication capabilities',
+      build: () {
+        when(() => localAuth.canCheckBiometrics).thenAnswer((_) async => false);
+        when(
+          () => localAuth.isDeviceSupported(),
+        ).thenAnswer((_) async => false);
+        return buildBloc();
+      },
+      act: (bloc) => bloc.add(const UpdateAppLock(true)),
+      expect: () => [
+        const SettingsState(
+          isInDemoMode: false,
+          setupSkipped: false,
+          status: SettingsStatus.loading,
+        ),
+        const SettingsState(
+          isInDemoMode: false,
+          setupSkipped: false,
+          status: SettingsStatus.error,
+          errorMessage:
+              'Cannot enable App Lock. Please set up device screen lock or biometrics first.',
+        ),
+      ],
+    );
+
+    blocTest<SettingsBloc, SettingsState>(
+      'saves setting when authentication is available',
+      build: () {
+        when(() => localAuth.canCheckBiometrics).thenAnswer((_) async => true);
+        when(
+          () => repository.saveAppLockEnabled(true),
+        ).thenAnswer((_) async => Right<Failure, void>(null));
+        return buildBloc();
+      },
+      act: (bloc) => bloc.add(const UpdateAppLock(true)),
+      expect: () => [
+        const SettingsState(
+          isInDemoMode: false,
+          setupSkipped: false,
+          status: SettingsStatus.loading,
+        ),
+        const SettingsState(
+          isInDemoMode: false,
+          setupSkipped: false,
+          isAppLockEnabled: true,
+          status: SettingsStatus.loaded,
+        ),
+      ],
+      verify: (_) {
+        verify(() => repository.saveAppLockEnabled(true)).called(1);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- handle app-lock toggle in SettingsBloc to avoid blocking switch UI
- wire LocalAuthentication into settings dependencies
- cover app-lock flows with new SettingsBloc tests
- clean up recurring transaction generation lints

## Testing
- `flutter analyze`
- `flutter test`
