### PR TITLE
🎨 Palette: Relax name validation to allow punctuation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Default Name Validation too Restrictive
+**Learning:** `CommonFormFields.buildNameField` enforced alphanumeric-only validation by default, which is poor UX for user-generated content like transaction titles where punctuation is common.
+**Action:** Review centralized form field builders for overly restrictive default validators; prefer permissive validation (checking only for emptiness) for general text fields.

--- a/lib/core/widgets/common_form_fields.dart
+++ b/lib/core/widgets/common_form_fields.dart
@@ -67,9 +67,7 @@ class CommonFormFields {
             if (value == null || value.trim().isEmpty) {
               return 'Please enter a value';
             }
-            // Ensure only alphanumeric characters and spaces are used
-            final isValid = RegExp(r'^[a-zA-Z0-9 ]+$').hasMatch(value.trim());
-            return isValid ? null : 'Only letters and numbers allowed';
+            return null;
           },
     );
   }

--- a/test/core/widgets/common_form_fields_test.dart
+++ b/test/core/widgets/common_form_fields_test.dart
@@ -42,10 +42,8 @@ void main() {
         expect(find.text('Please enter a value'), findsOneWidget);
       });
 
-      testWidgets('validator shows error for invalid characters', (
-        tester,
-      ) async {
-        controller.text = 'Invalid@Name';
+      testWidgets('validator allows special characters', (tester) async {
+        controller.text = 'Valid@Name & More!';
         await pumpWidgetWithProviders(
           tester: tester,
           widget: Builder(
@@ -61,7 +59,7 @@ void main() {
         );
         formKey.currentState!.validate();
         await tester.pump();
-        expect(find.text('Only letters and numbers allowed'), findsOneWidget);
+        expect(find.text('Only letters and numbers allowed'), findsNothing);
       });
     });
 


### PR DESCRIPTION
Relaxed the validation logic in `CommonFormFields.buildNameField` to allow special characters and punctuation. Previously, the validation strictly enforced alphanumeric characters, which prevented users from entering common names or titles containing symbols (e.g., "O'Reilly's", "Ben & Jerry's"). This change improves usability while maintaining the essential "required" check. Tests were updated to reflect this change.

---
*PR created automatically by Jules for task [17162110322158501767](https://jules.google.com/task/17162110322158501767) started by @Aditya-Bichave*