### PR TITLE
⚡ Bolt: Optimize transaction list rendering

### DIFF
--- a/lib/features/expenses/presentation/widgets/expense_card.dart
+++ b/lib/features/expenses/presentation/widgets/expense_card.dart
@@ -2,7 +2,6 @@
 // MODIFIED FILE (Implement interactive prompts)
 
 import 'package:expense_tracker/core/theme/app_mode_theme.dart';
-import 'package:expense_tracker/features/accounts/presentation/bloc/account_list/account_list_bloc.dart';
 import 'package:expense_tracker/features/categories/domain/entities/categorization_status.dart';
 import 'package:expense_tracker/features/categories/domain/entities/category.dart';
 import 'package:flutter/material.dart';
@@ -10,7 +9,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
 import 'package:expense_tracker/core/utils/date_formatter.dart';
 import 'package:expense_tracker/core/utils/currency_formatter.dart';
-import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:expense_tracker/core/widgets/app_card.dart';
 import 'package:expense_tracker/main.dart';
@@ -19,6 +17,8 @@ import 'package:expense_tracker/features/transactions/presentation/widgets/categ
 
 class ExpenseCard extends StatelessWidget {
   final Expense expense;
+  final String accountName;
+  final String currencySymbol;
   final Function(Expense expense)? onCardTap;
   final Function(Expense expense, Category selectedCategory)? onUserCategorized;
   final Function(Expense expense)? onChangeCategoryRequest;
@@ -26,6 +26,8 @@ class ExpenseCard extends StatelessWidget {
   const ExpenseCard({
     super.key,
     required this.expense,
+    required this.accountName,
+    required this.currencySymbol,
     this.onCardTap,
     this.onUserCategorized,
     this.onChangeCategoryRequest,
@@ -96,23 +98,9 @@ class ExpenseCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final settingsState = context.watch<SettingsBloc>().state;
-    final currencySymbol = settingsState.currencySymbol;
     final modeTheme = context.modeTheme;
     final category = expense.category ?? Category.uncategorized;
-    final accountState = context.watch<AccountListBloc>().state;
-    String accountName = '...';
-    if (accountState is AccountListLoaded) {
-      try {
-        accountName = accountState.items
-            .firstWhere((acc) => acc.id == expense.accountId)
-            .name;
-      } catch (_) {
-        accountName = 'Deleted';
-      }
-    } else if (accountState is AccountListError) {
-      accountName = 'Error';
-    }
+
     return AppCard(
       onTap: () => onCardTap?.call(expense),
       child: Row(

--- a/lib/features/income/presentation/widgets/income_card.dart
+++ b/lib/features/income/presentation/widgets/income_card.dart
@@ -2,7 +2,6 @@
 // MODIFIED FILE (Implement interactive prompts)
 
 import 'package:expense_tracker/core/theme/app_mode_theme.dart';
-import 'package:expense_tracker/features/accounts/presentation/bloc/account_list/account_list_bloc.dart';
 import 'package:expense_tracker/features/categories/domain/entities/categorization_status.dart';
 import 'package:expense_tracker/features/categories/domain/entities/category.dart';
 import 'package:flutter/material.dart';
@@ -10,7 +9,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:expense_tracker/features/income/domain/entities/income.dart';
 import 'package:expense_tracker/core/utils/date_formatter.dart';
 import 'package:expense_tracker/core/utils/currency_formatter.dart';
-import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:expense_tracker/core/widgets/app_card.dart';
 import 'package:expense_tracker/main.dart';
@@ -19,6 +17,8 @@ import 'package:expense_tracker/features/transactions/presentation/widgets/categ
 
 class IncomeCard extends StatelessWidget {
   final Income income;
+  final String accountName;
+  final String currencySymbol;
   final Function(Income income)? onCardTap;
   final Function(Income income, Category selectedCategory)? onUserCategorized;
   final Function(Income income)? onChangeCategoryRequest;
@@ -26,6 +26,8 @@ class IncomeCard extends StatelessWidget {
   const IncomeCard({
     super.key,
     required this.income,
+    required this.accountName,
+    required this.currencySymbol,
     this.onCardTap,
     this.onUserCategorized,
     this.onChangeCategoryRequest,
@@ -86,23 +88,9 @@ class IncomeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final settingsState = context.watch<SettingsBloc>().state;
-    final currencySymbol = settingsState.currencySymbol;
     final modeTheme = context.modeTheme;
     final category = income.category ?? Category.uncategorized;
-    final accountState = context.watch<AccountListBloc>().state;
-    String accountName = '...';
-    if (accountState is AccountListLoaded) {
-      try {
-        accountName = accountState.items
-            .firstWhere((acc) => acc.id == income.accountId)
-            .name;
-      } catch (_) {
-        accountName = 'Deleted';
-      }
-    } else if (accountState is AccountListError) {
-      accountName = 'Error';
-    }
+
     final Color incomeAmountColor =
         modeTheme?.incomeGlowColor ?? Colors.green.shade700;
     return AppCard(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -649,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1126,26 +1126,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
*   💡 What: Hoisted `AccountListBloc` subscription and account name lookup from `ExpenseCard`/`IncomeCard` to `TransactionListView`.
*   🎯 Why: To prevent O(N) Bloc listeners and O(N*M) lookups when rendering the transaction list.
*   📊 Impact: Reduces Bloc subscriptions from N+1 to 1 for the list. Eliminates redundant account name lookups during build.
*   🔬 Measurement: `flutter test test/features/transactions/presentation/widgets/transaction_list_view_test.dart` passes.

---
*PR created automatically by Jules for task [6571082481366945888](https://jules.google.com/task/6571082481366945888) started by @Aditya-Bichave*