### PR TITLE
🎨 Palette: Relax transaction title validation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Restrictive Transaction Titles
+**Learning:** Default "alphanumeric only" validation on transaction titles blocks valid real-world inputs like "Ben & Jerry's", "Rent (July)", or "T-Mobile". This creates significant friction for users trying to record normal expenses.
+**Action:** When building text input fields for names or descriptions, default to permissive validation (non-empty) and only add restrictions if technically required (e.g. IDs) or strictly business-logic driven.

--- a/lib/core/widgets/common_form_fields.dart
+++ b/lib/core/widgets/common_form_fields.dart
@@ -67,9 +67,7 @@ class CommonFormFields {
             if (value == null || value.trim().isEmpty) {
               return 'Please enter a value';
             }
-            // Ensure only alphanumeric characters and spaces are used
-            final isValid = RegExp(r'^[a-zA-Z0-9 ]+$').hasMatch(value.trim());
-            return isValid ? null : 'Only letters and numbers allowed';
+            return null;
           },
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -649,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1126,26 +1126,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/test/core/widgets/common_form_fields_test.dart
+++ b/test/core/widgets/common_form_fields_test.dart
@@ -42,10 +42,10 @@ void main() {
         expect(find.text('Please enter a value'), findsOneWidget);
       });
 
-      testWidgets('validator shows error for invalid characters', (
+      testWidgets('validator allows special characters', (
         tester,
       ) async {
-        controller.text = 'Invalid@Name';
+        controller.text = 'Valid & Name!';
         await pumpWidgetWithProviders(
           tester: tester,
           widget: Builder(
@@ -61,7 +61,8 @@ void main() {
         );
         formKey.currentState!.validate();
         await tester.pump();
-        expect(find.text('Only letters and numbers allowed'), findsOneWidget);
+        // Should NOT find the error message
+        expect(find.text('Only letters and numbers allowed'), findsNothing);
       });
     });
 


### PR DESCRIPTION
🎨 Palette Improvement: Relax Transaction Title Validation

💡 **What:**
Removed the restrictive regex validation `RegExp(r'^[a-zA-Z0-9 ]+$')` from `CommonFormFields.buildNameField`.

🎯 **Why:**
The previous validation prevented users from entering common and valid transaction names containing special characters, such as:
- "Ben & Jerry's" (Ampersand & Apostrophe)
- "Rent - July" (Dash)
- "Groceries (Whole Foods)" (Parentheses)
- "T-Mobile" (Dash)

This caused unnecessary friction and frustration. The new validation only checks that the field is not empty, which is sufficient for a descriptive text field in a personal finance app.

♿ **Accessibility / UX:**
- Reduced friction for all users.
- Respects user intent by allowing them to describe their expenses in their own words.

**Testing:**
- Updated `test/core/widgets/common_form_fields_test.dart` to assert that special characters are now allowed (and previously would have failed).
- Verified that empty strings are still rejected.

---
*PR created automatically by Jules for task [13552747737279536875](https://jules.google.com/task/13552747737279536875) started by @Aditya-Bichave*