### PR TITLE
🎨 Palette: Allow punctuation in transaction titles

### DIFF
--- a/lib/core/widgets/common_form_fields.dart
+++ b/lib/core/widgets/common_form_fields.dart
@@ -61,15 +61,12 @@ class CommonFormFields {
       hintText: hintText,
       prefixIcon: getPrefixIcon(context, iconKey, fallbackIcon),
       textCapitalization: textCapitalization,
-      validator:
-          validator ??
+      validator: validator ??
           (value) {
             if (value == null || value.trim().isEmpty) {
               return 'Please enter a value';
             }
-            // Ensure only alphanumeric characters and spaces are used
-            final isValid = RegExp(r'^[a-zA-Z0-9 ]+$').hasMatch(value.trim());
-            return isValid ? null : 'Only letters and numbers allowed';
+            return null;
           },
     );
   }
@@ -94,14 +91,11 @@ class CommonFormFields {
       inputFormatters: [
         FilteringTextInputFormatter.allow(RegExp(r'^\d*[,.]?\d{0,2}')),
       ],
-      validator:
-          validator ??
+      validator: validator ??
           (value) {
             if (value == null || value.isEmpty) return 'Enter amount';
-            final locale = context
-                .read<SettingsBloc>()
-                .state
-                .selectedCountryCode;
+            final locale =
+                context.read<SettingsBloc>().state.selectedCountryCode;
             final number = parseCurrency(value, locale);
             if (number.isNaN) return 'Invalid number';
             if (number <= 0) return 'Must be positive';
@@ -145,8 +139,7 @@ class CommonFormFields {
     final theme = Theme.of(context);
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: 12),
-      shape:
-          theme.inputDecorationTheme.enabledBorder ??
+      shape: theme.inputDecorationTheme.enabledBorder ??
           OutlineInputBorder(
             borderRadius: BorderRadius.circular(8.0),
             borderSide: BorderSide(color: theme.dividerColor),
@@ -188,8 +181,7 @@ class CommonFormFields {
     return AccountSelectorDropdown(
       selectedAccountId: selectedAccountId,
       onChanged: onChanged,
-      validator:
-          validator ??
+      validator: validator ??
           (value) => value == null ? 'Please select an account' : null,
       labelText: labelText,
       hintText: hintText,

--- a/test/core/widgets/common_form_fields_test.dart
+++ b/test/core/widgets/common_form_fields_test.dart
@@ -42,10 +42,10 @@ void main() {
         expect(find.text('Please enter a value'), findsOneWidget);
       });
 
-      testWidgets('validator shows error for invalid characters', (
+      testWidgets('validator accepts valid characters including punctuation', (
         tester,
       ) async {
-        controller.text = 'Invalid@Name';
+        controller.text = 'Valid - Name & More';
         await pumpWidgetWithProviders(
           tester: tester,
           widget: Builder(
@@ -61,7 +61,7 @@ void main() {
         );
         formKey.currentState!.validate();
         await tester.pump();
-        expect(find.text('Only letters and numbers allowed'), findsOneWidget);
+        expect(find.text('Only letters and numbers allowed'), findsNothing);
       });
     });
 


### PR DESCRIPTION
This change removes the restrictive regex validation in the common name field builder, allowing users to enter titles and names with punctuation (e.g., "O'Connor", "My-Wallet", "Groceries & Food"). This improves the user experience by not blocking valid inputs.

---
*PR created automatically by Jules for task [11581192170151027055](https://jules.google.com/task/11581192170151027055) started by @Aditya-Bichave*