### PR TITLE
Add transaction filtering tests and robust category handling

### DIFF
--- a/lib/features/categories/data/models/category_model.dart
+++ b/lib/features/categories/data/models/category_model.dart
@@ -2,6 +2,7 @@ import 'package:hive/hive.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:expense_tracker/features/categories/domain/entities/category.dart';
 import 'package:expense_tracker/features/categories/domain/entities/category_type.dart'; // Import enum
+import 'package:expense_tracker/main.dart'; // Logger
 
 part 'category_model.g.dart';
 
@@ -54,6 +55,15 @@ class CategoryModel extends HiveObject {
   }
 
   Category toEntity() {
+    CategoryType type;
+    if (typeIndex >= 0 && typeIndex < CategoryType.values.length) {
+      type = CategoryType.values[typeIndex];
+    } else {
+      log.warning(
+        "[CategoryModel] Invalid typeIndex '$typeIndex' for category '$id'. Defaulting to expense.",
+      );
+      type = CategoryType.expense;
+    }
     return Category(
       id: id,
       name: name,
@@ -61,10 +71,7 @@ class CategoryModel extends HiveObject {
       colorHex: colorHex,
       isCustom: isCustom,
       parentCategoryId: parentCategoryId,
-      // Convert index back to enum, handle potential invalid index
-      type: typeIndex >= 0 && typeIndex < CategoryType.values.length
-          ? CategoryType.values[typeIndex]
-          : CategoryType.expense, // Default to expense if index is invalid
+      type: type,
     );
   }
 

--- a/lib/features/transactions/presentation/pages/transaction_detail_page.dart
+++ b/lib/features/transactions/presentation/pages/transaction_detail_page.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:expense_tracker/main.dart';
+import 'package:collection/collection.dart';
 
 class TransactionDetailPage extends StatelessWidget {
   final TransactionEntity transaction; // Passed via GoRouter 'extra'
@@ -46,11 +47,12 @@ class TransactionDetailPage extends StatelessWidget {
   // Navigate to the unified Edit page
   void _navigateToEdit(BuildContext context) {
     log.info(
-        "[TxnDetailPage] Navigate to Edit requested for TXN ID: ${transaction.id}");
+      "[TxnDetailPage] Navigate to Edit requested for TXN ID: ${transaction.id}",
+    );
     // Use the unified edit route name
     const String routeName = RouteNames.editTransaction;
     final Map<String, String> params = {
-      RouteNames.paramTransactionId: transaction.id
+      RouteNames.paramTransactionId: transaction.id,
     };
     log.info("[TxnDetailPage] Navigating via pushNamed:");
     log.info("  Route Name: $routeName");
@@ -74,13 +76,11 @@ class TransactionDetailPage extends StatelessWidget {
     final accountState = context.watch<AccountListBloc>().state;
     String accountName = 'Loading...'; // Default
     if (accountState is AccountListLoaded) {
-      try {
-        accountName = accountState.items
-            .firstWhere((acc) => acc.id == transaction.accountId)
-            .name;
-      } catch (_) {
-        accountName = 'Unknown/Deleted Account';
-      }
+      accountName =
+          accountState.items
+              .firstWhereOrNull((acc) => acc.id == transaction.accountId)
+              ?.name ??
+          'Unknown/Deleted Account';
     }
 
     return Scaffold(
@@ -135,7 +135,8 @@ class TransactionDetailPage extends StatelessWidget {
           if (transaction.category != null)
             _buildDetailRow(
               context,
-              icon: availableIcons[transaction.category!.iconName] ??
+              icon:
+                  availableIcons[transaction.category!.iconName] ??
                   Icons.category_outlined, // Use actual icon
               label: 'Category',
               value: transaction.category!.name,
@@ -171,32 +172,38 @@ class TransactionDetailPage extends StatelessWidget {
   }
 
   // Helper for consistent detail rows
-  Widget _buildDetailRow(BuildContext context,
-      {required IconData icon,
-      required String label,
-      required String value,
-      Color? valueColor,
-      Color? iconColor, // Optional color for the icon
-      bool isMultiline = false}) {
+  Widget _buildDetailRow(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required String value,
+    Color? valueColor,
+    Color? iconColor, // Optional color for the icon
+    bool isMultiline = false,
+  }) {
     final theme = Theme.of(context);
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 10.0),
       child: Row(
-        crossAxisAlignment:
-            isMultiline ? CrossAxisAlignment.start : CrossAxisAlignment.center,
+        crossAxisAlignment: isMultiline
+            ? CrossAxisAlignment.start
+            : CrossAxisAlignment.center,
         children: [
-          Icon(icon,
-              size: 20,
-              color: iconColor ??
-                  theme.colorScheme.secondary), // Use iconColor or default
+          Icon(
+            icon,
+            size: 20,
+            color: iconColor ?? theme.colorScheme.secondary,
+          ), // Use iconColor or default
           const SizedBox(width: 16),
           Text('$label:', style: theme.textTheme.bodyLarge),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               value,
-              style: theme.textTheme.bodyLarge
-                  ?.copyWith(fontWeight: FontWeight.w500, color: valueColor),
+              style: theme.textTheme.bodyLarge?.copyWith(
+                fontWeight: FontWeight.w500,
+                color: valueColor,
+              ),
               textAlign: TextAlign.end,
               softWrap: isMultiline,
             ),

--- a/test/features/categories/data/category_model_test.dart
+++ b/test/features/categories/data/category_model_test.dart
@@ -1,0 +1,20 @@
+import 'package:expense_tracker/features/categories/data/models/category_model.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('toEntity defaults to expense when typeIndex is invalid', () {
+    final model = CategoryModel(
+      id: '1',
+      name: 'Test',
+      iconName: 'icon',
+      colorHex: '#ffffff',
+      isCustom: false,
+      parentCategoryId: null,
+      typeIndex: 99,
+    );
+
+    final entity = model.toEntity();
+    expect(entity.type, CategoryType.expense);
+  });
+}

--- a/test/features/expenses/data/expense_repository_impl_test.dart
+++ b/test/features/expenses/data/expense_repository_impl_test.dart
@@ -1,0 +1,170 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/expenses/data/datasources/expense_local_data_source.dart';
+import 'package:expense_tracker/features/expenses/data/models/expense_model.dart';
+import 'package:expense_tracker/features/expenses/data/repositories/expense_repository_impl.dart';
+import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockExpenseLocalDataSource extends Mock
+    implements ExpenseLocalDataSource {}
+
+class MockCategoryRepository extends Mock implements CategoryRepository {}
+
+void main() {
+  late MockExpenseLocalDataSource mockDataSource;
+  late MockCategoryRepository mockCategoryRepository;
+  late ExpenseRepositoryImpl repository;
+
+  setUp(() {
+    mockDataSource = MockExpenseLocalDataSource();
+    mockCategoryRepository = MockCategoryRepository();
+    repository = ExpenseRepositoryImpl(
+      localDataSource: mockDataSource,
+      categoryRepository: mockCategoryRepository,
+    );
+  });
+
+  final model1 = ExpenseModel(
+    id: '1',
+    title: 'Coffee',
+    amount: 3.0,
+    date: DateTime(2024, 1, 1),
+    accountId: 'a1',
+    categorizationStatusValue: 'uncategorized',
+  );
+  final model2 = ExpenseModel(
+    id: '2',
+    title: 'Sandwich',
+    amount: 5.0,
+    date: DateTime(2024, 1, 3),
+    accountId: 'a1',
+    categorizationStatusValue: 'uncategorized',
+  );
+  final model3 = ExpenseModel(
+    id: '3',
+    title: 'Tea',
+    amount: 2.0,
+    date: DateTime(2024, 1, 2),
+    accountId: 'a2',
+    categorizationStatusValue: 'uncategorized',
+  );
+
+  test('returns sorted expenses from data source', () async {
+    when(
+      () => mockDataSource.getExpenses(
+        startDate: any(named: 'startDate'),
+        endDate: any(named: 'endDate'),
+        categoryId: any(named: 'categoryId'),
+        accountId: any(named: 'accountId'),
+      ),
+    ).thenAnswer((_) async => [model1, model2, model3]);
+
+    final result = await repository.getExpenses(
+      startDate: DateTime(2024, 1, 1),
+      endDate: DateTime(2024, 1, 31),
+      categoryId: 'c1',
+      accountId: 'a1',
+    );
+
+    expect(result.isRight(), isTrue);
+    final models = result.getOrElse(() => []);
+    expect(models.map((m) => m.id), ['2', '3', '1']);
+    verify(
+      () => mockDataSource.getExpenses(
+        startDate: DateTime(2024, 1, 1),
+        endDate: DateTime(2024, 1, 31),
+        categoryId: 'c1',
+        accountId: 'a1',
+      ),
+    ).called(1);
+  });
+
+  test('propagates CacheFailure from data source', () async {
+    when(
+      () => mockDataSource.getExpenses(
+        startDate: any(named: 'startDate'),
+        endDate: any(named: 'endDate'),
+        categoryId: any(named: 'categoryId'),
+        accountId: any(named: 'accountId'),
+      ),
+    ).thenThrow(const CacheFailure('cache error'));
+
+    final result = await repository.getExpenses();
+
+    expect(result.isLeft(), isTrue);
+    result.fold(
+      (failure) => expect(failure, const CacheFailure('cache error')),
+      (_) => fail('should not return Right'),
+    );
+  });
+
+  test('passes category filter to data source', () async {
+    when(
+      () => mockDataSource.getExpenses(
+        startDate: any(named: 'startDate'),
+        endDate: any(named: 'endDate'),
+        categoryId: any(named: 'categoryId'),
+        accountId: any(named: 'accountId'),
+      ),
+    ).thenAnswer((_) async => [model1]);
+
+    await repository.getExpenses(categoryId: 'c1');
+
+    verify(
+      () => mockDataSource.getExpenses(
+        startDate: null,
+        endDate: null,
+        categoryId: 'c1',
+        accountId: null,
+      ),
+    ).called(1);
+  });
+
+  test('passes account filter to data source', () async {
+    when(
+      () => mockDataSource.getExpenses(
+        startDate: any(named: 'startDate'),
+        endDate: any(named: 'endDate'),
+        categoryId: any(named: 'categoryId'),
+        accountId: any(named: 'accountId'),
+      ),
+    ).thenAnswer((_) async => [model1]);
+
+    await repository.getExpenses(accountId: 'a1');
+
+    verify(
+      () => mockDataSource.getExpenses(
+        startDate: null,
+        endDate: null,
+        categoryId: null,
+        accountId: 'a1',
+      ),
+    ).called(1);
+  });
+
+  test('passes date range to data source', () async {
+    final start = DateTime(2024, 1, 1);
+    final end = DateTime(2024, 1, 31);
+    when(
+      () => mockDataSource.getExpenses(
+        startDate: any(named: 'startDate'),
+        endDate: any(named: 'endDate'),
+        categoryId: any(named: 'categoryId'),
+        accountId: any(named: 'accountId'),
+      ),
+    ).thenAnswer((_) async => [model1]);
+
+    await repository.getExpenses(startDate: start, endDate: end);
+
+    verify(
+      () => mockDataSource.getExpenses(
+        startDate: start,
+        endDate: end,
+        categoryId: null,
+        accountId: null,
+      ),
+    ).called(1);
+  });
+}

--- a/test/features/transactions/presentation/bloc/transaction_list_bloc_test.dart
+++ b/test/features/transactions/presentation/bloc/transaction_list_bloc_test.dart
@@ -210,4 +210,210 @@ void main() {
       ],
     );
   });
+
+  group('TransactionListBloc filtering and sorting', () {
+    late MockGetTransactionsUseCase getTransactions;
+    late MockDeleteExpenseUseCase deleteExpense;
+    late MockDeleteIncomeUseCase deleteIncome;
+    late MockApplyBatchCategoryUseCase applyBatch;
+    late MockSaveUserCategorizationHistoryUseCase saveHistory;
+    late MockExpenseRepository expenseRepo;
+    late MockIncomeRepository incomeRepo;
+
+    setUp(() {
+      getTransactions = MockGetTransactionsUseCase();
+      deleteExpense = MockDeleteExpenseUseCase();
+      deleteIncome = MockDeleteIncomeUseCase();
+      applyBatch = MockApplyBatchCategoryUseCase();
+      saveHistory = MockSaveUserCategorizationHistoryUseCase();
+      expenseRepo = MockExpenseRepository();
+      incomeRepo = MockIncomeRepository();
+    });
+
+    blocTest<TransactionListBloc, TransactionListState>(
+      'loads transactions with incoming filters',
+      build: () {
+        when(() => getTransactions(any())).thenAnswer((_) async => Right([]));
+        return TransactionListBloc(
+          getTransactionsUseCase: getTransactions,
+          deleteExpenseUseCase: deleteExpense,
+          deleteIncomeUseCase: deleteIncome,
+          applyCategoryToBatchUseCase: applyBatch,
+          saveUserHistoryUseCase: saveHistory,
+          expenseRepository: expenseRepo,
+          incomeRepository: incomeRepo,
+          dataChangeStream: const Stream<DataChangedEvent>.empty(),
+        );
+      },
+      act: (bloc) => bloc.add(
+        const LoadTransactions(
+          incomingFilters: {'categoryId': 'c1', 'accountId': 'a1'},
+        ),
+      ),
+      expect: () => [
+        isA<TransactionListState>()
+            .having((s) => s.status, 'loading', ListStatus.loading)
+            .having((s) => s.categoryId, 'categoryId', 'c1')
+            .having((s) => s.accountId, 'accountId', 'a1'),
+        isA<TransactionListState>()
+            .having((s) => s.status, 'success', ListStatus.success)
+            .having((s) => s.categoryId, 'categoryId', 'c1')
+            .having((s) => s.accountId, 'accountId', 'a1'),
+      ],
+      verify: (_) {
+        verify(() => getTransactions(any())).called(1);
+      },
+    );
+
+    blocTest<TransactionListBloc, TransactionListState>(
+      'updates filters and reloads',
+      build: () {
+        when(() => getTransactions(any())).thenAnswer((_) async => Right([]));
+        return TransactionListBloc(
+          getTransactionsUseCase: getTransactions,
+          deleteExpenseUseCase: deleteExpense,
+          deleteIncomeUseCase: deleteIncome,
+          applyCategoryToBatchUseCase: applyBatch,
+          saveUserHistoryUseCase: saveHistory,
+          expenseRepository: expenseRepo,
+          incomeRepository: incomeRepo,
+          dataChangeStream: const Stream<DataChangedEvent>.empty(),
+        );
+      },
+      seed: () => const TransactionListState(status: ListStatus.success),
+      act: (bloc) => bloc.add(const FilterChanged(categoryId: 'c1')),
+      expect: () => [
+        isA<TransactionListState>().having(
+          (s) => s.categoryId,
+          'categoryId',
+          'c1',
+        ),
+        isA<TransactionListState>()
+            .having((s) => s.status, 'reloading', ListStatus.reloading),
+        isA<TransactionListState>()
+            .having((s) => s.status, 'success', ListStatus.success),
+      ],
+    );
+
+    blocTest<TransactionListBloc, TransactionListState>(
+      'updates sort and reloads',
+      build: () {
+        when(() => getTransactions(any())).thenAnswer((_) async => Right([]));
+        return TransactionListBloc(
+          getTransactionsUseCase: getTransactions,
+          deleteExpenseUseCase: deleteExpense,
+          deleteIncomeUseCase: deleteIncome,
+          applyCategoryToBatchUseCase: applyBatch,
+          saveUserHistoryUseCase: saveHistory,
+          expenseRepository: expenseRepo,
+          incomeRepository: incomeRepo,
+          dataChangeStream: const Stream<DataChangedEvent>.empty(),
+        );
+      },
+      seed: () => const TransactionListState(status: ListStatus.success),
+      act: (bloc) => bloc.add(
+        const SortChanged(
+          sortBy: TransactionSortBy.amount,
+          sortDirection: SortDirection.ascending,
+        ),
+      ),
+      expect: () => [
+        isA<TransactionListState>()
+            .having((s) => s.sortBy, 'sortBy', TransactionSortBy.amount)
+            .having(
+              (s) => s.sortDirection,
+              'direction',
+              SortDirection.ascending,
+            ),
+        isA<TransactionListState>()
+            .having((s) => s.status, 'reloading', ListStatus.reloading),
+        isA<TransactionListState>()
+            .having((s) => s.status, 'success', ListStatus.success),
+      ],
+    );
+
+    blocTest<TransactionListBloc, TransactionListState>(
+      'updates search term and reloads',
+      build: () {
+        when(() => getTransactions(any())).thenAnswer((_) async => Right([]));
+        return TransactionListBloc(
+          getTransactionsUseCase: getTransactions,
+          deleteExpenseUseCase: deleteExpense,
+          deleteIncomeUseCase: deleteIncome,
+          applyCategoryToBatchUseCase: applyBatch,
+          saveUserHistoryUseCase: saveHistory,
+          expenseRepository: expenseRepo,
+          incomeRepository: incomeRepo,
+          dataChangeStream: const Stream<DataChangedEvent>.empty(),
+        );
+      },
+      seed: () => const TransactionListState(status: ListStatus.success),
+      act: (bloc) => bloc.add(const SearchChanged(searchTerm: 'coffee')),
+      expect: () => [
+        isA<TransactionListState>().having(
+          (s) => s.searchTerm,
+          'search',
+          'coffee',
+        ),
+        isA<TransactionListState>().having(
+          (s) => s.status,
+          'reloading',
+          ListStatus.reloading,
+        ),
+        isA<TransactionListState>().having(
+          (s) => s.status,
+          'success',
+          ListStatus.success,
+        ),
+      ],
+    );
+  });
+
+  group('TransactionListBloc batch edit toggle', () {
+    late MockGetTransactionsUseCase getTransactions;
+    late MockDeleteExpenseUseCase deleteExpense;
+    late MockDeleteIncomeUseCase deleteIncome;
+    late MockApplyBatchCategoryUseCase applyBatch;
+    late MockSaveUserCategorizationHistoryUseCase saveHistory;
+    late MockExpenseRepository expenseRepo;
+    late MockIncomeRepository incomeRepo;
+
+    setUp(() {
+      getTransactions = MockGetTransactionsUseCase();
+      deleteExpense = MockDeleteExpenseUseCase();
+      deleteIncome = MockDeleteIncomeUseCase();
+      applyBatch = MockApplyBatchCategoryUseCase();
+      saveHistory = MockSaveUserCategorizationHistoryUseCase();
+      expenseRepo = MockExpenseRepository();
+      incomeRepo = MockIncomeRepository();
+    });
+
+    blocTest<TransactionListBloc, TransactionListState>(
+      'toggles batch edit mode and clears selection when turning off',
+      build: () => TransactionListBloc(
+        getTransactionsUseCase: getTransactions,
+        deleteExpenseUseCase: deleteExpense,
+        deleteIncomeUseCase: deleteIncome,
+        applyCategoryToBatchUseCase: applyBatch,
+        saveUserHistoryUseCase: saveHistory,
+        expenseRepository: expenseRepo,
+        incomeRepository: incomeRepo,
+        dataChangeStream: const Stream<DataChangedEvent>.empty(),
+      ),
+      seed: () => const TransactionListState(
+        isInBatchEditMode: true,
+        selectedTransactionIds: {'1'},
+      ),
+      act: (bloc) => bloc.add(const ToggleBatchEdit()),
+      expect: () => [
+        isA<TransactionListState>()
+            .having((s) => s.isInBatchEditMode, 'batch off', false)
+            .having(
+              (s) => s.selectedTransactionIds.isEmpty,
+              'selection cleared',
+              true,
+            ),
+      ],
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- log and default when CategoryModel reads an invalid enum index
- prevent crashes for missing accounts by using `firstWhereOrNull` in transaction details
- expand TransactionListBloc and ExpenseRepositoryImpl tests for filtering and sorting
- cover invalid category model index with a unit test

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689e034dcb84832081cecff222622442