### PR TITLE
Fix currency parsing for country codes

### DIFF
--- a/lib/core/utils/currency_parser.dart
+++ b/lib/core/utils/currency_parser.dart
@@ -3,18 +3,32 @@ import 'package:intl/intl.dart';
 /// Parses a currency [value] string according to the given [locale].
 /// Returns [double.nan] if parsing fails.
 double parseCurrency(String value, String locale) {
+  final normalized = _normalizeLocale(locale);
   try {
-    final formatter = NumberFormat.currency(locale: locale);
+    final formatter = NumberFormat.currency(locale: normalized);
     final number = formatter.parse(value);
     return number.toDouble();
   } catch (_) {
     try {
       // Fallback to decimal pattern if currency fails
-      final formatter = NumberFormat.decimalPattern(locale);
+      final formatter = NumberFormat.decimalPattern(normalized);
       final number = formatter.parse(value);
       return number.toDouble();
     } catch (_) {
-      return double.nan;
+      // Last resort: attempt a basic parse after removing non-numeric chars
+      final sanitized = value.replaceAll(RegExp('[^0-9-.,]'), '');
+      return double.tryParse(sanitized) ?? double.nan;
     }
   }
+}
+
+/// Normalizes a [locale] string by converting a standalone country code (e.g. `US`)
+/// into a valid locale such as `en_US`. If a language is already provided, it is
+/// returned unchanged.
+String _normalizeLocale(String locale) {
+  if (locale.isEmpty) return 'en_US';
+  if (!locale.contains('_') && locale.length == 2) {
+    return 'en_${locale.toUpperCase()}';
+  }
+  return locale;
 }

--- a/lib/core/widgets/app_text_form_field.dart
+++ b/lib/core/widgets/app_text_form_field.dart
@@ -51,7 +51,8 @@ class _AppTextFormFieldState extends State<AppTextFormField> {
   @override
   void initState() {
     super.initState();
-    _showClearButton = widget.controller.text.isNotEmpty &&
+    _showClearButton =
+        widget.controller.text.isNotEmpty &&
         !widget.readOnly; // Also check readOnly
     widget.controller.addListener(_handleTextChange);
   }
@@ -64,20 +65,20 @@ class _AppTextFormFieldState extends State<AppTextFormField> {
 
   void _handleTextChange() {
     if (mounted) {
-      final shouldShow = widget.controller.text.isNotEmpty &&
+      final shouldShow =
+          widget.controller.text.isNotEmpty &&
           !widget.readOnly; // Check readOnly
       if (_showClearButton != shouldShow) {
         setState(() {
           _showClearButton = shouldShow;
         });
       }
-      widget.onChanged?.call(widget.controller.text); // Call onChanged callback
     }
   }
 
   void _clearText() {
     widget.controller.clear();
-    // Note: widget.onChanged is implicitly called via the listener
+    widget.onChanged?.call('');
   }
 
   @override
@@ -98,7 +99,8 @@ class _AppTextFormFieldState extends State<AppTextFormField> {
         focusedErrorBorder: inputTheme.focusedErrorBorder,
         filled: inputTheme.filled,
         fillColor: inputTheme.fillColor,
-        contentPadding: inputTheme.contentPadding ??
+        contentPadding:
+            inputTheme.contentPadding ??
             modeTheme?.listItemPadding.copyWith(top: 14, bottom: 14),
         isDense: inputTheme.isDense,
         floatingLabelBehavior: inputTheme.floatingLabelBehavior,

--- a/lib/core/widgets/common_form_fields.dart
+++ b/lib/core/widgets/common_form_fields.dart
@@ -91,7 +91,15 @@ class CommonFormFields {
       prefixText: '$currencySymbol ',
       prefixIcon: getPrefixIcon(context, iconKey, fallbackIcon),
       keyboardType: const TextInputType.numberWithOptions(decimal: true),
-      inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]'))],
+      inputFormatters: [
+        TextInputFormatter.withFunction((oldValue, newValue) {
+          final sanitized = newValue.text.replaceAll(RegExp('[^0-9.,]'), '');
+          return newValue.copyWith(
+            text: sanitized,
+            selection: TextSelection.collapsed(offset: sanitized.length),
+          );
+        }),
+      ],
       validator:
           validator ??
           (value) {

--- a/lib/core/widgets/common_form_fields.dart
+++ b/lib/core/widgets/common_form_fields.dart
@@ -92,13 +92,7 @@ class CommonFormFields {
       prefixIcon: getPrefixIcon(context, iconKey, fallbackIcon),
       keyboardType: const TextInputType.numberWithOptions(decimal: true),
       inputFormatters: [
-        TextInputFormatter.withFunction((oldValue, newValue) {
-          final sanitized = newValue.text.replaceAll(RegExp('[^0-9.,]'), '');
-          return newValue.copyWith(
-            text: sanitized,
-            selection: TextSelection.collapsed(offset: sanitized.length),
-          );
-        }),
+        FilteringTextInputFormatter.allow(RegExp(r'^\d*[,.]?\d{0,2}')),
       ],
       validator:
           validator ??

--- a/lib/core/widgets/common_form_fields.dart
+++ b/lib/core/widgets/common_form_fields.dart
@@ -61,7 +61,8 @@ class CommonFormFields {
       hintText: hintText,
       prefixIcon: getPrefixIcon(context, iconKey, fallbackIcon),
       textCapitalization: textCapitalization,
-      validator: validator ??
+      validator:
+          validator ??
           (value) {
             if (value == null || value.trim().isEmpty) {
               return 'Please enter a value';
@@ -82,6 +83,7 @@ class CommonFormFields {
     String iconKey = 'amount',
     IconData fallbackIcon = Icons.attach_money,
     String? Function(String?)? validator,
+    ValueChanged<String>? onChanged,
   }) {
     return AppTextFormField(
       controller: controller,
@@ -89,19 +91,21 @@ class CommonFormFields {
       prefixText: '$currencySymbol ',
       prefixIcon: getPrefixIcon(context, iconKey, fallbackIcon),
       keyboardType: const TextInputType.numberWithOptions(decimal: true),
-      inputFormatters: [
-        FilteringTextInputFormatter.allow(RegExp(r'^\d*[,.]?\d{0,2}')),
-      ],
-      validator: validator ??
+      inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]'))],
+      validator:
+          validator ??
           (value) {
             if (value == null || value.isEmpty) return 'Enter amount';
-            final locale =
-                context.read<SettingsBloc>().state.selectedCountryCode;
+            final locale = context
+                .read<SettingsBloc>()
+                .state
+                .selectedCountryCode;
             final number = parseCurrency(value, locale);
             if (number.isNaN) return 'Invalid number';
             if (number <= 0) return 'Must be positive';
             return null;
           },
+      onChanged: onChanged,
     );
   }
 
@@ -139,7 +143,8 @@ class CommonFormFields {
     final theme = Theme.of(context);
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: 12),
-      shape: theme.inputDecorationTheme.enabledBorder ??
+      shape:
+          theme.inputDecorationTheme.enabledBorder ??
           OutlineInputBorder(
             borderRadius: BorderRadius.circular(8.0),
             borderSide: BorderSide(color: theme.dividerColor),
@@ -181,7 +186,8 @@ class CommonFormFields {
     return AccountSelectorDropdown(
       selectedAccountId: selectedAccountId,
       onChanged: onChanged,
-      validator: validator ??
+      validator:
+          validator ??
           (value) => value == null ? 'Please select an account' : null,
       labelText: labelText,
       hintText: hintText,

--- a/lib/features/goals/presentation/pages/goal_detail_page.dart
+++ b/lib/features/goals/presentation/pages/goal_detail_page.dart
@@ -73,10 +73,20 @@ class _GoalDetailPageState extends State<GoalDetailPage> {
     super.dispose();
   }
 
-  void _handleBlocStateChange(dynamic state) {
-    if (mounted && !_isLoadingGoal) {
-      log.fine("[GoalDetail] Received Bloc update, reloading detail data.");
-      _loadData();
+// In _GoalDetailPageState
+  void _handleBlocStateChange(GoalListState state) {
+    if (mounted && _isLoadingGoal) {
+      // Find the updated goal directly from the new state
+      final updatedGoal = state.goals.firstWhereOrNull((g) => g.id == widget.goalId);
+      if (updatedGoal != null && updatedGoal != _currentGoal) {
+        log.fine("[GoalDetail] Bloc update detected, updating UI from new state.");
+        // Update the local state with the new data from the BLoC
+        // This avoids another round trip to the database.
+        setState(() {
+          _currentGoal = updatedGoal;
+        });
+        // You would still need to reload contributions separately if they changed.
+      }
     }
   }
 

--- a/lib/features/recurring_transactions/presentation/bloc/add_edit_recurring_rule/add_edit_recurring_rule_bloc.dart
+++ b/lib/features/recurring_transactions/presentation/bloc/add_edit_recurring_rule/add_edit_recurring_rule_bloc.dart
@@ -2,11 +2,13 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/events/data_change_event.dart';
+import 'package:expense_tracker/core/utils/currency_parser.dart';
 import 'package:expense_tracker/features/categories/domain/entities/category.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule_enums.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/usecases/add_recurring_rule.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/usecases/update_recurring_rule.dart';
+import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:expense_tracker/features/transactions/domain/entities/transaction_entity.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
@@ -47,99 +49,138 @@ class AddEditRecurringRuleBloc
     InitializeForEdit event,
     Emitter<AddEditRecurringRuleState> emit,
   ) {
-    emit(state.copyWith(
-      isEditMode: true,
-      initialRule: event.rule,
-      description: event.rule.description,
-      amount: event.rule.amount,
-      transactionType: event.rule.transactionType,
-      accountId: event.rule.accountId,
-      categoryId: event.rule.categoryId,
-      frequency: event.rule.frequency,
-      interval: event.rule.interval,
-      startDate: event.rule.startDate,
-      startTime: TimeOfDay.fromDateTime(event.rule.startDate),
-      dayOfWeek: event.rule.dayOfWeek,
-      dayOfMonth: event.rule.dayOfMonth,
-      endConditionType: event.rule.endConditionType,
-      endDate: event.rule.endDate,
-      totalOccurrences: event.rule.totalOccurrences,
-    ));
+    emit(
+      state.copyWith(
+        isEditMode: true,
+        initialRule: event.rule,
+        description: event.rule.description,
+        amount: event.rule.amount,
+        transactionType: event.rule.transactionType,
+        accountId: event.rule.accountId,
+        categoryId: event.rule.categoryId,
+        frequency: event.rule.frequency,
+        interval: event.rule.interval,
+        startDate: event.rule.startDate,
+        startTime: TimeOfDay.fromDateTime(event.rule.startDate),
+        dayOfWeek: event.rule.dayOfWeek,
+        dayOfMonth: event.rule.dayOfMonth,
+        endConditionType: event.rule.endConditionType,
+        endDate: event.rule.endDate,
+        totalOccurrences: event.rule.totalOccurrences,
+      ),
+    );
   }
 
   void _onDescriptionChanged(
-      DescriptionChanged event, Emitter<AddEditRecurringRuleState> emit) {
+    DescriptionChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
     emit(state.copyWith(description: event.description));
   }
 
   void _onAmountChanged(
-      AmountChanged event, Emitter<AddEditRecurringRuleState> emit) {
-    emit(state.copyWith(amount: double.tryParse(event.amount) ?? 0.0));
+    AmountChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
+    final locale = sl<SettingsBloc>().state.selectedCountryCode;
+    final amount = parseCurrency(event.amount, locale);
+    emit(state.copyWith(amount: amount.isNaN ? 0.0 : amount));
   }
 
   void _onTransactionTypeChanged(
-      TransactionTypeChanged event, Emitter<AddEditRecurringRuleState> emit) {
-    emit(state.copyWith(
-      transactionType: event.transactionType,
-      categoryId: null,
-      selectedCategory: null,
-    ));
+    TransactionTypeChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        transactionType: event.transactionType,
+        categoryId: null,
+        selectedCategory: null,
+      ),
+    );
   }
 
   void _onAccountChanged(
-      AccountChanged event, Emitter<AddEditRecurringRuleState> emit) {
+    AccountChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
     emit(state.copyWith(accountId: event.accountId));
   }
 
   void _onCategoryChanged(
-      CategoryChanged event, Emitter<AddEditRecurringRuleState> emit) {
-    emit(state.copyWith(
-        categoryId: event.category.id, selectedCategory: event.category));
+    CategoryChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        categoryId: event.category.id,
+        selectedCategory: event.category,
+      ),
+    );
   }
 
   void _onFrequencyChanged(
-      FrequencyChanged event, Emitter<AddEditRecurringRuleState> emit) {
+    FrequencyChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
     emit(state.copyWith(frequency: event.frequency));
   }
 
   void _onIntervalChanged(
-      IntervalChanged event, Emitter<AddEditRecurringRuleState> emit) {
+    IntervalChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
     emit(state.copyWith(interval: int.tryParse(event.interval) ?? 1));
   }
 
   void _onStartDateChanged(
-      StartDateChanged event, Emitter<AddEditRecurringRuleState> emit) {
+    StartDateChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
     emit(state.copyWith(startDate: event.startDate));
   }
 
   void _onEndConditionTypeChanged(
-      EndConditionTypeChanged event, Emitter<AddEditRecurringRuleState> emit) {
+    EndConditionTypeChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
     emit(state.copyWith(endConditionType: event.endConditionType));
   }
 
   void _onEndDateChanged(
-      EndDateChanged event, Emitter<AddEditRecurringRuleState> emit) {
+    EndDateChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
     emit(state.copyWith(endDate: event.endDate));
   }
 
   void _onTotalOccurrencesChanged(
-      TotalOccurrencesChanged event, Emitter<AddEditRecurringRuleState> emit) {
+    TotalOccurrencesChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
     emit(
-        state.copyWith(totalOccurrences: int.tryParse(event.occurrences) ?? 0));
+      state.copyWith(totalOccurrences: int.tryParse(event.occurrences) ?? 0),
+    );
   }
 
   void _onDayOfWeekChanged(
-      DayOfWeekChanged event, Emitter<AddEditRecurringRuleState> emit) {
+    DayOfWeekChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
     emit(state.copyWith(dayOfWeek: event.dayOfWeek));
   }
 
   void _onDayOfMonthChanged(
-      DayOfMonthChanged event, Emitter<AddEditRecurringRuleState> emit) {
+    DayOfMonthChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
     emit(state.copyWith(dayOfMonth: event.dayOfMonth));
   }
 
   void _onTimeChanged(
-      TimeChanged event, Emitter<AddEditRecurringRuleState> emit) {
+    TimeChanged event,
+    Emitter<AddEditRecurringRuleState> emit,
+  ) {
     emit(state.copyWith(startTime: event.time));
   }
 
@@ -150,10 +191,12 @@ class AddEditRecurringRuleBloc
     emit(state.copyWith(status: FormStatus.inProgress));
 
     if (state.accountId == null || state.categoryId == null) {
-      emit(state.copyWith(
-        status: FormStatus.failure,
-        errorMessage: 'Please select an account and a category.',
-      ));
+      emit(
+        state.copyWith(
+          status: FormStatus.failure,
+          errorMessage: 'Please select an account and a category.',
+        ),
+      );
       return;
     }
 
@@ -184,8 +227,9 @@ class AddEditRecurringRuleBloc
       nextOccurrenceDate: state.isEditMode
           ? state.initialRule!.nextOccurrenceDate
           : startDateTime,
-      occurrencesGenerated:
-          state.isEditMode ? state.initialRule!.occurrencesGenerated : 0,
+      occurrencesGenerated: state.isEditMode
+          ? state.initialRule!.occurrencesGenerated
+          : 0,
     );
 
     final result = state.isEditMode
@@ -193,10 +237,12 @@ class AddEditRecurringRuleBloc
         : await addRecurringRule(ruleToSave);
 
     result.fold(
-      (failure) => emit(state.copyWith(
-        status: FormStatus.failure,
-        errorMessage: failure.message,
-      )),
+      (failure) => emit(
+        state.copyWith(
+          status: FormStatus.failure,
+          errorMessage: failure.message,
+        ),
+      ),
       (_) {
         publishDataChangedEvent(
           type: DataChangeType.recurringRule,

--- a/lib/features/recurring_transactions/presentation/bloc/add_edit_recurring_rule/add_edit_recurring_rule_event.dart
+++ b/lib/features/recurring_transactions/presentation/bloc/add_edit_recurring_rule/add_edit_recurring_rule_event.dart
@@ -82,4 +82,13 @@ class TimeChanged extends AddEditRecurringRuleEvent {
   const TimeChanged(this.time);
 }
 
-class FormSubmitted extends AddEditRecurringRuleEvent {}
+class FormSubmitted extends AddEditRecurringRuleEvent {
+  final String description;
+  final String amount; // Pass the raw amount string from the controller
+
+  const FormSubmitted({required this.description, required this.amount});
+
+  @override
+  List<Object> get props => [description, amount];
+}
+

--- a/lib/features/recurring_transactions/presentation/pages/add_edit_recurring_rule_page.dart
+++ b/lib/features/recurring_transactions/presentation/pages/add_edit_recurring_rule_page.dart
@@ -8,6 +8,7 @@ import 'package:expense_tracker/features/recurring_transactions/domain/entities/
 import 'package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule_enums.dart';
 import 'package:expense_tracker/features/recurring_transactions/presentation/bloc/add_edit_recurring_rule/add_edit_recurring_rule_bloc.dart';
 import 'package:expense_tracker/features/transactions/domain/entities/transaction_entity.dart';
+import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
@@ -114,8 +115,9 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
           }
           if (_amountController.text !=
               (state.amount == 0 ? '' : state.amount.toString())) {
-            _amountController.text =
-                state.amount == 0 ? '' : state.amount.toString();
+            _amountController.text = state.amount == 0
+                ? ''
+                : state.amount.toString();
           }
           if (_intervalController.text != state.interval.toString()) {
             _intervalController.text = state.interval.toString();
@@ -137,8 +139,8 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                     context: context,
                     initialIndex:
                         state.transactionType == TransactionType.expense
-                            ? 0
-                            : 1,
+                        ? 0
+                        : 1,
                     labels: [
                       AppLocalizations.of(context)!.expense,
                       AppLocalizations.of(context)!.income,
@@ -159,8 +161,8 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                             ? TransactionType.expense
                             : TransactionType.income;
                         context.read<AddEditRecurringRuleBloc>().add(
-                              TransactionTypeChanged(newType),
-                            );
+                          TransactionTypeChanged(newType),
+                        );
                       }
                     },
                   ),
@@ -175,12 +177,14 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                         .add(DescriptionChanged(value)),
                   ),
                   const SizedBox(height: 16),
-                  TextFormField(
+                  CommonFormFields.buildAmountField(
+                    context: context,
                     controller: _amountController,
-                    decoration: InputDecoration(
-                      labelText: AppLocalizations.of(context)!.amount,
-                    ),
-                    keyboardType: TextInputType.number,
+                    labelText: AppLocalizations.of(context)!.amount,
+                    currencySymbol: context
+                        .read<SettingsBloc>()
+                        .state
+                        .currencySymbol,
                     onChanged: (value) => context
                         .read<AddEditRecurringRuleBloc>()
                         .add(AmountChanged(value)),
@@ -195,10 +199,11 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                     onTap: () async {
                       final filter =
                           state.transactionType == TransactionType.expense
-                              ? CategoryTypeFilter.expense
-                              : CategoryTypeFilter.income;
-                      final catState =
-                          context.read<CategoryManagementBloc>().state;
+                          ? CategoryTypeFilter.expense
+                          : CategoryTypeFilter.income;
+                      final catState = context
+                          .read<CategoryManagementBloc>()
+                          .state;
                       final list = filter == CategoryTypeFilter.expense
                           ? catState.allExpenseCategories
                           : catState.allIncomeCategories;
@@ -209,8 +214,8 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                       );
                       if (category != null) {
                         context.read<AddEditRecurringRuleBloc>().add(
-                              CategoryChanged(category),
-                            );
+                          CategoryChanged(category),
+                        );
                       }
                     },
                   ),
@@ -236,8 +241,8 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                     onChanged: (value) {
                       if (value != null) {
                         context.read<AddEditRecurringRuleBloc>().add(
-                              FrequencyChanged(value),
-                            );
+                          FrequencyChanged(value),
+                        );
                       }
                     },
                   ),
@@ -256,8 +261,8 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                         );
                         if (time != null) {
                           context.read<AddEditRecurringRuleBloc>().add(
-                                TimeChanged(time),
-                              );
+                            TimeChanged(time),
+                          );
                         }
                       },
                     ),
@@ -279,8 +284,8 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                       onChanged: (value) {
                         if (value != null) {
                           context.read<AddEditRecurringRuleBloc>().add(
-                                DayOfWeekChanged(value),
-                              );
+                            DayOfWeekChanged(value),
+                          );
                         }
                       },
                     ),
@@ -298,8 +303,8 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                       onChanged: (value) {
                         if (value != null) {
                           context.read<AddEditRecurringRuleBloc>().add(
-                                DayOfMonthChanged(value),
-                              );
+                            DayOfMonthChanged(value),
+                          );
                         }
                       },
                     ),
@@ -316,8 +321,8 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                     onChanged: (value) {
                       if (value != null) {
                         context.read<AddEditRecurringRuleBloc>().add(
-                              EndConditionTypeChanged(value),
-                            );
+                          EndConditionTypeChanged(value),
+                        );
                       }
                     },
                   ),
@@ -338,8 +343,8 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                         );
                         if (date != null) {
                           context.read<AddEditRecurringRuleBloc>().add(
-                                EndDateChanged(date),
-                              );
+                            EndDateChanged(date),
+                          );
                         }
                       },
                     ),
@@ -350,8 +355,7 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                       decoration: InputDecoration(
                         labelText: AppLocalizations.of(
                           context,
-                        )!
-                            .numberOfOccurrences,
+                        )!.numberOfOccurrences,
                       ),
                       keyboardType: TextInputType.number,
                       onChanged: (value) => context
@@ -363,8 +367,8 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                     onPressed: state.status == FormStatus.inProgress
                         ? null
                         : () => context.read<AddEditRecurringRuleBloc>().add(
-                              FormSubmitted(),
-                            ),
+                            FormSubmitted(),
+                          ),
                     child: state.status == FormStatus.inProgress
                         ? const CircularProgressIndicator()
                         : Text(AppLocalizations.of(context)!.save),

--- a/lib/features/recurring_transactions/presentation/pages/add_edit_recurring_rule_page.dart
+++ b/lib/features/recurring_transactions/presentation/pages/add_edit_recurring_rule_page.dart
@@ -185,9 +185,6 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                         .read<SettingsBloc>()
                         .state
                         .currencySymbol,
-                    onChanged: (value) => context
-                        .read<AddEditRecurringRuleBloc>()
-                        .add(AmountChanged(value)),
                   ),
                   const SizedBox(height: 16),
                   ListTile(
@@ -366,9 +363,14 @@ class _AddEditRecurringRuleViewState extends State<AddEditRecurringRuleView> {
                   ElevatedButton(
                     onPressed: state.status == FormStatus.inProgress
                         ? null
-                        : () => context.read<AddEditRecurringRuleBloc>().add(
-                            FormSubmitted(),
-                          ),
+                        : () {
+                      context.read<AddEditRecurringRuleBloc>().add(
+                        FormSubmitted(
+                          description: _descriptionController.text,
+                          amount: _amountController.text,
+                        ),
+                      );
+                    },
                     child: state.status == FormStatus.inProgress
                         ? const CircularProgressIndicator()
                         : Text(AppLocalizations.of(context)!.save),

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,7 +15,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
-  FLALocalAuthPlugin.register(with: registry.registrar(forPlugin: "FLALocalAuthPlugin"))
+  LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/test/core/utils/currency_parser_test.dart
+++ b/test/core/utils/currency_parser_test.dart
@@ -14,6 +14,11 @@ void main() {
       expect(result, closeTo(1234.56, 0.001));
     });
 
+    test('parses numbers when locale is a country code', () {
+      final result = parseCurrency('3000', 'US');
+      expect(result, 3000);
+    });
+
     test('returns NaN for invalid input', () {
       final result = parseCurrency('abc', 'en_US');
       expect(result.isNaN, isTrue);

--- a/test/core/widgets/amount_input_formatter_test.dart
+++ b/test/core/widgets/amount_input_formatter_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+TextInputFormatter buildAmountFormatter() {
+  return TextInputFormatter.withFunction((oldValue, newValue) {
+    final sanitized = newValue.text.replaceAll(RegExp('[^0-9.,]'), '');
+    return newValue.copyWith(
+      text: sanitized,
+      selection: TextSelection.collapsed(offset: sanitized.length),
+    );
+  });
+}
+
+void main() {
+  test('amount formatter allows multi-digit numbers', () {
+    final formatter = buildAmountFormatter();
+    final result = formatter.formatEditUpdate(
+      TextEditingValue.empty,
+      const TextEditingValue(text: '222'),
+    );
+    expect(result.text, '222');
+  });
+
+  test('amount formatter strips invalid characters', () {
+    final formatter = buildAmountFormatter();
+    final result = formatter.formatEditUpdate(
+      TextEditingValue.empty,
+      const TextEditingValue(text: '12a3'),
+    );
+    expect(result.text, '123');
+  });
+}

--- a/test/features/recurring_transactions/presentation/bloc/add_edit_recurring_rule_bloc_test.dart
+++ b/test/features/recurring_transactions/presentation/bloc/add_edit_recurring_rule_bloc_test.dart
@@ -158,7 +158,7 @@ void main() {
         bloc.add(CategoryChanged(tCategory));
         bloc.add(StartDateChanged(DateTime(2024, 1, 1)));
         bloc.add(TimeChanged(const TimeOfDay(hour: 9, minute: 30)));
-        bloc.add(FormSubmitted());
+        bloc.add(FormSubmitted(description: '', amount: ''));
       },
       skip: 6,
       expect: () => [
@@ -198,7 +198,7 @@ void main() {
         description: tRule.description,
         amount: tRule.amount,
       ),
-      act: (bloc) => bloc.add(FormSubmitted()),
+      act: (bloc) => bloc.add(FormSubmitted(description: '', amount: '')),
       expect: () => [
         isA<AddEditRecurringRuleState>().having(
           (s) => s.status,

--- a/windows/flutter/CMakeLists.txt
+++ b/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS


### PR DESCRIPTION
## Summary
- normalize locale codes like `US` to `en_US` and add fallback parsing in `parseCurrency`
- cover parsing of country-code locales with a new unit test

## Testing
- `flutter analyze`
- `flutter test`