### PR TITLE
refactor: centralize failure message mapping

### DIFF
--- a/lib/core/error/failure_extensions.dart
+++ b/lib/core/error/failure_extensions.dart
@@ -1,0 +1,27 @@
+import 'failure.dart';
+
+extension FailureMessage on Failure {
+  String toDisplayMessage({String? context}) {
+    String specificMessage;
+    switch (runtimeType) {
+      case CacheFailure:
+      case SettingsFailure:
+        specificMessage = 'Database Error: $message';
+        break;
+      case ValidationFailure:
+        specificMessage = message;
+        break;
+      case UnexpectedFailure:
+        specificMessage = 'An unexpected error occurred. Please try again.';
+        break;
+      default:
+        specificMessage = message.isNotEmpty
+            ? message
+            : 'An unknown error occurred.';
+    }
+    if (context != null && context.isNotEmpty) {
+      return '$context: $specificMessage';
+    }
+    return specificMessage;
+  }
+}

--- a/lib/features/accounts/presentation/bloc/account_list/account_list_bloc.dart
+++ b/lib/features/accounts/presentation/bloc/account_list/account_list_bloc.dart
@@ -5,6 +5,7 @@ import 'package:equatable/equatable.dart';
 import 'package:expense_tracker/core/common/base_list_state.dart';
 import 'package:expense_tracker/main.dart'; // Import logger
 import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/core/error/failure_extensions.dart';
 import 'package:expense_tracker/core/usecases/usecase.dart'; // For NoParams
 import 'package:expense_tracker/features/accounts/domain/entities/asset_account.dart';
 import 'package:expense_tracker/features/accounts/domain/usecases/delete_asset_account.dart';
@@ -24,33 +25,38 @@ class AccountListBloc extends Bloc<AccountListEvent, AccountListState> {
     required GetAssetAccountsUseCase getAssetAccountsUseCase,
     required DeleteAssetAccountUseCase deleteAssetAccountUseCase,
     required Stream<DataChangedEvent> dataChangeStream,
-  })  : _getAssetAccountsUseCase = getAssetAccountsUseCase,
-        _deleteAssetAccountUseCase = deleteAssetAccountUseCase,
-        super(const AccountListInitial()) {
+  }) : _getAssetAccountsUseCase = getAssetAccountsUseCase,
+       _deleteAssetAccountUseCase = deleteAssetAccountUseCase,
+       super(const AccountListInitial()) {
     on<LoadAccounts>(_onLoadAccounts);
     on<DeleteAccountRequested>(_onDeleteAccountRequested);
     on<_DataChanged>(_onDataChanged);
     on<ResetState>(_onResetState); // Add handler
 
-    _dataChangeSubscription = dataChangeStream.listen((event) {
-      // --- Listen for System Reset ---
-      if (event.type == DataChangeType.system &&
-          event.reason == DataChangeReason.reset) {
-        log.info(
-            "[AccountListBloc] System Reset event received. Adding ResetState.");
-        add(const ResetState());
-      } else if (event.type == DataChangeType.account ||
-          event.type == DataChangeType.income ||
-          event.type == DataChangeType.expense ||
-          event.type == DataChangeType.settings) {
-        log.info(
-            "[AccountListBloc] Relevant DataChangedEvent: $event. Triggering reload.");
-        add(const _DataChanged());
-      }
-      // --- End System Reset Handling ---
-    }, onError: (error, stackTrace) {
-      log.severe("[AccountListBloc] Error in dataChangeStream listener");
-    });
+    _dataChangeSubscription = dataChangeStream.listen(
+      (event) {
+        // --- Listen for System Reset ---
+        if (event.type == DataChangeType.system &&
+            event.reason == DataChangeReason.reset) {
+          log.info(
+            "[AccountListBloc] System Reset event received. Adding ResetState.",
+          );
+          add(const ResetState());
+        } else if (event.type == DataChangeType.account ||
+            event.type == DataChangeType.income ||
+            event.type == DataChangeType.expense ||
+            event.type == DataChangeType.settings) {
+          log.info(
+            "[AccountListBloc] Relevant DataChangedEvent: $event. Triggering reload.",
+          );
+          add(const _DataChanged());
+        }
+        // --- End System Reset Handling ---
+      },
+      onError: (error, stackTrace) {
+        log.severe("[AccountListBloc] Error in dataChangeStream listener");
+      },
+    );
 
     log.info("[AccountListBloc] Initialized and subscribed to data changes.");
   }
@@ -67,131 +73,142 @@ class AccountListBloc extends Bloc<AccountListEvent, AccountListState> {
   // ... rest of the handlers (_onDataChanged, _onLoadAccounts, _onDeleteAccountRequested, _mapFailureToMessage, close) remain the same ...
   // Internal event handler to trigger reload
   Future<void> _onDataChanged(
-      _DataChanged event, Emitter<AccountListState> emit) async {
+    _DataChanged event,
+    Emitter<AccountListState> emit,
+  ) async {
     if (state is! AccountListLoading) {
       log.info(
-          "[AccountListBloc] Handling _DataChanged event. Dispatching LoadAccounts(forceReload: true).");
+        "[AccountListBloc] Handling _DataChanged event. Dispatching LoadAccounts(forceReload: true).",
+      );
       add(const LoadAccounts(forceReload: true));
     }
   }
 
   Future<void> _onLoadAccounts(
-      LoadAccounts event, Emitter<AccountListState> emit) async {
+    LoadAccounts event,
+    Emitter<AccountListState> emit,
+  ) async {
     log.info(
-        "[AccountListBloc] Received LoadAccounts event (forceReload: ${event.forceReload}). Current state: ${state.runtimeType}");
+      "[AccountListBloc] Received LoadAccounts event (forceReload: ${event.forceReload}). Current state: ${state.runtimeType}",
+    );
 
     if (state is! AccountListLoaded || event.forceReload) {
       emit(AccountListLoading(isReloading: state is AccountListLoaded));
       log.info(
-          "[AccountListBloc] Emitting AccountListLoading (isReloading: ${state is AccountListLoaded}).");
+        "[AccountListBloc] Emitting AccountListLoading (isReloading: ${state is AccountListLoaded}).",
+      );
     } else {
       log.info(
-          "[AccountListBloc] State is AccountListLoaded and no force reload. Refreshing data silently.");
+        "[AccountListBloc] State is AccountListLoaded and no force reload. Refreshing data silently.",
+      );
     }
 
     try {
       final result = await _getAssetAccountsUseCase(const NoParams());
       log.info(
-          "[AccountListBloc] GetAssetAccountsUseCase returned. isLeft: ${result.isLeft()}");
+        "[AccountListBloc] GetAssetAccountsUseCase returned. isLeft: ${result.isLeft()}",
+      );
 
       result.fold(
         (failure) {
           log.warning(
-              "[AccountListBloc] Load failed: ${failure.message}. Emitting AccountListError.");
-          emit(AccountListError(_mapFailureToMessage(failure)));
+            "[AccountListBloc] Load failed: ${failure.message}. Emitting AccountListError.",
+          );
+          emit(AccountListError(failure.toDisplayMessage()));
         },
         (accounts) {
           log.info(
-              "[AccountListBloc] Load successful. Emitting AccountListLoaded with ${accounts.length} accounts.");
+            "[AccountListBloc] Load successful. Emitting AccountListLoaded with ${accounts.length} accounts.",
+          );
           emit(AccountListLoaded(accounts: accounts));
         },
       );
     } catch (e) {
       log.severe("[AccountListBloc] Unexpected error in _onLoadAccounts");
-      emit(AccountListError(
-          "An unexpected error occurred while loading accounts: ${e.toString()}"));
+      emit(
+        AccountListError(
+          "An unexpected error occurred while loading accounts: ${e.toString()}",
+        ),
+      );
     }
   }
 
   Future<void> _onDeleteAccountRequested(
-      DeleteAccountRequested event, Emitter<AccountListState> emit) async {
+    DeleteAccountRequested event,
+    Emitter<AccountListState> emit,
+  ) async {
     log.info(
-        "[AccountListBloc] Received DeleteAccountRequested for ID: ${event.accountId}");
+      "[AccountListBloc] Received DeleteAccountRequested for ID: ${event.accountId}",
+    );
     final currentState = state;
 
     if (currentState is AccountListLoaded) {
       log.info(
-          "[AccountListBloc] Current state is Loaded. Performing optimistic delete.");
+        "[AccountListBloc] Current state is Loaded. Performing optimistic delete.",
+      );
       // Optimistic UI Update using 'items' from base state
-      final optimisticList =
-          currentState.items.where((acc) => acc.id != event.accountId).toList();
+      final optimisticList = currentState.items
+          .where((acc) => acc.id != event.accountId)
+          .toList();
       log.info(
-          "[AccountListBloc] Optimistic list size: ${optimisticList.length}. Emitting updated AccountListLoaded.");
+        "[AccountListBloc] Optimistic list size: ${optimisticList.length}. Emitting updated AccountListLoaded.",
+      );
       emit(AccountListLoaded(accounts: optimisticList));
 
       try {
         final result = await _deleteAssetAccountUseCase(
-            DeleteAssetAccountParams(event.accountId));
+          DeleteAssetAccountParams(event.accountId),
+        );
         log.info(
-            "[AccountListBloc] DeleteAssetAccountUseCase returned. isLeft: ${result.isLeft()}");
+          "[AccountListBloc] DeleteAssetAccountUseCase returned. isLeft: ${result.isLeft()}",
+        );
 
         result.fold(
           (failure) {
             log.warning(
-                "[AccountListBloc] Deletion failed: ${failure.message}. Reverting to previous state.");
-            emit(AccountListError(_mapFailureToMessage(failure,
-                context: "Failed to delete account")));
+              "[AccountListBloc] Deletion failed: ${failure.message}. Reverting to previous state.",
+            );
+            emit(
+              AccountListError(
+                failure.toDisplayMessage(context: "Failed to delete account"),
+              ),
+            );
             emit(currentState);
           },
           (_) {
             log.info(
-                "[AccountListBloc] Deletion successful. Publishing DataChangedEvent.");
+              "[AccountListBloc] Deletion successful. Publishing DataChangedEvent.",
+            );
             publishDataChangedEvent(
-                type: DataChangeType.account, reason: DataChangeReason.deleted);
+              type: DataChangeType.account,
+              reason: DataChangeReason.deleted,
+            );
           },
         );
       } catch (e) {
         log.severe(
-            "[AccountListBloc] Unexpected error in _onDeleteAccountRequested for ID ${event.accountId}");
-        emit(AccountListError(
-            "An unexpected error occurred during deletion: ${e.toString()}"));
+          "[AccountListBloc] Unexpected error in _onDeleteAccountRequested for ID ${event.accountId}",
+        );
+        emit(
+          AccountListError(
+            "An unexpected error occurred during deletion: ${e.toString()}",
+          ),
+        );
         emit(currentState); // Revert optimistic update
       }
     } else {
       log.warning(
-          "[AccountListBloc] Delete requested but state is not AccountListLoaded. Ignoring.");
+        "[AccountListBloc] Delete requested but state is not AccountListLoaded. Ignoring.",
+      );
     }
-  }
-
-  String _mapFailureToMessage(Failure failure,
-      {String context = "An error occurred"}) {
-    log.warning(
-        "[AccountListBloc] Mapping failure: ${failure.runtimeType} - ${failure.message}");
-    String specificMessage;
-    switch (failure.runtimeType) {
-      case CacheFailure:
-        specificMessage = 'Database Error: ${failure.message}';
-        break;
-      case ValidationFailure:
-        specificMessage = failure.message;
-        break;
-      case UnexpectedFailure:
-        specificMessage = 'An unexpected error occurred. Please try again.';
-        break;
-      default:
-        specificMessage = failure.message.isNotEmpty
-            ? failure.message
-            : 'An unknown error occurred.';
-        break;
-    }
-    return "$context: $specificMessage";
   }
 
   @override
   Future<void> close() {
     _dataChangeSubscription.cancel();
     log.info(
-        "[AccountListBloc] Canceled data change subscription and closing.");
+      "[AccountListBloc] Canceled data change subscription and closing.",
+    );
     return super.close();
   }
 }

--- a/lib/features/budgets/presentation/bloc/budget_list/budget_list_bloc.dart
+++ b/lib/features/budgets/presentation/bloc/budget_list/budget_list_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/core/error/failure_extensions.dart';
 import 'package:expense_tracker/core/usecases/usecase.dart';
 import 'package:expense_tracker/core/events/data_change_event.dart';
 import 'package:expense_tracker/features/budgets/domain/entities/budget_status.dart';
@@ -41,12 +42,14 @@ class BudgetListBloc extends Bloc<BudgetListEvent, BudgetListState> {
       if (event.type == DataChangeType.system &&
           event.reason == DataChangeReason.reset) {
         log.info(
-            "[BudgetListBloc] System Reset event received. Adding ResetState.");
+          "[BudgetListBloc] System Reset event received. Adding ResetState.",
+        );
         add(const ResetState());
       } else if (event.type == DataChangeType.budget ||
           event.type == DataChangeType.expense) {
         log.info(
-            "[BudgetListBloc] Relevant DataChangedEvent ($event). Triggering reload.");
+          "[BudgetListBloc] Relevant DataChangedEvent ($event). Triggering reload.",
+        );
         add(const _BudgetsDataChanged());
       }
       // --- END MODIFIED ---
@@ -64,19 +67,24 @@ class BudgetListBloc extends Bloc<BudgetListEvent, BudgetListState> {
 
   // ... (rest of handlers remain the same) ...
   Future<void> _onDataChanged(
-      _BudgetsDataChanged event, Emitter<BudgetListState> emit) async {
+    _BudgetsDataChanged event,
+    Emitter<BudgetListState> emit,
+  ) async {
     // Avoid triggering reload if already loading/reloading
     if (state.status != BudgetListStatus.loading) {
       log.fine("[BudgetListBloc] Handling _DataChanged event.");
       add(const LoadBudgets(forceReload: true));
     } else {
       log.fine(
-          "[BudgetListBloc] _DataChanged received, but already loading. Skipping explicit reload.");
+        "[BudgetListBloc] _DataChanged received, but already loading. Skipping explicit reload.",
+      );
     }
   }
 
   Future<void> _onLoadBudgets(
-      LoadBudgets event, Emitter<BudgetListState> emit) async {
+    LoadBudgets event,
+    Emitter<BudgetListState> emit,
+  ) async {
     // Prevent duplicate loading unless forced
     if (state.status == BudgetListStatus.loading && !event.forceReload) {
       log.fine("[BudgetListBloc] LoadBudgets ignored, already loading.");
@@ -84,7 +92,8 @@ class BudgetListBloc extends Bloc<BudgetListEvent, BudgetListState> {
     }
 
     log.info(
-        "[BudgetListBloc] LoadBudgets triggered. ForceReload: ${event.forceReload}");
+      "[BudgetListBloc] LoadBudgets triggered. ForceReload: ${event.forceReload}",
+    );
     emit(state.copyWith(status: BudgetListStatus.loading, clearError: true));
 
     final budgetsResult = await _getBudgetsUseCase(const NoParams());
@@ -92,14 +101,19 @@ class BudgetListBloc extends Bloc<BudgetListEvent, BudgetListState> {
     await budgetsResult.fold(
       (failure) async {
         log.warning(
-            "[BudgetListBloc] Failed to load budgets: ${failure.message}");
-        emit(state.copyWith(
+          "[BudgetListBloc] Failed to load budgets: ${failure.message}",
+        );
+        emit(
+          state.copyWith(
             status: BudgetListStatus.error,
-            errorMessage: _mapFailureToMessage(failure)));
+            errorMessage: failure.toDisplayMessage(),
+          ),
+        );
       },
       (budgets) async {
         log.info(
-            "[BudgetListBloc] Loaded ${budgets.length} budgets. Calculating status...");
+          "[BudgetListBloc] Loaded ${budgets.length} budgets. Calculating status...",
+        );
         List<BudgetWithStatus> budgetsWithStatusList = [];
         bool calculationErrorOccurred = false;
         String? firstCalcErrorMsg;
@@ -118,20 +132,27 @@ class BudgetListBloc extends Bloc<BudgetListEvent, BudgetListState> {
             periodEnd: periodEnd,
           );
 
-          spentResult.fold((failure) {
-            log.warning(
-                "[BudgetListBloc] Failed to calculate spent for '${budget.name}': ${failure.message}");
-            calculationErrorOccurred = true;
-            firstCalcErrorMsg ??=
-                "Failed to calculate status for '${budget.name}': ${_mapFailureToMessage(failure)}";
-          }, (amountSpent) {
-            budgetsWithStatusList.add(BudgetWithStatus.calculate(
-                budget: budget,
-                amountSpent: amountSpent,
-                thrivingColor: thrivingColor,
-                nearingLimitColor: nearingLimitColor,
-                overLimitColor: overLimitColor));
-          });
+          spentResult.fold(
+            (failure) {
+              log.warning(
+                "[BudgetListBloc] Failed to calculate spent for '${budget.name}': ${failure.message}",
+              );
+              calculationErrorOccurred = true;
+              firstCalcErrorMsg ??= failure.toDisplayMessage(
+                  context: "Failed to calculate status for '${budget.name}'");
+            },
+            (amountSpent) {
+              budgetsWithStatusList.add(
+                BudgetWithStatus.calculate(
+                  budget: budget,
+                  amountSpent: amountSpent,
+                  thrivingColor: thrivingColor,
+                  nearingLimitColor: nearingLimitColor,
+                  overLimitColor: overLimitColor,
+                ),
+              );
+            },
+          );
           // Optional: Stop processing if a critical calculation error occurred
           if (calculationErrorOccurred &&
               firstCalcErrorMsg != null &&
@@ -142,29 +163,37 @@ class BudgetListBloc extends Bloc<BudgetListEvent, BudgetListState> {
 
         if (calculationErrorOccurred) {
           // Emit error if any calculation failed, but still show successfully calculated budgets
-          emit(state.copyWith(
-            status: BudgetListStatus.error,
-            budgetsWithStatus: budgetsWithStatusList, // Show what we have
-            errorMessage:
-                firstCalcErrorMsg ?? "An unknown calculation error occurred.",
-          ));
+          emit(
+            state.copyWith(
+              status: BudgetListStatus.error,
+              budgetsWithStatus: budgetsWithStatusList, // Show what we have
+              errorMessage:
+                  firstCalcErrorMsg ?? "An unknown calculation error occurred.",
+            ),
+          );
         } else {
           log.info(
-              "[BudgetListBloc] Successfully calculated status for all budgets.");
-          emit(state.copyWith(
-            status: BudgetListStatus.success,
-            budgetsWithStatus: budgetsWithStatusList,
-            clearError: true,
-          ));
+            "[BudgetListBloc] Successfully calculated status for all budgets.",
+          );
+          emit(
+            state.copyWith(
+              status: BudgetListStatus.success,
+              budgetsWithStatus: budgetsWithStatusList,
+              clearError: true,
+            ),
+          );
         }
       },
     );
   }
 
   Future<void> _onDeleteBudget(
-      DeleteBudget event, Emitter<BudgetListState> emit) async {
+    DeleteBudget event,
+    Emitter<BudgetListState> emit,
+  ) async {
     log.info(
-        "[BudgetListBloc] DeleteBudget triggered for ID: ${event.budgetId}");
+      "[BudgetListBloc] DeleteBudget triggered for ID: ${event.budgetId}",
+    );
 
     // Optimistic UI update - remove the item from the current list
     final optimisticList = state.budgetsWithStatus
@@ -174,48 +203,44 @@ class BudgetListBloc extends Bloc<BudgetListEvent, BudgetListState> {
     final optimisticStatus = state.status == BudgetListStatus.error
         ? BudgetListStatus.success
         : state.status;
-    emit(state.copyWith(
+    emit(
+      state.copyWith(
         budgetsWithStatus: optimisticList,
         status: optimisticStatus, // Assume success during operation
-        clearError: true));
+        clearError: true,
+      ),
+    );
 
-    final result =
-        await _deleteBudgetUseCase(DeleteBudgetParams(id: event.budgetId));
+    final result = await _deleteBudgetUseCase(
+      DeleteBudgetParams(id: event.budgetId),
+    );
 
     result.fold(
       (failure) {
         log.warning("[BudgetListBloc] Delete failed: ${failure.message}");
         // Revert UI implicitly by forcing a reload which will show the error state
-        emit(state.copyWith(
+        emit(
+          state.copyWith(
             status: BudgetListStatus.error,
-            errorMessage: _mapFailureToMessage(failure,
-                context: "Failed to delete budget")));
-        add(const LoadBudgets(
-            forceReload:
-                true)); // Force reload to show error and potentially revert list if needed
+            errorMessage: failure.toDisplayMessage(
+              context: "Failed to delete budget",
+            ),
+          ),
+        );
+        add(
+          const LoadBudgets(forceReload: true),
+        ); // Force reload to show error and potentially revert list if needed
       },
       (_) {
         log.info("[BudgetListBloc] Delete successful for ${event.budgetId}.");
         // Publish event - list will reload reactively via _onDataChanged
         publishDataChangedEvent(
-            type: DataChangeType.budget, reason: DataChangeReason.deleted);
+          type: DataChangeType.budget,
+          reason: DataChangeReason.deleted,
+        );
         // No need to emit success state here, reactive reload handles it
       },
     );
-  }
-
-  String _mapFailureToMessage(Failure failure,
-      {String context = "An error occurred"}) {
-    log.warning(
-        "[BudgetListBloc] Mapping failure: ${failure.runtimeType} - ${failure.message}");
-    switch (failure.runtimeType) {
-      case ValidationFailure:
-        return failure.message; // Use validation message directly
-      case CacheFailure:
-        return '$context: Database Error: ${failure.message}';
-      default:
-        return '$context: An unexpected error occurred.';
-    }
   }
 
   @override

--- a/lib/features/dashboard/presentation/bloc/dashboard_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/dashboard_bloc.dart
@@ -4,6 +4,7 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:expense_tracker/main.dart'; // Import logger
 import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/core/error/failure_extensions.dart';
 import 'package:expense_tracker/features/dashboard/domain/entities/financial_overview.dart';
 import 'package:expense_tracker/features/dashboard/domain/usecases/get_financial_overview.dart';
 import 'package:expense_tracker/core/events/data_change_event.dart';
@@ -23,34 +24,41 @@ class DashboardBloc extends Bloc<DashboardEvent, DashboardState> {
   DashboardBloc({
     required GetFinancialOverviewUseCase getFinancialOverviewUseCase,
     required Stream<DataChangedEvent> dataChangeStream,
-  })  : _getFinancialOverviewUseCase = getFinancialOverviewUseCase,
-        super(DashboardInitial()) {
+  }) : _getFinancialOverviewUseCase = getFinancialOverviewUseCase,
+       super(DashboardInitial()) {
     on<LoadDashboard>(_onLoadDashboard);
     on<_DataChanged>(_onDataChanged);
     on<ResetState>(_onResetState); // Add Handler
 
-    _dataChangeSubscription = dataChangeStream.listen((event) {
-      // --- MODIFIED Listener ---
-      if (event.type == DataChangeType.system &&
-          event.reason == DataChangeReason.reset) {
-        log.info(
-            "[DashboardBloc] System Reset event received. Adding ResetState.");
-        add(const ResetState());
-      } else if (event.type == DataChangeType.account ||
-          event.type == DataChangeType.expense ||
-          event.type == DataChangeType.income ||
-          event.type == DataChangeType.budget ||
-          event.type == DataChangeType.goal ||
-          event.type == DataChangeType.goalContribution ||
-          event.type == DataChangeType.settings) {
-        log.info(
-            "[DashboardBloc] Relevant DataChangedEvent: $event. Triggering reload.");
-        add(const _DataChanged());
-      }
-      // --- END MODIFIED ---
-    }, onError: (error, stackTrace) {
-      log.severe("[DashboardBloc] Error in dataChangeStream listener: $error");
-    });
+    _dataChangeSubscription = dataChangeStream.listen(
+      (event) {
+        // --- MODIFIED Listener ---
+        if (event.type == DataChangeType.system &&
+            event.reason == DataChangeReason.reset) {
+          log.info(
+            "[DashboardBloc] System Reset event received. Adding ResetState.",
+          );
+          add(const ResetState());
+        } else if (event.type == DataChangeType.account ||
+            event.type == DataChangeType.expense ||
+            event.type == DataChangeType.income ||
+            event.type == DataChangeType.budget ||
+            event.type == DataChangeType.goal ||
+            event.type == DataChangeType.goalContribution ||
+            event.type == DataChangeType.settings) {
+          log.info(
+            "[DashboardBloc] Relevant DataChangedEvent: $event. Triggering reload.",
+          );
+          add(const _DataChanged());
+        }
+        // --- END MODIFIED ---
+      },
+      onError: (error, stackTrace) {
+        log.severe(
+          "[DashboardBloc] Error in dataChangeStream listener: $error",
+        );
+      },
+    );
     log.info("[DashboardBloc] Initialized and subscribed to data changes.");
   }
 
@@ -64,21 +72,27 @@ class DashboardBloc extends Bloc<DashboardEvent, DashboardState> {
 
   // ... (rest of handlers remain the same) ...
   Future<void> _onDataChanged(
-      _DataChanged event, Emitter<DashboardState> emit) async {
+    _DataChanged event,
+    Emitter<DashboardState> emit,
+  ) async {
     if (state is! DashboardLoading) {
       // Avoid triggering multiple loads
       log.info("[DashboardBloc] Handling _DataChanged event.");
       add(const LoadDashboard(forceReload: true));
     } else {
       log.fine(
-          "[DashboardBloc] _DataChanged received, but already loading. Skipping explicit reload.");
+        "[DashboardBloc] _DataChanged received, but already loading. Skipping explicit reload.",
+      );
     }
   }
 
   Future<void> _onLoadDashboard(
-      LoadDashboard event, Emitter<DashboardState> emit) async {
+    LoadDashboard event,
+    Emitter<DashboardState> emit,
+  ) async {
     log.info(
-        "[DashboardBloc] Received LoadDashboard event (forceReload: ${event.forceReload}). Current state: ${state.runtimeType}");
+      "[DashboardBloc] Received LoadDashboard event (forceReload: ${event.forceReload}). Current state: ${state.runtimeType}",
+    );
 
     // Set default date range to current month if not provided
     final now = DateTime.now();
@@ -94,7 +108,8 @@ class DashboardBloc extends Bloc<DashboardEvent, DashboardState> {
     if (state is! DashboardLoaded || event.forceReload) {
       emit(DashboardLoading(isReloading: state is DashboardLoaded));
       log.info(
-          "[DashboardBloc] Emitting DashboardLoading (isReloading: ${state is DashboardLoaded}).");
+        "[DashboardBloc] Emitting DashboardLoading (isReloading: ${state is DashboardLoaded}).",
+      );
     } else {
       log.info("[DashboardBloc] State is Loaded, refreshing data silently.");
     }
@@ -105,39 +120,26 @@ class DashboardBloc extends Bloc<DashboardEvent, DashboardState> {
       endDate: _currentEndDate,
     );
     log.info(
-        "[DashboardBloc] Calling GetFinancialOverviewUseCase with params: Start=${params.startDate}, End=${params.endDate}");
+      "[DashboardBloc] Calling GetFinancialOverviewUseCase with params: Start=${params.startDate}, End=${params.endDate}",
+    );
 
     final result = await _getFinancialOverviewUseCase(params);
     log.info(
-        "[DashboardBloc] GetFinancialOverviewUseCase returned. isLeft: ${result.isLeft()}");
+      "[DashboardBloc] GetFinancialOverviewUseCase returned. isLeft: ${result.isLeft()}",
+    );
 
     result.fold(
       (failure) {
         log.warning(
-            "[DashboardBloc] Load failed: ${failure.message}. Emitting DashboardError.");
-        emit(DashboardError(_mapFailureToMessage(failure)));
+          "[DashboardBloc] Load failed: ${failure.message}. Emitting DashboardError.",
+        );
+        emit(DashboardError(failure.toDisplayMessage()));
       },
       (overview) {
         log.info("[DashboardBloc] Load successful. Emitting DashboardLoaded.");
         emit(DashboardLoaded(overview));
       },
     );
-  }
-
-  String _mapFailureToMessage(Failure failure) {
-    log.warning(
-        "[DashboardBloc] Mapping failure: ${failure.runtimeType} - ${failure.message}");
-    switch (failure.runtimeType) {
-      case CacheFailure:
-      case SettingsFailure:
-        return 'Database Error: Could not load dashboard data. ${failure.message}';
-      case UnexpectedFailure:
-        return 'An unexpected error occurred loading the dashboard.';
-      default:
-        return failure.message.isNotEmpty
-            ? failure.message
-            : 'An unknown error occurred.';
-    }
   }
 
   @override

--- a/test/core/error/failure_extensions_test.dart
+++ b/test/core/error/failure_extensions_test.dart
@@ -1,0 +1,35 @@
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/core/error/failure_extensions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FailureMessage extension', () {
+    test('includes context and database prefix for CacheFailure', () {
+      const failure = CacheFailure('DB issue');
+      final message = failure.toDisplayMessage(context: 'Load failed');
+      expect(message, 'Load failed: Database Error: DB issue');
+    });
+
+    test('returns validation message directly', () {
+      const failure = ValidationFailure('Invalid input');
+      expect(failure.toDisplayMessage(), 'Invalid input');
+    });
+
+    test('returns unexpected message', () {
+      const failure = UnexpectedFailure();
+      expect(
+        failure.toDisplayMessage(),
+        'An unexpected error occurred. Please try again.',
+      );
+    });
+
+    test('returns unknown message when empty', () {
+      const failure = _FailureStub('');
+      expect(failure.toDisplayMessage(), 'An unknown error occurred.');
+    });
+  });
+}
+
+class _FailureStub extends Failure {
+  const _FailureStub(String message) : super(message);
+}


### PR DESCRIPTION
## Summary
- add FailureMessage extension to centralize display error mapping
- refactor key BLoCs to use Failure.toDisplayMessage
- add tests for FailureMessage extension

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689dfd78f5708320850778a5a2335cab