### PR TITLE
Fix BLoC state handling and add tests

### DIFF
--- a/lib/features/transactions/presentation/bloc/transaction_list_state.dart
+++ b/lib/features/transactions/presentation/bloc/transaction_list_state.dart
@@ -22,6 +22,8 @@ class TransactionListState extends Equatable {
   final Set<String> selectedTransactionIds;
   // Error
   final String? errorMessage;
+  // Transient error specifically for delete failures
+  final String? deleteError;
 
   const TransactionListState({
     this.status = ListStatus.initial,
@@ -37,6 +39,7 @@ class TransactionListState extends Equatable {
     this.isInBatchEditMode = false,
     this.selectedTransactionIds = const {},
     this.errorMessage,
+    this.deleteError,
   });
 
   // Helper to check if filters are applied (excluding search)
@@ -61,6 +64,7 @@ class TransactionListState extends Equatable {
     bool? isInBatchEditMode,
     Set<String>? selectedTransactionIds,
     String? errorMessage,
+    String? deleteError,
     // Flags to clear nullable fields
     bool clearStartDate = false,
     bool clearEndDate = false,
@@ -69,6 +73,7 @@ class TransactionListState extends Equatable {
     bool clearTransactionType = false,
     bool clearSearchTerm = false,
     bool clearErrorMessage = false,
+    bool clearDeleteError = false,
   }) {
     return TransactionListState(
       status: status ?? this.status,
@@ -86,25 +91,28 @@ class TransactionListState extends Equatable {
       isInBatchEditMode: isInBatchEditMode ?? this.isInBatchEditMode,
       selectedTransactionIds:
           selectedTransactionIds ?? this.selectedTransactionIds,
-      errorMessage:
-          clearErrorMessage ? null : (errorMessage ?? this.errorMessage),
+      errorMessage: clearErrorMessage
+          ? null
+          : (errorMessage ?? this.errorMessage),
+      deleteError: clearDeleteError ? null : (deleteError ?? this.deleteError),
     );
   }
 
   @override
   List<Object?> get props => [
-        status,
-        transactions,
-        startDate,
-        endDate,
-        categoryId,
-        accountId,
-        transactionType,
-        searchTerm,
-        sortBy,
-        sortDirection,
-        isInBatchEditMode,
-        selectedTransactionIds,
-        errorMessage,
-      ];
+    status,
+    transactions,
+    startDate,
+    endDate,
+    categoryId,
+    accountId,
+    transactionType,
+    searchTerm,
+    sortBy,
+    sortDirection,
+    isInBatchEditMode,
+    selectedTransactionIds,
+    errorMessage,
+    deleteError,
+  ];
 }

--- a/test/features/dashboard/domain/get_financial_overview_usecase_test.dart
+++ b/test/features/dashboard/domain/get_financial_overview_usecase_test.dart
@@ -1,0 +1,72 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/accounts/domain/repositories/asset_account_repository.dart';
+import 'package:expense_tracker/features/dashboard/domain/entities/financial_overview.dart';
+import 'package:expense_tracker/features/dashboard/domain/usecases/get_financial_overview.dart';
+import 'package:expense_tracker/features/expenses/domain/repositories/expense_repository.dart';
+import 'package:expense_tracker/features/income/domain/repositories/income_repository.dart';
+import 'package:expense_tracker/features/budgets/domain/repositories/budget_repository.dart';
+import 'package:expense_tracker/features/goals/domain/repositories/goal_repository.dart';
+import 'package:expense_tracker/features/reports/domain/repositories/report_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class MockAccountRepo extends Mock implements AssetAccountRepository {}
+
+class MockIncomeRepo extends Mock implements IncomeRepository {}
+
+class MockExpenseRepo extends Mock implements ExpenseRepository {}
+
+class MockBudgetRepo extends Mock implements BudgetRepository {}
+
+class MockGoalRepo extends Mock implements GoalRepository {}
+
+class MockReportRepo extends Mock implements ReportRepository {}
+
+void main() {
+  late MockAccountRepo accountRepo;
+  late MockIncomeRepo incomeRepo;
+  late MockExpenseRepo expenseRepo;
+  late MockBudgetRepo budgetRepo;
+  late MockGoalRepo goalRepo;
+  late MockReportRepo reportRepo;
+  late GetFinancialOverviewUseCase useCase;
+
+  setUp(() {
+    accountRepo = MockAccountRepo();
+    incomeRepo = MockIncomeRepo();
+    expenseRepo = MockExpenseRepo();
+    budgetRepo = MockBudgetRepo();
+    goalRepo = MockGoalRepo();
+    reportRepo = MockReportRepo();
+    useCase = GetFinancialOverviewUseCase(
+      accountRepository: accountRepo,
+      incomeRepository: incomeRepo,
+      expenseRepository: expenseRepo,
+      budgetRepository: budgetRepo,
+      goalRepository: goalRepo,
+    );
+  });
+
+  test('propagates failure when income repository fails', () async {
+    when(
+      () => accountRepo.getAssetAccounts(),
+    ).thenAnswer((_) async => const Right([]));
+    when(
+      () => incomeRepo.getTotalIncomeForAccount(
+        any(),
+        startDate: any(named: 'startDate'),
+        endDate: any(named: 'endDate'),
+      ),
+    ).thenAnswer((_) async => Left(ServerFailure('fail')));
+
+    final result = await useCase(
+      GetFinancialOverviewParams(
+        startDate: DateTime(2024),
+        endDate: DateTime(2024),
+      ),
+    );
+
+    expect(result, isA<Left<Failure, FinancialOverview>>());
+  });
+}

--- a/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
+++ b/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
@@ -7,6 +7,7 @@ import 'package:expense_tracker/features/categories/domain/repositories/category
 import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
 import 'package:expense_tracker/features/expenses/domain/usecases/add_expense.dart';
 import 'package:expense_tracker/features/income/domain/usecases/add_income.dart';
+import 'package:expense_tracker/features/income/domain/entities/income.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule_enums.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/repositories/recurring_transaction_repository.dart';

--- a/test/features/transactions/presentation/bloc/add_edit_transaction_bloc_test.dart
+++ b/test/features/transactions/presentation/bloc/add_edit_transaction_bloc_test.dart
@@ -1,0 +1,160 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category_type.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
+import 'package:expense_tracker/features/income/domain/entities/income.dart';
+import 'package:expense_tracker/features/expenses/domain/usecases/add_expense.dart';
+import 'package:expense_tracker/features/expenses/domain/usecases/update_expense.dart';
+import 'package:expense_tracker/features/income/domain/usecases/add_income.dart';
+import 'package:expense_tracker/features/income/domain/usecases/update_income.dart';
+import 'package:expense_tracker/features/categories/domain/usecases/categorize_transaction.dart';
+import 'package:expense_tracker/features/expenses/domain/repositories/expense_repository.dart';
+import 'package:expense_tracker/features/income/domain/repositories/income_repository.dart';
+import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
+import 'package:expense_tracker/features/transactions/presentation/bloc/add_edit_transaction/add_edit_transaction_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class MockAddExpenseUseCase extends Mock implements AddExpenseUseCase {}
+
+class MockUpdateExpenseUseCase extends Mock implements UpdateExpenseUseCase {}
+
+class MockAddIncomeUseCase extends Mock implements AddIncomeUseCase {}
+
+class MockUpdateIncomeUseCase extends Mock implements UpdateIncomeUseCase {}
+
+class MockCategorizeTransactionUseCase extends Mock
+    implements CategorizeTransactionUseCase {}
+
+class MockExpenseRepository extends Mock implements ExpenseRepository {}
+
+class MockIncomeRepository extends Mock implements IncomeRepository {}
+
+class MockCategoryRepository extends Mock implements CategoryRepository {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      AddExpenseParams(
+        Expense(
+          id: '',
+          title: '',
+          amount: 0,
+          date: DateTime(2024),
+          accountId: 'a',
+        ),
+      ),
+    );
+    registerFallbackValue(
+      UpdateExpenseParams(
+        Expense(
+          id: '',
+          title: '',
+          amount: 0,
+          date: DateTime(2024),
+          accountId: 'a',
+        ),
+      ),
+    );
+    registerFallbackValue(
+      AddIncomeParams(
+        Income(
+          id: '',
+          title: '',
+          amount: 0,
+          date: DateTime(2024),
+          accountId: 'a',
+        ),
+      ),
+    );
+    registerFallbackValue(
+      UpdateIncomeParams(
+        Income(
+          id: '',
+          title: '',
+          amount: 0,
+          date: DateTime(2024),
+          accountId: 'a',
+        ),
+      ),
+    );
+    registerFallbackValue(
+      CategorizeTransactionParams(description: '', merchantId: null),
+    );
+  });
+
+  group('AddEditTransactionBloc save failure', () {
+    late MockAddExpenseUseCase addExpense;
+    late MockUpdateExpenseUseCase updateExpense;
+    late MockAddIncomeUseCase addIncome;
+    late MockUpdateIncomeUseCase updateIncome;
+    late MockCategorizeTransactionUseCase categorize;
+    late MockExpenseRepository expenseRepo;
+    late MockIncomeRepository incomeRepo;
+    late MockCategoryRepository categoryRepo;
+
+    setUp(() {
+      addExpense = MockAddExpenseUseCase();
+      updateExpense = MockUpdateExpenseUseCase();
+      addIncome = MockAddIncomeUseCase();
+      updateIncome = MockUpdateIncomeUseCase();
+      categorize = MockCategorizeTransactionUseCase();
+      expenseRepo = MockExpenseRepository();
+      incomeRepo = MockIncomeRepository();
+      categoryRepo = MockCategoryRepository();
+    });
+
+    blocTest<AddEditTransactionBloc, AddEditTransactionState>(
+      'retains form data when save fails',
+      build: () {
+        when(
+          () => addExpense(any()),
+        ).thenAnswer((_) async => Left(ServerFailure('fail')));
+        return AddEditTransactionBloc(
+          addExpenseUseCase: addExpense,
+          updateExpenseUseCase: updateExpense,
+          addIncomeUseCase: addIncome,
+          updateIncomeUseCase: updateIncome,
+          categorizeTransactionUseCase: categorize,
+          expenseRepository: expenseRepo,
+          incomeRepository: incomeRepo,
+          categoryRepository: categoryRepo,
+        );
+      },
+      act: (bloc) => bloc.add(
+        SaveTransactionRequested(
+          title: 't',
+          amount: 1.0,
+          date: DateTime(2024),
+          category: const Category(
+            id: 'c1',
+            name: 'c',
+            iconName: 'i',
+            colorHex: '#fff',
+            type: CategoryType.expense,
+            isCustom: true,
+          ),
+          accountId: 'a',
+        ),
+      ),
+      expect: () => [
+        isA<AddEditTransactionState>().having(
+          (s) => s.status,
+          'loading',
+          AddEditStatus.loading,
+        ),
+        isA<AddEditTransactionState>().having(
+          (s) => s.status,
+          'saving',
+          AddEditStatus.saving,
+        ),
+        isA<AddEditTransactionState>()
+            .having((s) => s.status, 'error', AddEditStatus.error)
+            .having((s) => s.tempTitle, 'title persists', 't')
+            .having((s) => s.tempAmount, 'amount persists', 1.0),
+      ],
+    );
+  });
+}

--- a/test/features/transactions/presentation/bloc/transaction_list_bloc_test.dart
+++ b/test/features/transactions/presentation/bloc/transaction_list_bloc_test.dart
@@ -1,0 +1,213 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/core/events/data_change_event.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
+import 'package:expense_tracker/features/transactions/domain/entities/transaction_entity.dart';
+import 'package:expense_tracker/features/transactions/domain/usecases/get_transactions_usecase.dart';
+import 'package:expense_tracker/features/expenses/domain/usecases/delete_expense.dart';
+import 'package:expense_tracker/features/income/domain/usecases/delete_income.dart';
+import 'package:expense_tracker/features/categories/domain/usecases/apply_category_to_batch.dart';
+import 'package:expense_tracker/features/categories/domain/usecases/save_user_categorization_history.dart';
+import 'package:expense_tracker/features/expenses/domain/repositories/expense_repository.dart';
+import 'package:expense_tracker/features/income/domain/repositories/income_repository.dart';
+import 'package:expense_tracker/features/transactions/presentation/bloc/transaction_list_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class MockGetTransactionsUseCase extends Mock
+    implements GetTransactionsUseCase {}
+
+class MockDeleteExpenseUseCase extends Mock implements DeleteExpenseUseCase {}
+
+class MockDeleteIncomeUseCase extends Mock implements DeleteIncomeUseCase {}
+
+class MockApplyBatchCategoryUseCase extends Mock
+    implements ApplyCategoryToBatchUseCase {}
+
+class MockSaveUserCategorizationHistoryUseCase extends Mock
+    implements SaveUserCategorizationHistoryUseCase {}
+
+class MockExpenseRepository extends Mock implements ExpenseRepository {}
+
+class MockIncomeRepository extends Mock implements IncomeRepository {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(GetTransactionsParams());
+    registerFallbackValue(DeleteExpenseParams(''));
+    registerFallbackValue(DeleteIncomeParams(''));
+    registerFallbackValue(
+      ApplyCategoryToBatchParams(
+        transactionIds: const [],
+        categoryId: '',
+        transactionType: TransactionType.expense,
+      ),
+    );
+    registerFallbackValue(
+      SaveUserCategorizationHistoryParams(
+        transactionData: const TransactionMatchData(description: ''),
+        selectedCategory: Category.uncategorized,
+      ),
+    );
+  });
+
+  group('TransactionListBloc delete', () {
+    late MockGetTransactionsUseCase getTransactions;
+    late MockDeleteExpenseUseCase deleteExpense;
+    late MockDeleteIncomeUseCase deleteIncome;
+    late MockApplyBatchCategoryUseCase applyBatch;
+    late MockSaveUserCategorizationHistoryUseCase saveHistory;
+    late MockExpenseRepository expenseRepo;
+    late MockIncomeRepository incomeRepo;
+
+    setUp(() {
+      getTransactions = MockGetTransactionsUseCase();
+      deleteExpense = MockDeleteExpenseUseCase();
+      deleteIncome = MockDeleteIncomeUseCase();
+      applyBatch = MockApplyBatchCategoryUseCase();
+      saveHistory = MockSaveUserCategorizationHistoryUseCase();
+      expenseRepo = MockExpenseRepository();
+      incomeRepo = MockIncomeRepository();
+    });
+
+    blocTest<TransactionListBloc, TransactionListState>(
+      'emits deleteError and restores list when deletion fails',
+      build: () {
+        final bloc = TransactionListBloc(
+          getTransactionsUseCase: getTransactions,
+          deleteExpenseUseCase: deleteExpense,
+          deleteIncomeUseCase: deleteIncome,
+          applyCategoryToBatchUseCase: applyBatch,
+          saveUserHistoryUseCase: saveHistory,
+          expenseRepository: expenseRepo,
+          incomeRepository: incomeRepo,
+          dataChangeStream: const Stream<DataChangedEvent>.empty(),
+        );
+        return bloc;
+      },
+      seed: () {
+        final expense = Expense(
+          id: '1',
+          title: 't',
+          amount: 1.0,
+          date: DateTime(2024),
+          accountId: 'a',
+          category: Category.uncategorized,
+        );
+        final txn = TransactionEntity.fromExpense(expense);
+        return TransactionListState(
+          status: ListStatus.success,
+          transactions: [txn],
+        );
+      },
+      act: (bloc) {
+        when(
+          () => deleteExpense(any()),
+        ).thenAnswer((_) async => Left(ServerFailure('fail')));
+        final txn = bloc.state.transactions.first;
+        bloc.add(DeleteTransaction(txn));
+      },
+      expect: () => [
+        isA<TransactionListState>().having(
+          (s) => s.transactions.length,
+          'optimistic removal',
+          0,
+        ),
+        isA<TransactionListState>()
+            .having((s) => s.transactions.length, 'restored', 1)
+            .having((s) => s.deleteError, 'deleteError', isNotNull),
+      ],
+    );
+  });
+
+  group('TransactionListBloc batch apply', () {
+    late MockGetTransactionsUseCase getTransactions;
+    late MockDeleteExpenseUseCase deleteExpense;
+    late MockDeleteIncomeUseCase deleteIncome;
+    late MockApplyBatchCategoryUseCase applyBatch;
+    late MockSaveUserCategorizationHistoryUseCase saveHistory;
+    late MockExpenseRepository expenseRepo;
+    late MockIncomeRepository incomeRepo;
+
+    setUp(() {
+      getTransactions = MockGetTransactionsUseCase();
+      deleteExpense = MockDeleteExpenseUseCase();
+      deleteIncome = MockDeleteIncomeUseCase();
+      applyBatch = MockApplyBatchCategoryUseCase();
+      saveHistory = MockSaveUserCategorizationHistoryUseCase();
+      expenseRepo = MockExpenseRepository();
+      incomeRepo = MockIncomeRepository();
+    });
+
+    blocTest<TransactionListBloc, TransactionListState>(
+      'refreshes from repository after successful batch apply',
+      build: () {
+        when(
+          () => applyBatch(any()),
+        ).thenAnswer((_) async => const Right(null));
+        when(() => getTransactions(any())).thenAnswer(
+          (_) async => Right([
+            TransactionEntity.fromExpense(
+              Expense(
+                id: '2',
+                title: 'n',
+                amount: 2,
+                date: DateTime(2024),
+                accountId: 'a',
+                category: Category.uncategorized,
+              ),
+            ),
+          ]),
+        );
+        return TransactionListBloc(
+          getTransactionsUseCase: getTransactions,
+          deleteExpenseUseCase: deleteExpense,
+          deleteIncomeUseCase: deleteIncome,
+          applyCategoryToBatchUseCase: applyBatch,
+          saveUserHistoryUseCase: saveHistory,
+          expenseRepository: expenseRepo,
+          incomeRepository: incomeRepo,
+          dataChangeStream: const Stream<DataChangedEvent>.empty(),
+        );
+      },
+      seed: () {
+        final expense = Expense(
+          id: '1',
+          title: 't',
+          amount: 1.0,
+          date: DateTime(2024),
+          accountId: 'a',
+          category: Category.uncategorized,
+        );
+        final txn = TransactionEntity.fromExpense(expense);
+        return TransactionListState(
+          status: ListStatus.success,
+          transactions: [txn],
+          isInBatchEditMode: true,
+          selectedTransactionIds: {'1'},
+        );
+      },
+      act: (bloc) => bloc.add(const ApplyBatchCategory('cat1')),
+      expect: () => [
+        isA<TransactionListState>().having(
+          (s) => s.status,
+          'initial reloading',
+          ListStatus.reloading,
+        ),
+        isA<TransactionListState>()
+            .having((s) => s.isInBatchEditMode, 'batch off', false)
+            .having((s) => s.status, 'still reloading', ListStatus.reloading),
+        isA<TransactionListState>().having(
+          (s) => s.status,
+          'load triggered',
+          ListStatus.loading,
+        ),
+        isA<TransactionListState>()
+            .having((s) => s.status, 'loaded', ListStatus.success)
+            .having((s) => s.transactions.first.id, 'new txn id', '2'),
+      ],
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Preserve and flag delete errors without flicker in `TransactionListBloc`
- Re-fetch transactions after batch categorization instead of mutating in-memory
- Keep form data on save failure in `AddEditTransactionBloc`
- Reload budget detail page only when relevant bloc updates occur
- Propagate dashboard data load failures instead of silently defaulting

## Testing
- `flutter analyze`
- `flutter test`