### PR TITLE
Improve sort sheet defaults and loading feedback

### DIFF
--- a/lib/core/services/downloader_service_web.dart
+++ b/lib/core/services/downloader_service_web.dart
@@ -17,7 +17,11 @@ class DownloaderServiceImpl implements DownloaderService {
       ..style.display = 'none'
       ..download = downloadName;
     html.document.body!.children.add(anchor);
-    anchor.click();
+    try {
+      anchor.click();
+    } catch (e) {
+      debugPrint('Download blocked by browser: $e');
+    }
     html.document.body!.children.remove(anchor);
     html.Url.revokeObjectUrl(url);
   }

--- a/lib/core/utils/app_dialogs.dart
+++ b/lib/core/utils/app_dialogs.dart
@@ -28,7 +28,8 @@ class AppDialogs {
             ),
             TextButton(
               style: TextButton.styleFrom(
-                  foregroundColor: confirmColor ?? theme.colorScheme.primary),
+                foregroundColor: confirmColor ?? theme.colorScheme.primary,
+              ),
               child: Text(confirmText),
               onPressed: () => Navigator.of(ctx).pop(true),
             ),
@@ -47,81 +48,110 @@ class AppDialogs {
     required String confirmationPhrase,
     Color? confirmColor,
     bool barrierDismissible = false,
-  }) async {
-    // ----------------------------------------------------------
-    final theme = Theme.of(context);
-    final controller = TextEditingController();
-    final formKey = GlobalKey<FormState>();
-
-    bool isDisposed = false;
-    void disposeController() {
-      if (!isDisposed) {
-        controller.dispose();
-        isDisposed = true;
-      }
-    }
-
+  }) {
     return showDialog<bool>(
       context: context,
       barrierDismissible: barrierDismissible,
-      builder: (BuildContext ctx) {
-        return AlertDialog(
-          title: Text(title),
-          content: StatefulBuilder(
-            builder: (context, setDialogState) {
-              return Form(
-                key: formKey,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(content, style: theme.textTheme.bodyMedium),
-                    const SizedBox(height: 15),
-                    Text('Please type "$confirmationPhrase" to confirm:',
-                        style: theme.textTheme.bodySmall),
-                    const SizedBox(height: 8),
-                    TextFormField(
-                      controller: controller,
-                      decoration: InputDecoration(
-                          hintText: confirmationPhrase,
-                          border: const OutlineInputBorder(),
-                          isDense: true),
-                      autovalidateMode: AutovalidateMode.onUserInteraction,
-                      validator: (value) => (value != confirmationPhrase)
-                          ? 'Incorrect phrase'
-                          : null,
-                      onChanged: (_) => setDialogState(() {}),
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
-          actions: <Widget>[
-            TextButton(
-              child: const Text('Cancel'),
-              onPressed: () => Navigator.of(ctx).pop(false),
+      builder: (ctx) => _StrongConfirmationDialog(
+        title: title,
+        content: content,
+        confirmText: confirmText,
+        confirmationPhrase: confirmationPhrase,
+        confirmColor: confirmColor,
+      ),
+    );
+  }
+}
+
+class _StrongConfirmationDialog extends StatefulWidget {
+  const _StrongConfirmationDialog({
+    required this.title,
+    required this.content,
+    required this.confirmText,
+    required this.confirmationPhrase,
+    this.confirmColor,
+  });
+
+  final String title;
+  final String content;
+  final String confirmText;
+  final String confirmationPhrase;
+  final Color? confirmColor;
+
+  @override
+  State<_StrongConfirmationDialog> createState() =>
+      _StrongConfirmationDialogState();
+}
+
+class _StrongConfirmationDialogState extends State<_StrongConfirmationDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      title: Text(widget.title),
+      content: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(widget.content, style: theme.textTheme.bodyMedium),
+            const SizedBox(height: 15),
+            Text(
+              'Please type "${widget.confirmationPhrase}" to confirm:',
+              style: theme.textTheme.bodySmall,
             ),
-            ValueListenableBuilder<TextEditingValue>(
-              valueListenable: controller,
-              builder: (context, value, child) {
-                return TextButton(
-                  style: TextButton.styleFrom(
-                      foregroundColor: confirmColor ?? theme.colorScheme.error),
-                  onPressed: value.text == confirmationPhrase
-                      ? () {
-                          if (formKey.currentState?.validate() ?? false) {
-                            Navigator.of(ctx).pop(true);
-                          }
-                        }
-                      : null,
-                  child: Text(confirmText),
-                );
-              },
+            const SizedBox(height: 8),
+            TextFormField(
+              controller: _controller,
+              decoration: InputDecoration(
+                hintText: widget.confirmationPhrase,
+                border: const OutlineInputBorder(),
+                isDense: true,
+              ),
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              validator: (value) => value != widget.confirmationPhrase
+                  ? 'Incorrect phrase'
+                  : null,
+              onChanged: (_) => setState(() {}),
             ),
           ],
-        );
-      },
-    ).whenComplete(disposeController);
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Cancel'),
+          onPressed: () => Navigator.of(context).pop(false),
+        ),
+        TextButton(
+          style: TextButton.styleFrom(
+            foregroundColor: widget.confirmColor ?? theme.colorScheme.error,
+          ),
+          onPressed: _controller.text == widget.confirmationPhrase
+              ? () {
+                  if (_formKey.currentState?.validate() ?? false) {
+                    Navigator.of(context).pop(true);
+                  }
+                }
+              : null,
+          child: Text(widget.confirmText),
+        ),
+      ],
+    );
   }
 }

--- a/lib/features/goals/presentation/pages/goal_detail_page.dart
+++ b/lib/features/goals/presentation/pages/goal_detail_page.dart
@@ -32,11 +32,7 @@ class GoalDetailPage extends StatefulWidget {
   final String goalId;
   final Goal? initialGoal;
 
-  const GoalDetailPage({
-    super.key,
-    required this.goalId,
-    this.initialGoal,
-  });
+  const GoalDetailPage({super.key, required this.goalId, this.initialGoal});
 
   @override
   State<GoalDetailPage> createState() => _GoalDetailPageState();
@@ -61,11 +57,13 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
   void initState() {
     super.initState();
     _currentGoal = widget.initialGoal;
-    _confettiController =
-        ConfettiController(duration: const Duration(seconds: 3));
+    _confettiController = ConfettiController(
+      duration: const Duration(seconds: 3),
+    );
     _loadData();
-    _goalListSubscription =
-        context.read<GoalListBloc>().stream.listen(_handleBlocStateChange);
+    _goalListSubscription = context.read<GoalListBloc>().stream.listen(
+      _handleBlocStateChange,
+    );
   }
 
   @override
@@ -102,48 +100,55 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
     final goalResult = await _goalRepository.getGoalById(widget.goalId);
     Goal? loadedGoal;
 
-    await goalResult.fold((failure) async {
-      log.severe(
-          "[GoalDetail] Failed to load goal details: ${failure.message}");
-      if (mounted) {
-        setState(() {
-          _error = "Failed to load goal details.";
-          _isLoadingGoal = false;
-          _isLoadingContributions = false;
-        });
-      }
-    }, (goal) async {
-      if (goal == null) {
-        log.severe("[GoalDetail] Goal ${widget.goalId} not found.");
+    await goalResult.fold(
+      (failure) async {
+        log.severe(
+          "[GoalDetail] Failed to load goal details: ${failure.message}",
+        );
         if (mounted) {
           setState(() {
-            _error = "Goal not found.";
+            _error = "Failed to load goal details.";
             _isLoadingGoal = false;
             _isLoadingContributions = false;
           });
         }
-      } else {
-        loadedGoal = goal;
-        if (mounted) {
-          setState(() {
-            _currentGoal = loadedGoal;
-            _isLoadingGoal = false;
-          });
+      },
+      (goal) async {
+        if (goal == null) {
+          log.severe("[GoalDetail] Goal ${widget.goalId} not found.");
+          if (mounted) {
+            setState(() {
+              _error = "Goal not found.";
+              _isLoadingGoal = false;
+              _isLoadingContributions = false;
+            });
+          }
+        } else {
+          loadedGoal = goal;
+          if (mounted) {
+            setState(() {
+              _currentGoal = loadedGoal;
+              _isLoadingGoal = false;
+            });
 
-          final uiMode = context.read<SettingsBloc>().state.uiMode;
-          if (_currentGoal!.isAchieved &&
-              !goalAlreadyAchievedBeforeLoad &&
-              uiMode != UIMode.quantum) {
-            log.info(
-                "[GoalDetail] Goal ${widget.goalId} newly achieved! Playing confetti.");
-            _confettiController.play();
-          } else if (!_currentGoal!.isAchieved &&
-              goalAlreadyAchievedBeforeLoad) {
-            log.info("[GoalDetail] Goal ${widget.goalId} no longer achieved.");
+            final uiMode = context.read<SettingsBloc>().state.uiMode;
+            if (_currentGoal!.isAchieved &&
+                !goalAlreadyAchievedBeforeLoad &&
+                uiMode != UIMode.quantum) {
+              log.info(
+                "[GoalDetail] Goal ${widget.goalId} newly achieved! Playing confetti.",
+              );
+              _confettiController.play();
+            } else if (!_currentGoal!.isAchieved &&
+                goalAlreadyAchievedBeforeLoad) {
+              log.info(
+                "[GoalDetail] Goal ${widget.goalId} no longer achieved.",
+              );
+            }
           }
         }
-      }
-    });
+      },
+    );
 
     if (_error != null || _currentGoal == null) {
       return; // Stop if goal loading failed
@@ -151,74 +156,96 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
 
     // Fetch Contributions
     final contributionsResult = await _getContributionsUseCase(
-        GetContributionsParams(goalId: widget.goalId));
+      GetContributionsParams(goalId: widget.goalId),
+    );
     if (!mounted) return;
 
-    contributionsResult.fold((failure) {
-      log.warning(
-          "[GoalDetail] Failed to load contributions: ${failure.message}");
-      setState(() {
-        _error = "${_error ?? ""}\nFailed to load contribution history.";
-        _isLoadingContributions = false;
-      });
-    }, (contributions) {
-      log.info("[GoalDetail] Loaded ${contributions.length} contributions.");
-      // Optimization: Only update state if the list content actually changed
-      if (!const DeepCollectionEquality()
-          .equals(_contributions, contributions)) {
+    contributionsResult.fold(
+      (failure) {
+        log.warning(
+          "[GoalDetail] Failed to load contributions: ${failure.message}",
+        );
         setState(() {
-          _contributions = contributions;
+          _error = "${_error ?? ""}\nFailed to load contribution history.";
+          _isLoadingContributions = false;
         });
-      }
-      setState(() {
-        _isLoadingContributions = false;
-      });
-    });
+      },
+      (contributions) {
+        log.info("[GoalDetail] Loaded ${contributions.length} contributions.");
+        // Optimization: Only update state if the list content actually changed
+        if (!const DeepCollectionEquality().equals(
+          _contributions,
+          contributions,
+        )) {
+          setState(() {
+            _contributions = contributions;
+          });
+        }
+        setState(() {
+          _isLoadingContributions = false;
+        });
+      },
+    );
   }
 
   void _navigateToEdit(BuildContext context) {
     // ... (no change needed) ...
     if (_currentGoal == null) return;
-    context.pushNamed(RouteNames.editGoal,
-        pathParameters: {'id': _currentGoal!.id}, extra: _currentGoal);
+    context.pushNamed(
+      RouteNames.editGoal,
+      pathParameters: {'id': _currentGoal!.id},
+      extra: _currentGoal,
+    );
   }
 
   void _handleArchive(BuildContext context) async {
     // ... (no change needed) ...
     if (_currentGoal == null) return;
-    final confirmed = await AppDialogs.showConfirmation(context,
-        title: "Confirm Archive",
-        content:
-            'Archive "${_currentGoal!.name}"? Contributions will be kept, but the goal will be hidden from the active list.',
-        confirmText: "Archive",
-        confirmColor: Colors.orange[700]);
+    final confirmed = await AppDialogs.showConfirmation(
+      context,
+      title: "Confirm Archive",
+      content:
+          'Archive "${_currentGoal!.name}"? Contributions will be kept, but the goal will be hidden from the active list.',
+      confirmText: "Archive",
+      confirmColor: Colors.orange[700],
+    );
     if (confirmed == true && context.mounted) {
       context.read<GoalListBloc>().add(ArchiveGoal(goalId: _currentGoal!.id));
       if (context.canPop()) {
         context.pop();
       } else {
-        context.go(RouteNames.budgetsAndCats,
-            extra: {'initialTabIndex': 1}); // Navigate to goals tab
+        context.go(
+          RouteNames.budgetsAndCats,
+          extra: {'initialTabIndex': 1},
+        ); // Navigate to goals tab
       }
     }
   }
 
   Future<bool?> _handleDeleteContribution(
-      BuildContext context, GoalContribution contribution) async {
+    BuildContext context,
+    GoalContribution contribution,
+  ) async {
     // ... (no change needed) ...
     final settings = context.read<SettingsBloc>().state;
-    final confirmed = await AppDialogs.showConfirmation(context,
-        title: "Delete Contribution?",
-        content:
-            "Delete contribution of ${CurrencyFormatter.format(contribution.amount, settings.currencySymbol)} made on ${DateFormatter.formatDate(contribution.date)}?",
-        confirmText: "Delete",
-        confirmColor: Theme.of(context).colorScheme.error);
+    final confirmed = await AppDialogs.showConfirmation(
+      context,
+      title: "Delete Contribution?",
+      content:
+          "Delete contribution of ${CurrencyFormatter.format(contribution.amount, settings.currencySymbol)} made on ${DateFormatter.formatDate(contribution.date)}?",
+      confirmText: "Delete",
+      confirmColor: Theme.of(context).colorScheme.error,
+    );
     if (confirmed == true && context.mounted) {
       // Use sl directly if context is problematic across async gaps
       final logContribBloc = sl<LogContributionBloc>();
       // Initialize the bloc with the contribution to be deleted
-      logContribBloc.add(InitializeContribution(
-          goalId: contribution.goalId, initialContribution: contribution));
+      logContribBloc.add(
+        InitializeContribution(
+          goalId: contribution.goalId,
+          initialContribution: contribution,
+        ),
+      );
       logContribBloc.add(const DeleteContribution());
       return true; // Indicate dialog should close
     }
@@ -226,54 +253,67 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
   }
 
   Widget _buildProgressIndicatorWidget(
-      BuildContext context, AppModeTheme? modeTheme, UIMode uiMode) {
+    BuildContext context,
+    AppModeTheme? modeTheme,
+    UIMode uiMode,
+  ) {
     // ... (no change needed) ...
     final theme = Theme.of(context);
     if (_currentGoal == null) return const SizedBox(height: 90);
     final goal = _currentGoal!;
     final progress = goal.percentageComplete;
-    final color =
-        goal.isAchieved ? Colors.green.shade600 : theme.colorScheme.primary;
-    final backgroundColor =
-        theme.colorScheme.surfaceContainerHighest.withOpacity(0.5);
+    final color = goal.isAchieved
+        ? Colors.green.shade600
+        : theme.colorScheme.primary;
+    final backgroundColor = theme.colorScheme.surfaceContainerHighest
+        .withOpacity(0.5);
     final bool isQuantum = uiMode == UIMode.quantum;
 
     final double radius = isQuantum ? 60.0 : 70.0;
     final double lineWidth = isQuantum ? 8.0 : 12.0;
-    final TextStyle centerTextStyle = (isQuantum
+    final TextStyle centerTextStyle =
+        (isQuantum
                 ? theme.textTheme.headlineSmall
                 : theme.textTheme.headlineMedium)
             ?.copyWith(fontWeight: FontWeight.bold, color: color) ??
         TextStyle(color: color);
 
     return CircularPercentIndicator(
-        radius: radius,
-        lineWidth: lineWidth,
-        animation: !isQuantum,
-        animationDuration: isQuantum ? 0 : 1000,
-        percent: progress,
-        center: Text("${(progress * 100).toStringAsFixed(0)}%",
-            style: centerTextStyle),
-        circularStrokeCap: CircularStrokeCap.round,
-        progressColor: color,
-        backgroundColor: backgroundColor);
+      radius: radius,
+      lineWidth: lineWidth,
+      animation: !isQuantum,
+      animationDuration: isQuantum ? 0 : 1000,
+      percent: progress,
+      center: Text(
+        "${(progress * 100).toStringAsFixed(0)}%",
+        style: centerTextStyle,
+      ),
+      circularStrokeCap: CircularStrokeCap.round,
+      progressColor: color,
+      backgroundColor: backgroundColor,
+    );
   }
 
   // REFINED: Contribution List/Chart Widget
   Widget _buildContributionWidget(
-      BuildContext context, AppModeTheme? modeTheme, UIMode uiMode) {
+    BuildContext context,
+    AppModeTheme? modeTheme,
+    UIMode uiMode,
+  ) {
     final theme = Theme.of(context);
     final settings = context.watch<SettingsBloc>().state;
 
     if (_isLoadingContributions) {
       return const Padding(
-          padding: EdgeInsets.symmetric(vertical: 20.0),
-          child: Center(child: CircularProgressIndicator(strokeWidth: 2)));
+        padding: EdgeInsets.symmetric(vertical: 20.0),
+        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+      );
     }
     if (_contributions.isEmpty) {
       return const Padding(
-          padding: EdgeInsets.symmetric(vertical: 24.0),
-          child: Center(child: Text("No contributions logged yet.")));
+        padding: EdgeInsets.symmetric(vertical: 24.0),
+        child: Center(child: Text("No contributions logged yet.")),
+      );
     }
 
     return Column(
@@ -304,8 +344,8 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
               ? KeyedSubtree(
                   // Use key to help AnimatedSwitcher
                   key: const ValueKey('contrib_chart'),
-                  child: SizedBox(
-                    height: 200, // Fixed height for chart
+                  child: AspectRatio(
+                    aspectRatio: 1.6,
                     child: GoalContributionChart(contributions: _contributions),
                   ),
                 )
@@ -322,10 +362,12 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
   Widget _buildContributionList(BuildContext context, SettingsState settings) {
     final bool isAether = settings.uiMode == UIMode.aether;
     final modeTheme = context.modeTheme;
-    final itemDelay =
-        isAether ? (modeTheme?.listAnimationDelay ?? 80.ms) : 50.ms;
-    final itemDuration =
-        isAether ? (modeTheme?.listAnimationDuration ?? 450.ms) : 300.ms;
+    final itemDelay = isAether
+        ? (modeTheme?.listAnimationDelay ?? 80.ms)
+        : 50.ms;
+    final itemDuration = isAether
+        ? (modeTheme?.listAnimationDuration ?? 450.ms)
+        : 300.ms;
     final theme = Theme.of(context);
 
     return ListView.separated(
@@ -335,13 +377,16 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
       itemBuilder: (ctx, index) {
         final contribution = _contributions[index];
         Widget item = ContributionListItem(
-            contribution: contribution, goalId: widget.goalId);
+          contribution: contribution,
+          goalId: widget.goalId,
+        );
 
         // --- ADDED: InkWell for Drill Down ---
         item = InkWell(
           onTap: () {
             log.info(
-                "[GoalDetail] Tapped contribution item ID: ${contribution.id}");
+              "[GoalDetail] Tapped contribution item ID: ${contribution.id}",
+            );
             showLogContributionSheet(
               context,
               contribution.goalId,
@@ -359,17 +404,21 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
             .slideY(begin: 0.1, curve: Curves.easeOut);
 
         return Dismissible(
-            key: Key('contrib_dismiss_detail_${contribution.id}'),
-            direction: DismissDirection.endToStart,
-            background: Container(
-                color: theme.colorScheme.errorContainer,
-                alignment: Alignment.centerRight,
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: Icon(Icons.delete_sweep_outlined,
-                    color: theme.colorScheme.onErrorContainer)),
-            confirmDismiss: (_) =>
-                _handleDeleteContribution(context, contribution),
-            child: item);
+          key: Key('contrib_dismiss_detail_${contribution.id}'),
+          direction: DismissDirection.endToStart,
+          background: Container(
+            color: theme.colorScheme.errorContainer,
+            alignment: Alignment.centerRight,
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Icon(
+              Icons.delete_sweep_outlined,
+              color: theme.colorScheme.onErrorContainer,
+            ),
+          ),
+          confirmDismiss: (_) =>
+              _handleDeleteContribution(context, contribution),
+          child: item,
+        );
       },
       separatorBuilder: (_, __) => const Divider(height: 1, thickness: 0.5),
     );
@@ -386,35 +435,43 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
 
     if (_isLoadingGoal) {
       return Scaffold(
-          appBar: AppBar(),
-          body: const Center(child: CircularProgressIndicator()));
+        appBar: AppBar(),
+        body: const Center(child: CircularProgressIndicator()),
+      );
     }
     if (_error != null || _currentGoal == null) {
       return Scaffold(
-          appBar: AppBar(title: const Text("Error")),
-          body: Center(
-              child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Text(_error ?? "Goal could not be loaded.",
-                      style: TextStyle(color: theme.colorScheme.error)))));
+        appBar: AppBar(title: const Text("Error")),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Text(
+              _error ?? "Goal could not be loaded.",
+              style: TextStyle(color: theme.colorScheme.error),
+            ),
+          ),
+        ),
+      );
     }
 
     final goal = _currentGoal!;
     final isAether = uiMode == UIMode.aether;
     final String? bgPath = isAether
         ? (Theme.of(context).brightness == Brightness.dark
-            ? modeTheme?.assets.mainBackgroundDark
-            : modeTheme?.assets.mainBackgroundLight)
+              ? modeTheme?.assets.mainBackgroundDark
+              : modeTheme?.assets.mainBackgroundLight)
         : null;
 
     Widget mainContent = ListView(
-      padding: modeTheme?.pagePadding.copyWith(
-              bottom: 100, // Increased padding for FAB
-              top: isAether
-                  ? (modeTheme.pagePadding.top +
+      padding:
+          modeTheme?.pagePadding.copyWith(
+            bottom: 100, // Increased padding for FAB
+            top: isAether
+                ? (modeTheme.pagePadding.top +
                       kToolbarHeight +
                       MediaQuery.of(context).padding.top)
-                  : modeTheme.pagePadding.top) ??
+                : modeTheme.pagePadding.top,
+          ) ??
           const EdgeInsets.all(16.0).copyWith(bottom: 100),
       children: [
         Center(
@@ -428,8 +485,9 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
             padding: const EdgeInsets.only(bottom: 8.0),
             child: Text(
               '${CurrencyFormatter.format(goal.totalSaved, settings.currencySymbol)} / ${CurrencyFormatter.format(goal.targetAmount, settings.currencySymbol)}',
-              style: theme.textTheme.titleLarge
-                  ?.copyWith(fontWeight: FontWeight.bold),
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
             ),
           ),
         ),
@@ -441,9 +499,10 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
                   ? 'Goal Achieved!'
                   : '${CurrencyFormatter.format(goal.amountRemaining, settings.currencySymbol)} remaining',
               style: theme.textTheme.bodyMedium?.copyWith(
-                  color: goal.isAchieved
-                      ? Colors.green
-                      : theme.colorScheme.onSurfaceVariant),
+                color: goal.isAchieved
+                    ? Colors.green
+                    : theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ),
         ),
@@ -454,14 +513,18 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Icon(Icons.flag_outlined,
-                      size: 16,
-                      color:
-                          theme.colorScheme.onSurfaceVariant.withOpacity(0.7)),
+                  Icon(
+                    Icons.flag_outlined,
+                    size: 16,
+                    color: theme.colorScheme.onSurfaceVariant.withOpacity(0.7),
+                  ),
                   const SizedBox(width: 4),
-                  Text('Target: ${DateFormatter.formatDate(goal.targetDate!)}',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant)),
+                  Text(
+                    'Target: ${DateFormatter.formatDate(goal.targetDate!)}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -469,8 +532,11 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
         if (goal.description != null && goal.description!.isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(bottom: 24.0),
-            child: Text(goal.description!,
-                style: theme.textTheme.bodyMedium, textAlign: TextAlign.center),
+            child: Text(
+              goal.description!,
+              style: theme.textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
           ),
         const SectionHeader(title: "Contribution History"),
         // --- REPLACED List with conditional Chart/List ---
@@ -487,43 +553,48 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
         actions: [
           if (!goal.isArchived)
             IconButton(
-                icon: const Icon(Icons.edit_outlined),
-                onPressed: () => _navigateToEdit(context),
-                tooltip: "Edit Goal"),
+              icon: const Icon(Icons.edit_outlined),
+              onPressed: () => _navigateToEdit(context),
+              tooltip: "Edit Goal",
+            ),
           if (!goal.isArchived)
             IconButton(
-                icon: const Icon(Icons.archive_outlined),
-                onPressed: () => _handleArchive(context),
-                tooltip: "Archive Goal"),
+              icon: const Icon(Icons.archive_outlined),
+              onPressed: () => _handleArchive(context),
+              tooltip: "Archive Goal",
+            ),
         ],
       ),
       extendBodyBehindAppBar: isAether,
-      body: Stack(alignment: Alignment.topCenter, children: [
-        if (isAether && bgPath != null && bgPath.isNotEmpty)
-          Positioned.fill(child: SvgPicture.asset(bgPath, fit: BoxFit.cover)),
-        mainContent,
-        Align(
-          alignment: Alignment.topCenter,
-          child: ConfettiWidget(
-            confettiController: _confettiController,
-            blastDirectionality: BlastDirectionality.explosive,
-            shouldLoop: false,
-            numberOfParticles: 25,
-            gravity: 0.1,
-            emissionFrequency: 0.03,
-            maxBlastForce: 7,
-            minBlastForce: 3,
-            particleDrag: 0.05,
-            colors: const [
-              Colors.green,
-              Colors.blue,
-              Colors.pink,
-              Colors.orange,
-              Colors.purple
-            ],
+      body: Stack(
+        alignment: Alignment.topCenter,
+        children: [
+          if (isAether && bgPath != null && bgPath.isNotEmpty)
+            Positioned.fill(child: SvgPicture.asset(bgPath, fit: BoxFit.cover)),
+          mainContent,
+          Align(
+            alignment: Alignment.topCenter,
+            child: ConfettiWidget(
+              confettiController: _confettiController,
+              blastDirectionality: BlastDirectionality.explosive,
+              shouldLoop: false,
+              numberOfParticles: 25,
+              gravity: 0.1,
+              emissionFrequency: 0.03,
+              maxBlastForce: 7,
+              minBlastForce: 3,
+              particleDrag: 0.05,
+              colors: const [
+                Colors.green,
+                Colors.blue,
+                Colors.pink,
+                Colors.orange,
+                Colors.purple,
+              ],
+            ),
           ),
-        ),
-      ]),
+        ],
+      ),
       floatingActionButton: goal.isAchieved || goal.isArchived
           ? null
           : FloatingActionButton.extended(

--- a/lib/features/reports/presentation/widgets/report_filter_controls.dart
+++ b/lib/features/reports/presentation/widgets/report_filter_controls.dart
@@ -15,9 +15,11 @@ class ReportFilterControls extends StatelessWidget {
     if (filterBloc.state.optionsStatus != FilterOptionsStatus.loaded) {
       filterBloc.add(const LoadFilterOptions(forceReload: true));
       // Consider showing a loading indicator briefly or disabling button until loaded
-      await filterBloc.stream.firstWhere((state) =>
-          state.optionsStatus == FilterOptionsStatus.loaded ||
-          state.optionsStatus == FilterOptionsStatus.error);
+      await filterBloc.stream.firstWhere(
+        (state) =>
+            state.optionsStatus == FilterOptionsStatus.loaded ||
+            state.optionsStatus == FilterOptionsStatus.error,
+      );
       if (!context.mounted ||
           filterBloc.state.optionsStatus == FilterOptionsStatus.error) {
         return; // Don't show sheet if loading failed
@@ -28,11 +30,14 @@ class ReportFilterControls extends StatelessWidget {
       context: context,
       isScrollControlled: true,
       shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.vertical(top: Radius.circular(20))),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
       builder: (sheetContext) {
         // Provide the SAME Filter Bloc instance down to the sheet content
         return BlocProvider.value(
-            value: filterBloc, child: const ReportFilterSheetContent());
+          value: filterBloc,
+          child: const ReportFilterSheetContent(),
+        );
       },
     );
   }
@@ -58,7 +63,7 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
   late List<String> _tempSelectedBudgetIds;
   late List<String> _tempSelectedGoalIds;
   late TransactionType?
-      _tempSelectedTransactionType; // Corrected state variable
+  _tempSelectedTransactionType; // Corrected state variable
 
   @override
   void initState() {
@@ -75,8 +80,10 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
   }
 
   Future<void> _selectDateRange(BuildContext context) async {
-    final initialRange =
-        DateTimeRange(start: _tempStartDate, end: _tempEndDate);
+    final initialRange = DateTimeRange(
+      start: _tempStartDate,
+      end: _tempEndDate,
+    );
     final DateTimeRange? picked = await showDateRangePicker(
       context: context,
       initialDateRange: initialRange,
@@ -92,13 +99,17 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
   }
 
   void _applyFilters() {
-    context.read<ReportFilterBloc>().add(UpdateReportFilters(
-          startDate: _tempStartDate, endDate: _tempEndDate,
-          categoryIds: _tempSelectedCategoryIds,
-          accountIds: _tempSelectedAccountIds,
-          budgetIds: _tempSelectedBudgetIds, goalIds: _tempSelectedGoalIds,
-          transactionType: _tempSelectedTransactionType, // Pass the value
-        ));
+    context.read<ReportFilterBloc>().add(
+      UpdateReportFilters(
+        startDate: _tempStartDate,
+        endDate: _tempEndDate,
+        categoryIds: _tempSelectedCategoryIds,
+        accountIds: _tempSelectedAccountIds,
+        budgetIds: _tempSelectedBudgetIds,
+        goalIds: _tempSelectedGoalIds,
+        transactionType: _tempSelectedTransactionType, // Pass the value
+      ),
+    );
     Navigator.pop(context);
   }
 
@@ -145,18 +156,26 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
 
         return Padding(
           padding: EdgeInsets.only(
-              bottom: MediaQuery.of(context).viewInsets.bottom + 16,
-              top: 16,
-              left: 16,
-              right: 16),
+            bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+            top: 16,
+            left: 16,
+            right: 16,
+          ),
           child: SingleChildScrollView(
             child: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Text('Filter Report Data',
-                    style: theme.textTheme.titleLarge,
-                    textAlign: TextAlign.center),
+                Text(
+                  'Filter Report Data',
+                  style: theme.textTheme.titleLarge,
+                  textAlign: TextAlign.center,
+                ),
+                if (state.optionsStatus == FilterOptionsStatus.loading)
+                  const Padding(
+                    padding: EdgeInsets.only(top: 8),
+                    child: LinearProgressIndicator(),
+                  ),
                 const SizedBox(height: 16),
 
                 // Date Range
@@ -164,12 +183,14 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                   leading: const Icon(Icons.date_range_outlined),
                   title: const Text('Date Range'),
                   subtitle: Text(
-                      '${DateFormatter.formatDate(_tempStartDate)} - ${DateFormatter.formatDate(_tempEndDate)}'),
+                    '${DateFormatter.formatDate(_tempStartDate)} - ${DateFormatter.formatDate(_tempEndDate)}',
+                  ),
                   trailing: const Icon(Icons.edit_calendar_outlined),
                   onTap: () => _selectDateRange(context),
                   shape: RoundedRectangleBorder(
-                      side: BorderSide(color: theme.dividerColor),
-                      borderRadius: BorderRadius.circular(8)),
+                    side: BorderSide(color: theme.dividerColor),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
                 ),
                 const SizedBox(height: 16),
 
@@ -179,32 +200,40 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                   decoration: InputDecoration(
                     labelText: 'Transaction Type',
                     prefixIcon: Icon(
-                        _tempSelectedTransactionType == TransactionType.expense
-                            ? Icons.arrow_downward
-                            : _tempSelectedTransactionType ==
-                                    TransactionType.income
-                                ? Icons.arrow_upward
-                                : Icons.swap_vert,
-                        size: 20),
+                      _tempSelectedTransactionType == TransactionType.expense
+                          ? Icons.arrow_downward
+                          : _tempSelectedTransactionType ==
+                                TransactionType.income
+                          ? Icons.arrow_upward
+                          : Icons.swap_vert,
+                      size: 20,
+                    ),
                     border: const OutlineInputBorder(),
                     isDense: true,
                     contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 12, vertical: 14),
+                      horizontal: 12,
+                      vertical: 14,
+                    ),
                   ),
-                  hint: const Text('All Types'), isExpanded: true,
+                  hint: const Text('All Types'),
+                  isExpanded: true,
                   items: const [
                     DropdownMenuItem<TransactionType?>(
-                        value: null, child: Text('All Types')),
+                      value: null,
+                      child: Text('All Types'),
+                    ),
                     DropdownMenuItem<TransactionType?>(
-                        value: TransactionType.expense,
-                        child: Text('Expenses Only')),
+                      value: TransactionType.expense,
+                      child: Text('Expenses Only'),
+                    ),
                     DropdownMenuItem<TransactionType?>(
-                        value: TransactionType.income,
-                        child: Text('Income Only'))
+                      value: TransactionType.income,
+                      child: Text('Income Only'),
+                    ),
                   ],
-                  onChanged: (TransactionType? newValue) => setState(() =>
-                      _tempSelectedTransactionType =
-                          newValue), // Update local temp state
+                  onChanged: (TransactionType? newValue) => setState(
+                    () => _tempSelectedTransactionType = newValue,
+                  ), // Update local temp state
                 ),
                 const SizedBox(height: 16),
 
@@ -215,15 +244,18 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                     initialValue: _tempSelectedAccountIds,
                     title: const Text("Select Accounts"),
                     buttonText: Text(
-                        _tempSelectedAccountIds.isEmpty
-                            ? "All Accounts"
-                            : "${_tempSelectedAccountIds.length} Accounts Selected",
-                        overflow: TextOverflow.ellipsis),
-                    buttonIcon:
-                        const Icon(Icons.account_balance_wallet_outlined),
+                      _tempSelectedAccountIds.isEmpty
+                          ? "All Accounts"
+                          : "${_tempSelectedAccountIds.length} Accounts Selected",
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    buttonIcon: const Icon(
+                      Icons.account_balance_wallet_outlined,
+                    ),
                     decoration: BoxDecoration(
-                        border: Border.all(color: theme.dividerColor),
-                        borderRadius: BorderRadius.circular(8)),
+                      border: Border.all(color: theme.dividerColor),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
                     chipDisplay: MultiSelectChipDisplay.none(),
                     onConfirm: (values) =>
                         setState(() => _tempSelectedAccountIds = values),
@@ -233,8 +265,10 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                 else if (state.optionsStatus == FilterOptionsStatus.loading)
                   const LinearProgressIndicator()
                 else if (state.optionsStatus == FilterOptionsStatus.error)
-                  Text("Error loading accounts",
-                      style: TextStyle(color: theme.colorScheme.error)),
+                  Text(
+                    "Error loading accounts",
+                    style: TextStyle(color: theme.colorScheme.error),
+                  ),
                 const SizedBox(height: 16),
 
                 // Category Multi-Select
@@ -244,14 +278,16 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                     initialValue: _tempSelectedCategoryIds,
                     title: const Text("Select Categories"),
                     buttonText: Text(
-                        _tempSelectedCategoryIds.isEmpty
-                            ? "All Categories"
-                            : "${_tempSelectedCategoryIds.length} Categories Selected",
-                        overflow: TextOverflow.ellipsis),
+                      _tempSelectedCategoryIds.isEmpty
+                          ? "All Categories"
+                          : "${_tempSelectedCategoryIds.length} Categories Selected",
+                      overflow: TextOverflow.ellipsis,
+                    ),
                     buttonIcon: const Icon(Icons.category_outlined),
                     decoration: BoxDecoration(
-                        border: Border.all(color: theme.dividerColor),
-                        borderRadius: BorderRadius.circular(8)),
+                      border: Border.all(color: theme.dividerColor),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
                     chipDisplay: MultiSelectChipDisplay.none(),
                     onConfirm: (values) =>
                         setState(() => _tempSelectedCategoryIds = values),
@@ -261,8 +297,10 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                 else if (state.optionsStatus == FilterOptionsStatus.loading)
                   const SizedBox.shrink()
                 else if (state.optionsStatus == FilterOptionsStatus.error)
-                  Text("Error loading categories",
-                      style: TextStyle(color: theme.colorScheme.error)),
+                  Text(
+                    "Error loading categories",
+                    style: TextStyle(color: theme.colorScheme.error),
+                  ),
                 const SizedBox(height: 16),
 
                 // Budget Multi-Select
@@ -272,14 +310,16 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                     initialValue: _tempSelectedBudgetIds,
                     title: const Text("Select Budgets (For Budget Report)"),
                     buttonText: Text(
-                        _tempSelectedBudgetIds.isEmpty
-                            ? "All Budgets"
-                            : "${_tempSelectedBudgetIds.length} Budgets Selected",
-                        overflow: TextOverflow.ellipsis),
+                      _tempSelectedBudgetIds.isEmpty
+                          ? "All Budgets"
+                          : "${_tempSelectedBudgetIds.length} Budgets Selected",
+                      overflow: TextOverflow.ellipsis,
+                    ),
                     buttonIcon: const Icon(Icons.pie_chart_outline),
                     decoration: BoxDecoration(
-                        border: Border.all(color: theme.dividerColor),
-                        borderRadius: BorderRadius.circular(8)),
+                      border: Border.all(color: theme.dividerColor),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
                     chipDisplay: MultiSelectChipDisplay.none(),
                     onConfirm: (values) =>
                         setState(() => _tempSelectedBudgetIds = values),
@@ -289,8 +329,10 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                 else if (state.optionsStatus == FilterOptionsStatus.loading)
                   const SizedBox.shrink()
                 else if (state.optionsStatus == FilterOptionsStatus.error)
-                  Text("Error loading budgets",
-                      style: TextStyle(color: theme.colorScheme.error)),
+                  Text(
+                    "Error loading budgets",
+                    style: TextStyle(color: theme.colorScheme.error),
+                  ),
                 const SizedBox(height: 16),
 
                 // Goal Multi-Select
@@ -300,14 +342,16 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                     initialValue: _tempSelectedGoalIds,
                     title: const Text("Select Goals (For Goal Report)"),
                     buttonText: Text(
-                        _tempSelectedGoalIds.isEmpty
-                            ? "All Goals"
-                            : "${_tempSelectedGoalIds.length} Goals Selected",
-                        overflow: TextOverflow.ellipsis),
+                      _tempSelectedGoalIds.isEmpty
+                          ? "All Goals"
+                          : "${_tempSelectedGoalIds.length} Goals Selected",
+                      overflow: TextOverflow.ellipsis,
+                    ),
                     buttonIcon: const Icon(Icons.savings_outlined),
                     decoration: BoxDecoration(
-                        border: Border.all(color: theme.dividerColor),
-                        borderRadius: BorderRadius.circular(8)),
+                      border: Border.all(color: theme.dividerColor),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
                     chipDisplay: MultiSelectChipDisplay.none(),
                     onConfirm: (values) =>
                         setState(() => _tempSelectedGoalIds = values),
@@ -317,27 +361,42 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                 else if (state.optionsStatus == FilterOptionsStatus.loading)
                   const SizedBox.shrink()
                 else if (state.optionsStatus == FilterOptionsStatus.error)
-                  Text("Error loading goals",
-                      style: TextStyle(color: theme.colorScheme.error)),
+                  Text(
+                    "Error loading goals",
+                    style: TextStyle(color: theme.colorScheme.error),
+                  ),
                 const SizedBox(height: 24),
 
                 // Action Buttons
                 Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      TextButton(
-                          onPressed: _clearFilters,
-                          child: const Text('Clear All')),
-                      Row(children: [
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    TextButton(
+                      onPressed: _clearFilters,
+                      child: const Text('Clear All'),
+                    ),
+                    Row(
+                      children: [
                         TextButton(
-                            onPressed: () => Navigator.pop(context),
-                            child: const Text('Cancel')),
+                          onPressed: () => Navigator.pop(context),
+                          child: const Text('Cancel'),
+                        ),
                         const SizedBox(width: 8),
                         ElevatedButton(
-                            onPressed: _applyFilters,
-                            child: const Text('Apply Filters'))
-                      ])
-                    ]),
+                          onPressed:
+                              state.optionsStatus == FilterOptionsStatus.loaded
+                              ? _applyFilters
+                              : null,
+                          child: Text(
+                            state.optionsStatus == FilterOptionsStatus.loaded
+                                ? 'Apply Filters'
+                                : 'Loading options...',
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ],
             ),
           ),

--- a/lib/features/transactions/presentation/widgets/transaction_sort_sheet.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_sort_sheet.dart
@@ -20,33 +20,46 @@ class TransactionSortSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
+    SortDirection defaultDirection(TransactionSortBy sortBy) {
+      switch (sortBy) {
+        case TransactionSortBy.date:
+        case TransactionSortBy.amount:
+          return SortDirection.descending;
+        case TransactionSortBy.category:
+        case TransactionSortBy.title:
+          return SortDirection.ascending;
+      }
+    }
+
     final sortOptions = TransactionSortBy.values.map((sortBy) {
       final bool isSelected = currentSortBy == sortBy;
+      final SortDirection defaultDir = defaultDirection(sortBy);
       final IconData directionIcon = isSelected
           ? (currentSortDirection == SortDirection.descending
               ? Icons.arrow_downward_rounded
               : Icons.arrow_upward_rounded)
-          : Icons.swap_vert_rounded; // Indicate sortable but not selected
+          : (defaultDir == SortDirection.descending
+              ? Icons.arrow_downward_rounded
+              : Icons.arrow_upward_rounded);
 
       return RadioListTile<TransactionSortBy>(
-        title: Text(
-            sortBy.name.capitalize()), // Assuming capitalize extension exists
+        title: Text(sortBy.name.capitalize()),
         value: sortBy,
         groupValue: currentSortBy,
-        secondary: Icon(directionIcon,
-            color:
-                isSelected ? theme.colorScheme.primary : theme.disabledColor),
+        secondary: Icon(
+          directionIcon,
+          color: isSelected ? theme.colorScheme.primary : theme.disabledColor,
+        ),
         activeColor: theme.colorScheme.primary,
         onChanged: (TransactionSortBy? value) {
           if (value != null) {
-            // If selecting the same criteria, toggle direction, otherwise default to descending
             final newDirection = isSelected
                 ? (currentSortDirection == SortDirection.descending
                     ? SortDirection.ascending
                     : SortDirection.descending)
-                : SortDirection.descending;
+                : defaultDirection(value);
             onApplySort(value, newDirection);
-            Navigator.pop(context); // Close sheet after selection
+            Navigator.pop(context);
           }
         },
       );
@@ -59,10 +72,14 @@ class TransactionSortSheet extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-            child:
-                Text('Sort Transactions By', style: theme.textTheme.titleLarge),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16.0,
+              vertical: 8.0,
+            ),
+            child: Text(
+              'Sort Transactions By',
+              style: theme.textTheme.titleLarge,
+            ),
           ),
           ...sortOptions,
           const SizedBox(height: 8), // Padding at bottom

--- a/test/core/utils/app_dialogs_test.dart
+++ b/test/core/utils/app_dialogs_test.dart
@@ -1,0 +1,47 @@
+import 'package:expense_tracker/core/utils/app_dialogs.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('showStrongConfirmation confirms only on exact phrase', (
+    tester,
+  ) async {
+    bool? result;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              result = await AppDialogs.showStrongConfirmation(
+                context,
+                title: 'Delete',
+                content: 'Type DELETE',
+                confirmText: 'Delete',
+                confirmationPhrase: 'DELETE',
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // Confirm button should be disabled initially
+    final confirmButton = find.widgetWithText(TextButton, 'Delete');
+    expect(tester.widget<TextButton>(confirmButton).onPressed, isNull);
+
+    await tester.enterText(find.byType(TextFormField), 'DELETE');
+    await tester.pump();
+    expect(tester.widget<TextButton>(confirmButton).onPressed, isNotNull);
+
+    await tester.tap(confirmButton);
+    await tester.pumpAndSettle();
+
+    expect(result, isTrue);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/features/reports/presentation/widgets/report_filter_controls_test.dart
+++ b/test/features/reports/presentation/widgets/report_filter_controls_test.dart
@@ -1,0 +1,50 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:expense_tracker/features/reports/presentation/bloc/report_filter/report_filter_bloc.dart';
+import 'package:expense_tracker/features/reports/presentation/widgets/report_filter_controls.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockReportFilterBloc
+    extends MockBloc<ReportFilterEvent, ReportFilterState>
+    implements ReportFilterBloc {}
+
+class FakeReportFilterEvent extends Fake implements ReportFilterEvent {}
+
+class FakeReportFilterState extends Fake implements ReportFilterState {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeReportFilterEvent());
+    registerFallbackValue(FakeReportFilterState());
+  });
+
+  testWidgets('disables apply button and shows loading indicator', (
+    tester,
+  ) async {
+    final bloc = MockReportFilterBloc();
+    when(() => bloc.state).thenReturn(
+      ReportFilterState.initial().copyWith(
+        optionsStatus: FilterOptionsStatus.loading,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BlocProvider<ReportFilterBloc>.value(
+            value: bloc,
+            child: const ReportFilterSheetContent(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(LinearProgressIndicator), findsWidgets);
+    final ElevatedButton button = tester.widget(
+      find.widgetWithText(ElevatedButton, 'Loading options...'),
+    );
+    expect(button.onPressed, isNull);
+  });
+}

--- a/test/features/transactions/presentation/widgets/transaction_sort_sheet_test.dart
+++ b/test/features/transactions/presentation/widgets/transaction_sort_sheet_test.dart
@@ -1,0 +1,43 @@
+import 'package:expense_tracker/features/transactions/domain/usecases/get_transactions_usecase.dart';
+import 'package:expense_tracker/features/transactions/presentation/widgets/transaction_sort_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows default direction icons for unselected options', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TransactionSortSheet(
+            currentSortBy: TransactionSortBy.date,
+            currentSortDirection: SortDirection.descending,
+            onApplySort: (_, __) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.arrow_downward_rounded), findsNWidgets(2));
+    expect(find.byIcon(Icons.arrow_upward_rounded), findsNWidgets(2));
+  });
+
+  test('default direction mapping works correctly', () {
+    SortDirection defaultDir(TransactionSortBy sortBy) {
+      switch (sortBy) {
+        case TransactionSortBy.date:
+        case TransactionSortBy.amount:
+          return SortDirection.descending;
+        case TransactionSortBy.category:
+        case TransactionSortBy.title:
+          return SortDirection.ascending;
+      }
+    }
+
+    expect(defaultDir(TransactionSortBy.date), SortDirection.descending);
+    expect(defaultDir(TransactionSortBy.amount), SortDirection.descending);
+    expect(defaultDir(TransactionSortBy.title), SortDirection.ascending);
+    expect(defaultDir(TransactionSortBy.category), SortDirection.ascending);
+  });
+}


### PR DESCRIPTION
## Summary
- show criterion-specific default direction icons and apply those defaults when switching sort options
- make goal contribution chart responsive using AspectRatio
- display global loading indicator and disable Apply while report filter options load
- log when browser blocks programmatic download clicks on web
- add widget tests for sort sheet and report filter controls

## Testing
- `flutter analyze lib/features/transactions/presentation/widgets/transaction_sort_sheet.dart lib/features/goals/presentation/pages/goal_detail_page.dart lib/features/reports/presentation/widgets/report_filter_controls.dart lib/core/services/downloader_service_web.dart test/features/transactions/presentation/widgets/transaction_sort_sheet_test.dart test/features/reports/presentation/widgets/report_filter_controls_test.dart`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689dc8225cec8320b91068cd4a3aa683