### PR TITLE
Fix time handling, navigation, and loading UX; stabilize chart colors

### DIFF
--- a/lib/core/widgets/demo_indicator_widget.dart
+++ b/lib/core/widgets/demo_indicator_widget.dart
@@ -2,6 +2,7 @@ import 'package:expense_tracker/features/settings/presentation/bloc/settings_blo
 import 'package:expense_tracker/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:expense_tracker/core/utils/app_dialogs.dart';
 
 class DemoIndicatorWidget extends StatelessWidget {
   const DemoIndicatorWidget({super.key});
@@ -44,14 +45,24 @@ class DemoIndicatorWidget extends StatelessWidget {
                         foregroundColor: theme.colorScheme.onSecondaryContainer,
                         padding: const EdgeInsets.symmetric(
                             horizontal: 12, vertical: 4),
-                        minimumSize: Size.zero, // Remove extra padding
+                        minimumSize: Size.zero,
                         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                         visualDensity: VisualDensity.compact,
                       ),
-                      onPressed: () {
+                      onPressed: () async {
                         log.info("[DemoIndicator] Exit Demo button tapped.");
-                        context.read<SettingsBloc>().add(const ExitDemoMode());
-                        // Navigation is handled by the AuthWrapper/Router now based on state
+                        final confirmed = await AppDialogs.showConfirmation(
+                          context,
+                          title: 'Exit Demo Mode?',
+                          content:
+                              'This will clear demo data and restart setup. Continue?',
+                          confirmText: 'Exit',
+                        );
+                        if (confirmed == true && context.mounted) {
+                          context
+                              .read<SettingsBloc>()
+                              .add(const ExitDemoMode());
+                        }
                       },
                       child: const Text('Exit Demo'),
                     ),

--- a/lib/features/dashboard/presentation/widgets/asset_distribution_pie_chart.dart
+++ b/lib/features/dashboard/presentation/widgets/asset_distribution_pie_chart.dart
@@ -1,4 +1,5 @@
 import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:expense_tracker/main.dart'; // Import logger
 import 'package:flutter_bloc/flutter_bloc.dart'; // To read settings
@@ -16,6 +17,30 @@ class AssetDistributionPieChart extends StatefulWidget {
 class AssetDistributionPieChartState extends State<AssetDistributionPieChart> {
   int touchedIndex = -1;
   late Map<String, Color> _colorCache;
+
+  static const List<Color> colorPalette = [
+    Colors.blue,
+    Colors.red,
+    Colors.green,
+    Colors.orange,
+    Colors.purple,
+    Colors.cyan,
+    Colors.amber,
+    Colors.teal,
+    Colors.pink,
+    Colors.lime,
+  ];
+
+  @visibleForTesting
+  static Map<String, Color> generateColorMap(Iterable<String> accountNames) {
+    final map = <String, Color>{};
+    int index = 0;
+    for (final name in accountNames) {
+      map[name] = colorPalette[index % colorPalette.length];
+      index++;
+    }
+    return map;
+  }
 
   @override
   void initState() {
@@ -38,18 +63,7 @@ class AssetDistributionPieChartState extends State<AssetDistributionPieChart> {
   }
 
   void _generateColorCache(Iterable<String> accountNames) {
-    _colorCache.clear();
-    for (final name in accountNames) {
-      _colorCache[name] = _generateColorForName(name);
-    }
-  }
-
-  Color _generateColorForName(String name) {
-    final hash = name.hashCode;
-    final r = (hash & 0xFF0000) >> 16;
-    final g = (hash & 0x00FF00) >> 8;
-    final b = hash & 0x0000FF;
-    return Color.fromRGBO((r % 156) + 100, (g % 156) + 100, (b % 156) + 100, 1);
+    _colorCache = generateColorMap(accountNames);
   }
 
   @override
@@ -95,10 +109,9 @@ class AssetDistributionPieChartState extends State<AssetDistributionPieChart> {
     final double totalPositiveBalance =
         balances.fold(0.0, (sum, item) => sum + item);
 
-    // Get colors from cache/generation
-    final List<Color> sectionColors = accountNames
-        .map((name) => _colorCache[name] ?? _generateColorForName(name))
-        .toList();
+    // Get colors from cache
+    final List<Color> sectionColors =
+        accountNames.map((name) => _colorCache[name]!).toList();
 
     return Card(
       // Use Card theme

--- a/lib/features/recurring_transactions/presentation/bloc/add_edit_recurring_rule/add_edit_recurring_rule_bloc.dart
+++ b/lib/features/recurring_transactions/presentation/bloc/add_edit_recurring_rule/add_edit_recurring_rule_bloc.dart
@@ -58,6 +58,7 @@ class AddEditRecurringRuleBloc
       frequency: event.rule.frequency,
       interval: event.rule.interval,
       startDate: event.rule.startDate,
+      startTime: TimeOfDay.fromDateTime(event.rule.startDate),
       dayOfWeek: event.rule.dayOfWeek,
       dayOfMonth: event.rule.dayOfMonth,
       endConditionType: event.rule.endConditionType,
@@ -123,8 +124,8 @@ class AddEditRecurringRuleBloc
 
   void _onTotalOccurrencesChanged(
       TotalOccurrencesChanged event, Emitter<AddEditRecurringRuleState> emit) {
-    emit(state.copyWith(
-        totalOccurrences: int.tryParse(event.occurrences) ?? 0));
+    emit(
+        state.copyWith(totalOccurrences: int.tryParse(event.occurrences) ?? 0));
   }
 
   void _onDayOfWeekChanged(
@@ -137,7 +138,8 @@ class AddEditRecurringRuleBloc
     emit(state.copyWith(dayOfMonth: event.dayOfMonth));
   }
 
-  void _onTimeChanged(TimeChanged event, Emitter<AddEditRecurringRuleState> emit) {
+  void _onTimeChanged(
+      TimeChanged event, Emitter<AddEditRecurringRuleState> emit) {
     emit(state.copyWith(startTime: event.time));
   }
 
@@ -155,6 +157,14 @@ class AddEditRecurringRuleBloc
       return;
     }
 
+    final startDateTime = DateTime(
+      state.startDate.year,
+      state.startDate.month,
+      state.startDate.day,
+      state.startTime?.hour ?? 0,
+      state.startTime?.minute ?? 0,
+    );
+
     final ruleToSave = RecurringRule(
       id: state.isEditMode ? state.initialRule!.id : uuid.v4(),
       description: state.description,
@@ -164,7 +174,7 @@ class AddEditRecurringRuleBloc
       categoryId: state.categoryId!,
       frequency: state.frequency,
       interval: state.interval,
-      startDate: state.startDate,
+      startDate: startDateTime,
       dayOfWeek: state.dayOfWeek,
       dayOfMonth: state.dayOfMonth,
       endConditionType: state.endConditionType,
@@ -173,7 +183,7 @@ class AddEditRecurringRuleBloc
       status: state.isEditMode ? state.initialRule!.status : RuleStatus.active,
       nextOccurrenceDate: state.isEditMode
           ? state.initialRule!.nextOccurrenceDate
-          : state.startDate,
+          : startDateTime,
       occurrencesGenerated:
           state.isEditMode ? state.initialRule!.occurrencesGenerated : 0,
     );

--- a/lib/features/reports/presentation/widgets/report_filter_controls.dart
+++ b/lib/features/reports/presentation/widgets/report_filter_controls.dart
@@ -63,7 +63,7 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
   late List<String> _tempSelectedBudgetIds;
   late List<String> _tempSelectedGoalIds;
   late TransactionType?
-  _tempSelectedTransactionType; // Corrected state variable
+      _tempSelectedTransactionType; // Corrected state variable
 
   @override
   void initState() {
@@ -100,16 +100,16 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
 
   void _applyFilters() {
     context.read<ReportFilterBloc>().add(
-      UpdateReportFilters(
-        startDate: _tempStartDate,
-        endDate: _tempEndDate,
-        categoryIds: _tempSelectedCategoryIds,
-        accountIds: _tempSelectedAccountIds,
-        budgetIds: _tempSelectedBudgetIds,
-        goalIds: _tempSelectedGoalIds,
-        transactionType: _tempSelectedTransactionType, // Pass the value
-      ),
-    );
+          UpdateReportFilters(
+            startDate: _tempStartDate,
+            endDate: _tempEndDate,
+            categoryIds: _tempSelectedCategoryIds,
+            accountIds: _tempSelectedAccountIds,
+            budgetIds: _tempSelectedBudgetIds,
+            goalIds: _tempSelectedGoalIds,
+            transactionType: _tempSelectedTransactionType, // Pass the value
+          ),
+        );
     Navigator.pop(context);
   }
 
@@ -177,225 +177,228 @@ class _ReportFilterSheetContentState extends State<ReportFilterSheetContent> {
                     child: LinearProgressIndicator(),
                   ),
                 const SizedBox(height: 16),
-
-                // Date Range
-                ListTile(
-                  leading: const Icon(Icons.date_range_outlined),
-                  title: const Text('Date Range'),
-                  subtitle: Text(
-                    '${DateFormatter.formatDate(_tempStartDate)} - ${DateFormatter.formatDate(_tempEndDate)}',
-                  ),
-                  trailing: const Icon(Icons.edit_calendar_outlined),
-                  onTap: () => _selectDateRange(context),
-                  shape: RoundedRectangleBorder(
-                    side: BorderSide(color: theme.dividerColor),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-                const SizedBox(height: 16),
-
-                // Transaction Type Filter
-                DropdownButtonFormField<TransactionType?>(
-                  value: _tempSelectedTransactionType, // Use local temp state
-                  decoration: InputDecoration(
-                    labelText: 'Transaction Type',
-                    prefixIcon: Icon(
-                      _tempSelectedTransactionType == TransactionType.expense
-                          ? Icons.arrow_downward
-                          : _tempSelectedTransactionType ==
-                                TransactionType.income
-                          ? Icons.arrow_upward
-                          : Icons.swap_vert,
-                      size: 20,
-                    ),
-                    border: const OutlineInputBorder(),
-                    isDense: true,
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 14,
-                    ),
-                  ),
-                  hint: const Text('All Types'),
-                  isExpanded: true,
-                  items: const [
-                    DropdownMenuItem<TransactionType?>(
-                      value: null,
-                      child: Text('All Types'),
-                    ),
-                    DropdownMenuItem<TransactionType?>(
-                      value: TransactionType.expense,
-                      child: Text('Expenses Only'),
-                    ),
-                    DropdownMenuItem<TransactionType?>(
-                      value: TransactionType.income,
-                      child: Text('Income Only'),
-                    ),
-                  ],
-                  onChanged: (TransactionType? newValue) => setState(
-                    () => _tempSelectedTransactionType = newValue,
-                  ), // Update local temp state
-                ),
-                const SizedBox(height: 16),
-
-                // Account Multi-Select
-                if (state.optionsStatus == FilterOptionsStatus.loaded)
-                  MultiSelectDialogField<String>(
-                    items: accountItems,
-                    initialValue: _tempSelectedAccountIds,
-                    title: const Text("Select Accounts"),
-                    buttonText: Text(
-                      _tempSelectedAccountIds.isEmpty
-                          ? "All Accounts"
-                          : "${_tempSelectedAccountIds.length} Accounts Selected",
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    buttonIcon: const Icon(
-                      Icons.account_balance_wallet_outlined,
-                    ),
-                    decoration: BoxDecoration(
-                      border: Border.all(color: theme.dividerColor),
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    chipDisplay: MultiSelectChipDisplay.none(),
-                    onConfirm: (values) =>
-                        setState(() => _tempSelectedAccountIds = values),
-                    searchable: true,
-                    searchHint: "Search Accounts",
-                  )
-                else if (state.optionsStatus == FilterOptionsStatus.loading)
-                  const LinearProgressIndicator()
-                else if (state.optionsStatus == FilterOptionsStatus.error)
-                  Text(
-                    "Error loading accounts",
-                    style: TextStyle(color: theme.colorScheme.error),
-                  ),
-                const SizedBox(height: 16),
-
-                // Category Multi-Select
-                if (state.optionsStatus == FilterOptionsStatus.loaded)
-                  MultiSelectDialogField<String>(
-                    items: categoryItems,
-                    initialValue: _tempSelectedCategoryIds,
-                    title: const Text("Select Categories"),
-                    buttonText: Text(
-                      _tempSelectedCategoryIds.isEmpty
-                          ? "All Categories"
-                          : "${_tempSelectedCategoryIds.length} Categories Selected",
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    buttonIcon: const Icon(Icons.category_outlined),
-                    decoration: BoxDecoration(
-                      border: Border.all(color: theme.dividerColor),
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    chipDisplay: MultiSelectChipDisplay.none(),
-                    onConfirm: (values) =>
-                        setState(() => _tempSelectedCategoryIds = values),
-                    searchable: true,
-                    searchHint: "Search Categories",
-                  )
-                else if (state.optionsStatus == FilterOptionsStatus.loading)
-                  const SizedBox.shrink()
-                else if (state.optionsStatus == FilterOptionsStatus.error)
-                  Text(
-                    "Error loading categories",
-                    style: TextStyle(color: theme.colorScheme.error),
-                  ),
-                const SizedBox(height: 16),
-
-                // Budget Multi-Select
-                if (state.optionsStatus == FilterOptionsStatus.loaded)
-                  MultiSelectDialogField<String>(
-                    items: budgetItems,
-                    initialValue: _tempSelectedBudgetIds,
-                    title: const Text("Select Budgets (For Budget Report)"),
-                    buttonText: Text(
-                      _tempSelectedBudgetIds.isEmpty
-                          ? "All Budgets"
-                          : "${_tempSelectedBudgetIds.length} Budgets Selected",
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    buttonIcon: const Icon(Icons.pie_chart_outline),
-                    decoration: BoxDecoration(
-                      border: Border.all(color: theme.dividerColor),
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    chipDisplay: MultiSelectChipDisplay.none(),
-                    onConfirm: (values) =>
-                        setState(() => _tempSelectedBudgetIds = values),
-                    searchable: true,
-                    searchHint: "Search Budgets",
-                  )
-                else if (state.optionsStatus == FilterOptionsStatus.loading)
-                  const SizedBox.shrink()
-                else if (state.optionsStatus == FilterOptionsStatus.error)
-                  Text(
-                    "Error loading budgets",
-                    style: TextStyle(color: theme.colorScheme.error),
-                  ),
-                const SizedBox(height: 16),
-
-                // Goal Multi-Select
-                if (state.optionsStatus == FilterOptionsStatus.loaded)
-                  MultiSelectDialogField<String>(
-                    items: goalItems,
-                    initialValue: _tempSelectedGoalIds,
-                    title: const Text("Select Goals (For Goal Report)"),
-                    buttonText: Text(
-                      _tempSelectedGoalIds.isEmpty
-                          ? "All Goals"
-                          : "${_tempSelectedGoalIds.length} Goals Selected",
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    buttonIcon: const Icon(Icons.savings_outlined),
-                    decoration: BoxDecoration(
-                      border: Border.all(color: theme.dividerColor),
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    chipDisplay: MultiSelectChipDisplay.none(),
-                    onConfirm: (values) =>
-                        setState(() => _tempSelectedGoalIds = values),
-                    searchable: true,
-                    searchHint: "Search Goals",
-                  )
-                else if (state.optionsStatus == FilterOptionsStatus.loading)
-                  const SizedBox.shrink()
-                else if (state.optionsStatus == FilterOptionsStatus.error)
-                  Text(
-                    "Error loading goals",
-                    style: TextStyle(color: theme.colorScheme.error),
-                  ),
-                const SizedBox(height: 24),
-
-                // Action Buttons
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    TextButton(
-                      onPressed: _clearFilters,
-                      child: const Text('Clear All'),
-                    ),
-                    Row(
-                      children: [
-                        TextButton(
-                          onPressed: () => Navigator.pop(context),
-                          child: const Text('Cancel'),
+                AbsorbPointer(
+                  absorbing: state.optionsStatus == FilterOptionsStatus.loading,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // Date Range
+                      ListTile(
+                        leading: const Icon(Icons.date_range_outlined),
+                        title: const Text('Date Range'),
+                        subtitle: Text(
+                          '${DateFormatter.formatDate(_tempStartDate)} - ${DateFormatter.formatDate(_tempEndDate)}',
                         ),
-                        const SizedBox(width: 8),
-                        ElevatedButton(
-                          onPressed:
-                              state.optionsStatus == FilterOptionsStatus.loaded
-                              ? _applyFilters
-                              : null,
-                          child: Text(
-                            state.optionsStatus == FilterOptionsStatus.loaded
-                                ? 'Apply Filters'
-                                : 'Loading options...',
+                        trailing: const Icon(Icons.edit_calendar_outlined),
+                        onTap: () => _selectDateRange(context),
+                        shape: RoundedRectangleBorder(
+                          side: BorderSide(color: theme.dividerColor),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+
+                      // Transaction Type Filter
+                      DropdownButtonFormField<TransactionType?>(
+                        value:
+                            _tempSelectedTransactionType, // Use local temp state
+                        decoration: InputDecoration(
+                          labelText: 'Transaction Type',
+                          prefixIcon: Icon(
+                            _tempSelectedTransactionType ==
+                                    TransactionType.expense
+                                ? Icons.arrow_downward
+                                : _tempSelectedTransactionType ==
+                                        TransactionType.income
+                                    ? Icons.arrow_upward
+                                    : Icons.swap_vert,
+                            size: 20,
+                          ),
+                          border: const OutlineInputBorder(),
+                          isDense: true,
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                            vertical: 14,
                           ),
                         ),
-                      ],
-                    ),
-                  ],
+                        hint: const Text('All Types'),
+                        isExpanded: true,
+                        items: const [
+                          DropdownMenuItem<TransactionType?>(
+                            value: null,
+                            child: Text('All Types'),
+                          ),
+                          DropdownMenuItem<TransactionType?>(
+                            value: TransactionType.expense,
+                            child: Text('Expenses Only'),
+                          ),
+                          DropdownMenuItem<TransactionType?>(
+                            value: TransactionType.income,
+                            child: Text('Income Only'),
+                          ),
+                        ],
+                        onChanged: (TransactionType? newValue) => setState(
+                          () => _tempSelectedTransactionType = newValue,
+                        ), // Update local temp state
+                      ),
+                      const SizedBox(height: 16),
+
+                      // Account Multi-Select
+                      if (state.optionsStatus != FilterOptionsStatus.error)
+                        MultiSelectDialogField<String>(
+                          items: accountItems,
+                          initialValue: _tempSelectedAccountIds,
+                          title: const Text("Select Accounts"),
+                          buttonText: Text(
+                            _tempSelectedAccountIds.isEmpty
+                                ? "All Accounts"
+                                : "${_tempSelectedAccountIds.length} Accounts Selected",
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          buttonIcon: const Icon(
+                            Icons.account_balance_wallet_outlined,
+                          ),
+                          decoration: BoxDecoration(
+                            border: Border.all(color: theme.dividerColor),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          chipDisplay: MultiSelectChipDisplay.none(),
+                          onConfirm: (values) =>
+                              setState(() => _tempSelectedAccountIds = values),
+                          searchable: true,
+                          searchHint: "Search Accounts",
+                        )
+                      else
+                        Text(
+                          "Error loading accounts",
+                          style: TextStyle(color: theme.colorScheme.error),
+                        ),
+                      const SizedBox(height: 16),
+
+                      // Category Multi-Select
+                      if (state.optionsStatus != FilterOptionsStatus.error)
+                        MultiSelectDialogField<String>(
+                          items: categoryItems,
+                          initialValue: _tempSelectedCategoryIds,
+                          title: const Text("Select Categories"),
+                          buttonText: Text(
+                            _tempSelectedCategoryIds.isEmpty
+                                ? "All Categories"
+                                : "${_tempSelectedCategoryIds.length} Categories Selected",
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          buttonIcon: const Icon(Icons.category_outlined),
+                          decoration: BoxDecoration(
+                            border: Border.all(color: theme.dividerColor),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          chipDisplay: MultiSelectChipDisplay.none(),
+                          onConfirm: (values) =>
+                              setState(() => _tempSelectedCategoryIds = values),
+                          searchable: true,
+                          searchHint: "Search Categories",
+                        )
+                      else
+                        Text(
+                          "Error loading categories",
+                          style: TextStyle(color: theme.colorScheme.error),
+                        ),
+                      const SizedBox(height: 16),
+
+                      // Budget Multi-Select
+                      if (state.optionsStatus != FilterOptionsStatus.error)
+                        MultiSelectDialogField<String>(
+                          items: budgetItems,
+                          initialValue: _tempSelectedBudgetIds,
+                          title:
+                              const Text("Select Budgets (For Budget Report)"),
+                          buttonText: Text(
+                            _tempSelectedBudgetIds.isEmpty
+                                ? "All Budgets"
+                                : "${_tempSelectedBudgetIds.length} Budgets Selected",
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          buttonIcon: const Icon(Icons.pie_chart_outline),
+                          decoration: BoxDecoration(
+                            border: Border.all(color: theme.dividerColor),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          chipDisplay: MultiSelectChipDisplay.none(),
+                          onConfirm: (values) =>
+                              setState(() => _tempSelectedBudgetIds = values),
+                          searchable: true,
+                          searchHint: "Search Budgets",
+                        )
+                      else
+                        Text(
+                          "Error loading budgets",
+                          style: TextStyle(color: theme.colorScheme.error),
+                        ),
+                      const SizedBox(height: 16),
+
+                      // Goal Multi-Select
+                      if (state.optionsStatus != FilterOptionsStatus.error)
+                        MultiSelectDialogField<String>(
+                          items: goalItems,
+                          initialValue: _tempSelectedGoalIds,
+                          title: const Text("Select Goals (For Goal Report)"),
+                          buttonText: Text(
+                            _tempSelectedGoalIds.isEmpty
+                                ? "All Goals"
+                                : "${_tempSelectedGoalIds.length} Goals Selected",
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          buttonIcon: const Icon(Icons.savings_outlined),
+                          decoration: BoxDecoration(
+                            border: Border.all(color: theme.dividerColor),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          chipDisplay: MultiSelectChipDisplay.none(),
+                          onConfirm: (values) =>
+                              setState(() => _tempSelectedGoalIds = values),
+                          searchable: true,
+                          searchHint: "Search Goals",
+                        )
+                      else
+                        Text(
+                          "Error loading goals",
+                          style: TextStyle(color: theme.colorScheme.error),
+                        ),
+                      const SizedBox(height: 24),
+
+                      // Action Buttons
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          TextButton(
+                            onPressed: _clearFilters,
+                            child: const Text('Clear All'),
+                          ),
+                          Row(
+                            children: [
+                              TextButton(
+                                onPressed: () => Navigator.pop(context),
+                                child: const Text('Cancel'),
+                              ),
+                              const SizedBox(width: 8),
+                              ElevatedButton(
+                                onPressed: state.optionsStatus ==
+                                        FilterOptionsStatus.loaded
+                                    ? _applyFilters
+                                    : null,
+                                child: Text(
+                                  state.optionsStatus ==
+                                          FilterOptionsStatus.loaded
+                                      ? 'Apply Filters'
+                                      : 'Loading options...',
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
               ],
             ),

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -113,6 +113,12 @@ class AppRouter {
         log.info(
             "[RouterRedirect] To: $currentRoute, IsInDemo: $isInDemo, IsAuth: $isAuthenticated, IsInit: $isInitialized, SetupSkipped: $setupSkipped");
 
+        if (setupSkipped && isGoingToInitialSetup) {
+          log.info(
+              "[RouterRedirect] Setup skipped, redirecting from InitialSetup to Dashboard.");
+          return RouteNames.dashboard;
+        }
+
         // Don't redirect if settings aren't initialized unless going to setup
         if (!isInitialized && !isGoingToInitialSetup) {
           log.info(
@@ -351,7 +357,8 @@ class AppRouter {
                           const AddEditRecurringRulePage(),
                     ),
                     GoRoute(
-                      path: '${RouteNames.editRecurring}/:${RouteNames.paramId}',
+                      path:
+                          '${RouteNames.editRecurring}/:${RouteNames.paramId}',
                       name: RouteNames.editRecurring,
                       parentNavigatorKey: _rootNavigatorKey,
                       builder: (context, state) {
@@ -413,8 +420,7 @@ class AppRouter {
             child: BlocProvider<ReportFilterBloc>(
               create: (_) => filterBloc,
               child: BlocProvider<SpendingTimeReportBloc>(
-                create: (_) =>
-                    sl<SpendingTimeReportBloc>(param1: filterBloc),
+                create: (_) => sl<SpendingTimeReportBloc>(param1: filterBloc),
                 child: const SpendingOverTimePage(),
               ),
             ),
@@ -432,8 +438,7 @@ class AppRouter {
             child: BlocProvider<ReportFilterBloc>(
               create: (_) => filterBloc,
               child: BlocProvider<IncomeExpenseReportBloc>(
-                create: (_) =>
-                    sl<IncomeExpenseReportBloc>(param1: filterBloc),
+                create: (_) => sl<IncomeExpenseReportBloc>(param1: filterBloc),
                 child: const IncomeVsExpensePage(),
               ),
             ),
@@ -470,8 +475,7 @@ class AppRouter {
             child: BlocProvider<ReportFilterBloc>(
               create: (_) => filterBloc,
               child: BlocProvider<GoalProgressReportBloc>(
-                create: (_) =>
-                    sl<GoalProgressReportBloc>(param1: filterBloc),
+                create: (_) => sl<GoalProgressReportBloc>(param1: filterBloc),
                 child: const GoalProgressPage(),
               ),
             ),

--- a/test/core/widgets/demo_indicator_widget_test.dart
+++ b/test/core/widgets/demo_indicator_widget_test.dart
@@ -1,0 +1,46 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:expense_tracker/core/widgets/demo_indicator_widget.dart';
+import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
+    implements SettingsBloc {}
+
+class FakeSettingsEvent extends Fake implements SettingsEvent {}
+
+class FakeSettingsState extends Fake implements SettingsState {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeSettingsEvent());
+    registerFallbackValue(FakeSettingsState());
+  });
+
+  testWidgets('shows confirmation before exiting demo mode', (tester) async {
+    final bloc = MockSettingsBloc();
+    when(() => bloc.state).thenReturn(const SettingsState(isInDemoMode: true));
+    when(() => bloc.stream).thenAnswer((_) => const Stream.empty());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: BlocProvider<SettingsBloc>.value(
+          value: bloc,
+          child: const Scaffold(body: DemoIndicatorWidget()),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Exit Demo'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Exit Demo Mode?'), findsOneWidget);
+
+    await tester.tap(find.text('Exit'));
+    await tester.pumpAndSettle();
+
+    verify(() => bloc.add(const ExitDemoMode())).called(1);
+  });
+}

--- a/test/features/dashboard/presentation/widgets/asset_distribution_pie_chart_test.dart
+++ b/test/features/dashboard/presentation/widgets/asset_distribution_pie_chart_test.dart
@@ -1,0 +1,14 @@
+import 'package:expense_tracker/features/dashboard/presentation/widgets/asset_distribution_pie_chart.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  test('generateColorMap assigns colors sequentially', () {
+    final map = AssetDistributionPieChartState.generateColorMap(
+      ['Checking', 'Savings', 'Brokerage'],
+    );
+    expect(map['Checking'], AssetDistributionPieChartState.colorPalette[0]);
+    expect(map['Savings'], AssetDistributionPieChartState.colorPalette[1]);
+    expect(map['Brokerage'], AssetDistributionPieChartState.colorPalette[2]);
+  });
+}

--- a/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
+++ b/test/features/recurring_transactions/domain/usecases/generate_transactions_on_launch_test.dart
@@ -7,6 +7,7 @@ import 'package:expense_tracker/features/categories/domain/repositories/category
 import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
 import 'package:expense_tracker/features/expenses/domain/usecases/add_expense.dart';
 import 'package:expense_tracker/features/income/domain/usecases/add_income.dart';
+import 'package:expense_tracker/features/income/domain/entities/income.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule_enums.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/repositories/recurring_transaction_repository.dart';

--- a/test/features/reports/presentation/widgets/report_filter_controls_test.dart
+++ b/test/features/reports/presentation/widgets/report_filter_controls_test.dart
@@ -41,7 +41,7 @@ void main() {
       ),
     );
 
-    expect(find.byType(LinearProgressIndicator), findsWidgets);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
     final ElevatedButton button = tester.widget(
       find.widgetWithText(ElevatedButton, 'Loading options...'),
     );

--- a/test/router_redirect_test.dart
+++ b/test/router_redirect_test.dart
@@ -1,0 +1,51 @@
+import 'package:expense_tracker/core/constants/route_names.dart';
+import 'package:expense_tracker/core/di/service_locator.dart' as di;
+import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:expense_tracker/router.dart' deferred as app_router
+    hide StringExtension;
+
+class MockSettingsBloc extends Mock implements SettingsBloc {}
+
+class FakeBuildContext extends Fake implements BuildContext {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late MockSettingsBloc settingsBloc;
+
+  setUp(() async {
+    settingsBloc = MockSettingsBloc();
+    di.sl.registerSingleton<SettingsBloc>(settingsBloc);
+    when(() => settingsBloc.stream).thenAnswer((_) => const Stream.empty());
+    when(() => settingsBloc.state).thenReturn(
+      const SettingsState(status: SettingsStatus.loaded, setupSkipped: true),
+    );
+    await app_router.loadLibrary();
+  });
+
+  tearDown(() {
+    di.sl.reset();
+  });
+
+  test('redirects skipped setup to dashboard', () {
+    final redirect = app_router.AppRouter.router.configuration.topRedirect;
+    final routeState = GoRouterState(
+      RouteConfiguration(
+        routes: const [],
+        redirectLimit: 20,
+        topRedirect: (_, __) => null,
+        navigatorKey: GlobalKey<NavigatorState>(),
+      ),
+      uri: Uri.parse(RouteNames.initialSetup),
+      matchedLocation: RouteNames.initialSetup,
+      fullPath: RouteNames.initialSetup,
+      pathParameters: const {},
+      pageKey: const ValueKey('page'),
+    );
+    final result = redirect(FakeBuildContext(), routeState);
+    expect(result, RouteNames.dashboard);
+  });
+}


### PR DESCRIPTION
## Summary
- combine selected start date and time for recurring rules
- block navigating back to setup after skipping
- show single loading indicator and disable report filters while loading
- confirm before exiting demo mode
- use fixed color palette for asset distribution chart

## Testing
- `flutter analyze`
- `flutter test`