### PR TITLE
Test Coverage Increase for Analytics and Reports

### DIFF
--- a/lib/features/analytics/presentation/bloc/summary_bloc.dart
+++ b/lib/features/analytics/presentation/bloc/summary_bloc.dart
@@ -85,7 +85,19 @@ class SummaryBloc extends Bloc<SummaryEvent, SummaryState> {
 
     // Emit loading state only if not already loaded or forced
     if (state is! SummaryLoaded || event.forceReload) {
-      emit(SummaryLoading(isReloading: state is SummaryLoaded));
+      ExpenseSummary? previousSummary;
+      final currentState = state;
+      if (currentState is SummaryLoaded) {
+        previousSummary = currentState.summary;
+      } else if (currentState is SummaryLoading) {
+        previousSummary = currentState.previousSummary;
+      }
+
+      emit(SummaryLoading(
+        isReloading: currentState is SummaryLoaded ||
+            (currentState is SummaryLoading && currentState.isReloading),
+        previousSummary: previousSummary,
+      ));
       log.info(
           "[SummaryBloc] Emitting SummaryLoading (isReloading: ${state is SummaryLoaded}).");
     } else {

--- a/lib/features/analytics/presentation/bloc/summary_state.dart
+++ b/lib/features/analytics/presentation/bloc/summary_state.dart
@@ -12,10 +12,12 @@ class SummaryInitial extends SummaryState {}
 class SummaryLoading extends SummaryState {
   final bool
       isReloading; // True if loading triggered while data was already loaded
-  const SummaryLoading({this.isReloading = false});
+  final ExpenseSummary? previousSummary;
+
+  const SummaryLoading({this.isReloading = false, this.previousSummary});
 
   @override
-  List<Object> get props => [isReloading];
+  List<Object?> get props => [isReloading, previousSummary];
 }
 
 class SummaryLoaded extends SummaryState {

--- a/lib/features/analytics/presentation/widgets/summary_card.dart
+++ b/lib/features/analytics/presentation/widgets/summary_card.dart
@@ -35,8 +35,9 @@ class SummaryCard extends StatelessWidget {
               "[SummaryCard UI] State is SummaryLoaded or reloading. Building card content.");
           final summary = (state is SummaryLoaded)
               ? state.summary
-              : (context.read<SummaryBloc>().state as SummaryLoaded?)
-                  ?.summary; // Use previous data if reloading
+              : (state is SummaryLoading)
+                  ? state.previousSummary
+                  : null; // Use previous data if reloading
 
           if (summary == null) {
             // Should not happen if reloading logic is correct, but safety check

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -649,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1126,26 +1126,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/test/features/analytics/domain/entities/expense_summary_test.dart
+++ b/test/features/analytics/domain/entities/expense_summary_test.dart
@@ -1,0 +1,25 @@
+import 'package:expense_tracker/features/analytics/domain/entities/expense_summary.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ExpenseSummary', () {
+    const double totalExpenses = 100.0;
+    final Map<String, double> categoryBreakdown = {'Food': 60.0, 'Transport': 40.0};
+    final expenseSummary = ExpenseSummary(
+      totalExpenses: totalExpenses,
+      categoryBreakdown: categoryBreakdown,
+    );
+
+    test('supports value equality', () {
+      final expenseSummary2 = ExpenseSummary(
+        totalExpenses: totalExpenses,
+        categoryBreakdown: categoryBreakdown,
+      );
+      expect(expenseSummary, equals(expenseSummary2));
+    });
+
+    test('props are correct', () {
+      expect(expenseSummary.props, [totalExpenses, categoryBreakdown]);
+    });
+  });
+}

--- a/test/features/analytics/domain/usecases/get_expense_summary_test.dart
+++ b/test/features/analytics/domain/usecases/get_expense_summary_test.dart
@@ -1,0 +1,66 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/features/analytics/domain/entities/expense_summary.dart';
+import 'package:expense_tracker/features/analytics/domain/usecases/get_expense_summary.dart';
+import 'package:expense_tracker/features/expenses/domain/repositories/expense_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockExpenseRepository extends Mock implements ExpenseRepository {}
+
+void main() {
+  late GetExpenseSummaryUseCase usecase;
+  late MockExpenseRepository mockExpenseRepository;
+
+  setUp(() {
+    mockExpenseRepository = MockExpenseRepository();
+    usecase = GetExpenseSummaryUseCase(mockExpenseRepository);
+  });
+
+  const tExpenseSummary = ExpenseSummary(
+    totalExpenses: 100.0,
+    categoryBreakdown: {'Food': 100.0},
+  );
+  final tStartDate = DateTime(2023, 1, 1);
+  final tEndDate = DateTime(2023, 1, 31);
+  final tParams = GetSummaryParams(startDate: tStartDate, endDate: tEndDate);
+
+  test(
+    'should get expense summary from the repository',
+    () async {
+      // arrange
+      when(() => mockExpenseRepository.getExpenseSummary(
+            startDate: tStartDate,
+            endDate: tEndDate,
+          )).thenAnswer((_) async => const Right(tExpenseSummary));
+      // act
+      final result = await usecase(tParams);
+      // assert
+      expect(result, const Right(tExpenseSummary));
+      verify(() => mockExpenseRepository.getExpenseSummary(
+            startDate: tStartDate,
+            endDate: tEndDate,
+          ));
+      verifyNoMoreInteractions(mockExpenseRepository);
+    },
+  );
+
+  test(
+    'should return null for start and end dates when params are empty',
+    () async {
+      // arrange
+      when(() => mockExpenseRepository.getExpenseSummary(
+            startDate: null,
+            endDate: null,
+          )).thenAnswer((_) async => const Right(tExpenseSummary));
+      // act
+      final result = await usecase(const GetSummaryParams());
+      // assert
+      expect(result, const Right(tExpenseSummary));
+      verify(() => mockExpenseRepository.getExpenseSummary(
+            startDate: null,
+            endDate: null,
+          ));
+      verifyNoMoreInteractions(mockExpenseRepository);
+    },
+  );
+}

--- a/test/features/analytics/presentation/bloc/summary_bloc_test.dart
+++ b/test/features/analytics/presentation/bloc/summary_bloc_test.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/core/events/data_change_event.dart';
+import 'package:expense_tracker/features/analytics/domain/entities/expense_summary.dart';
+import 'package:expense_tracker/features/analytics/domain/usecases/get_expense_summary.dart';
+import 'package:expense_tracker/features/analytics/presentation/bloc/summary_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockGetExpenseSummaryUseCase extends Mock
+    implements GetExpenseSummaryUseCase {}
+
+class FakeGetSummaryParams extends Fake implements GetSummaryParams {}
+
+void main() {
+  late MockGetExpenseSummaryUseCase mockUseCase;
+  late StreamController<DataChangedEvent> dataChangeStreamController;
+  late SummaryBloc bloc;
+
+  setUpAll(() {
+    registerFallbackValue(FakeGetSummaryParams());
+  });
+
+  setUp(() {
+    mockUseCase = MockGetExpenseSummaryUseCase();
+    dataChangeStreamController = StreamController<DataChangedEvent>.broadcast();
+    bloc = SummaryBloc(
+      getExpenseSummaryUseCase: mockUseCase,
+      dataChangeStream: dataChangeStreamController.stream,
+    );
+  });
+
+  tearDown(() {
+    bloc.close();
+    dataChangeStreamController.close();
+  });
+
+  const tExpenseSummary = ExpenseSummary(
+    totalExpenses: 100.0,
+    categoryBreakdown: {'Food': 100.0},
+  );
+  final tStartDate = DateTime(2023, 1, 1);
+  final tEndDate = DateTime(2023, 1, 31);
+
+  test('initial state is SummaryInitial', () {
+    expect(bloc.state, isA<SummaryInitial>());
+  });
+
+  blocTest<SummaryBloc, SummaryState>(
+    'emits [SummaryLoading, SummaryLoaded] when LoadSummary is added and succeeds',
+    build: () {
+      when(() => mockUseCase(any()))
+          .thenAnswer((_) async => const Right(tExpenseSummary));
+      return bloc;
+    },
+    act: (bloc) => bloc.add(LoadSummary(startDate: tStartDate, endDate: tEndDate)),
+    expect: () => [
+      const SummaryLoading(isReloading: false),
+      const SummaryLoaded(tExpenseSummary),
+    ],
+    verify: (_) {
+      verify(() => mockUseCase(
+            GetSummaryParams(startDate: tStartDate, endDate: tEndDate),
+          )).called(1);
+    },
+  );
+
+  blocTest<SummaryBloc, SummaryState>(
+    'emits [SummaryLoading, SummaryError] when LoadSummary is added and fails',
+    build: () {
+      when(() => mockUseCase(any()))
+          .thenAnswer((_) async => const Left(CacheFailure('Error')));
+      return bloc;
+    },
+    act: (bloc) => bloc.add(const LoadSummary()),
+    expect: () => [
+      const SummaryLoading(isReloading: false),
+      const SummaryError('Could not load summary from local data. Error'),
+    ],
+  );
+
+  blocTest<SummaryBloc, SummaryState>(
+    'emits [SummaryLoading, SummaryLoaded] with previous data when reloading',
+    seed: () => const SummaryLoaded(tExpenseSummary),
+    build: () {
+      when(() => mockUseCase(any()))
+          .thenAnswer((_) async => const Right(tExpenseSummary));
+      return bloc;
+    },
+    act: (bloc) => bloc.add(const LoadSummary(forceReload: true)),
+    expect: () => [
+      const SummaryLoading(isReloading: true, previousSummary: tExpenseSummary),
+      const SummaryLoaded(tExpenseSummary),
+    ],
+  );
+
+  blocTest<SummaryBloc, SummaryState>(
+    'reloads data when DataChangedEvent (expense) is received',
+    build: () {
+      when(() => mockUseCase(any()))
+          .thenAnswer((_) async => const Right(tExpenseSummary));
+      return bloc;
+    },
+    act: (bloc) async {
+      // First load to set state
+      bloc.add(LoadSummary(startDate: tStartDate, endDate: tEndDate));
+      // Wait for initial load to complete
+      await Future.delayed(Duration.zero);
+      // Trigger data change
+      dataChangeStreamController.add(const DataChangedEvent(
+          type: DataChangeType.expense, reason: DataChangeReason.added));
+    },
+    // We expect initial load sequence, then reload sequence
+    // But since `act` is async and `blocTest` waits for stream to settle...
+    // Let's just focus on the reload part by seeding?
+    // But stream listener is in constructor.
+    // If we seed, `_currentStartDate` is null.
+    // Let's just verify the reload happens.
+    skip: 0, // Don't skip
+    expect: () => [
+      const SummaryLoading(isReloading: false),
+      const SummaryLoaded(tExpenseSummary),
+      const SummaryLoading(isReloading: true, previousSummary: tExpenseSummary),
+      const SummaryLoaded(tExpenseSummary),
+    ],
+  );
+
+  blocTest<SummaryBloc, SummaryState>(
+    'resets state when DataChangedEvent (reset) is received',
+    seed: () => const SummaryLoaded(tExpenseSummary),
+    build: () {
+      when(() => mockUseCase(any()))
+          .thenAnswer((_) async => const Right(tExpenseSummary));
+      return bloc;
+    },
+    act: (bloc) => dataChangeStreamController.add(const DataChangedEvent(
+      type: DataChangeType.system,
+      reason: DataChangeReason.reset,
+    )),
+    expect: () => [
+      SummaryInitial(),
+      const SummaryLoading(isReloading: false),
+      const SummaryLoaded(tExpenseSummary),
+    ],
+  );
+}

--- a/test/features/analytics/presentation/widgets/summary_card_test.dart
+++ b/test/features/analytics/presentation/widgets/summary_card_test.dart
@@ -1,0 +1,97 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:expense_tracker/features/analytics/domain/entities/expense_summary.dart';
+import 'package:expense_tracker/features/analytics/presentation/bloc/summary_bloc.dart';
+import 'package:expense_tracker/features/analytics/presentation/widgets/summary_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+class MockSummaryBloc extends MockBloc<SummaryEvent, SummaryState>
+    implements SummaryBloc {}
+
+void main() {
+  late MockSummaryBloc mockSummaryBloc;
+
+  setUp(() {
+    mockSummaryBloc = MockSummaryBloc();
+  });
+
+  const tExpenseSummary = ExpenseSummary(
+    totalExpenses: 150.0,
+    categoryBreakdown: {'Food': 100.0, 'Transport': 50.0},
+  );
+
+  testWidgets('renders loading indicator when state is SummaryLoading (initial)',
+      (tester) async {
+    when(() => mockSummaryBloc.state)
+        .thenReturn(const SummaryLoading(isReloading: false));
+
+    await pumpWidgetWithProviders(
+      tester: tester,
+      widget: const SummaryCard(),
+      blocProviders: [
+        BlocProvider<SummaryBloc>.value(value: mockSummaryBloc),
+      ],
+      settle: false,
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('renders summary content when state is SummaryLoaded',
+      (tester) async {
+    when(() => mockSummaryBloc.state)
+        .thenReturn(const SummaryLoaded(tExpenseSummary));
+
+    await pumpWidgetWithProviders(
+      tester: tester,
+      widget: const SummaryCard(),
+      blocProviders: [
+        BlocProvider<SummaryBloc>.value(value: mockSummaryBloc),
+      ],
+    );
+
+    expect(find.text('Expense Summary'), findsOneWidget);
+    expect(find.text('Total Spent:'), findsOneWidget);
+    expect(find.text('Food'), findsOneWidget);
+    expect(find.text('Transport'), findsOneWidget);
+  });
+
+  testWidgets('renders previous summary content when reloading',
+      (tester) async {
+    when(() => mockSummaryBloc.state).thenReturn(const SummaryLoading(
+      isReloading: true,
+      previousSummary: tExpenseSummary,
+    ));
+
+    await pumpWidgetWithProviders(
+      tester: tester,
+      widget: const SummaryCard(),
+      blocProviders: [
+        BlocProvider<SummaryBloc>.value(value: mockSummaryBloc),
+      ],
+    );
+
+    expect(find.text('Expense Summary'), findsOneWidget);
+    expect(find.text('Food'), findsOneWidget);
+  });
+
+  testWidgets('renders error message when state is SummaryError',
+      (tester) async {
+    when(() => mockSummaryBloc.state)
+        .thenReturn(const SummaryError('Failed to load'));
+
+    await pumpWidgetWithProviders(
+      tester: tester,
+      widget: const SummaryCard(),
+      blocProviders: [
+        BlocProvider<SummaryBloc>.value(value: mockSummaryBloc),
+      ],
+    );
+
+    expect(find.text('Error loading summary: Failed to load'), findsOneWidget);
+  });
+}

--- a/test/features/expenses/data/repositories/expense_repository_impl_summary_test.dart
+++ b/test/features/expenses/data/repositories/expense_repository_impl_summary_test.dart
@@ -1,0 +1,166 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/analytics/domain/entities/expense_summary.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category_type.dart';
+import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
+import 'package:expense_tracker/features/expenses/data/datasources/expense_local_data_source.dart';
+import 'package:expense_tracker/features/expenses/data/models/expense_model.dart';
+import 'package:expense_tracker/features/expenses/data/repositories/expense_repository_impl.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockExpenseLocalDataSource extends Mock
+    implements ExpenseLocalDataSource {}
+
+class MockCategoryRepository extends Mock implements CategoryRepository {}
+
+void main() {
+  late MockExpenseLocalDataSource mockDataSource;
+  late MockCategoryRepository mockCategoryRepository;
+  late ExpenseRepositoryImpl repository;
+
+  setUp(() {
+    mockDataSource = MockExpenseLocalDataSource();
+    mockCategoryRepository = MockCategoryRepository();
+    repository = ExpenseRepositoryImpl(
+      localDataSource: mockDataSource,
+      categoryRepository: mockCategoryRepository,
+    );
+  });
+
+  const tCategoryId1 = 'c1';
+  const tCategoryId2 = 'c2';
+  const tCategoryName1 = 'Food';
+  const tCategoryName2 = 'Transport';
+
+  final tCategory1 = Category(
+    id: tCategoryId1,
+    name: tCategoryName1,
+    iconName: 'food',
+    colorHex: '#FF0000',
+    type: CategoryType.expense,
+    isCustom: false,
+  );
+  final tCategory2 = Category(
+    id: tCategoryId2,
+    name: tCategoryName2,
+    iconName: 'transport',
+    colorHex: '#00FF00',
+    type: CategoryType.expense,
+    isCustom: false,
+  );
+
+  final tExpense1 = ExpenseModel(
+    id: '1',
+    title: 'Burger',
+    amount: 10.0,
+    date: DateTime(2023, 1, 1),
+    accountId: 'a1',
+    categoryId: tCategoryId1,
+    categorizationStatusValue: 'uncategorized',
+  );
+  final tExpense2 = ExpenseModel(
+    id: '2',
+    title: 'Bus',
+    amount: 5.0,
+    date: DateTime(2023, 1, 2),
+    accountId: 'a1',
+    categoryId: tCategoryId2,
+    categorizationStatusValue: 'uncategorized',
+  );
+  final tExpense3 = ExpenseModel(
+    id: '3',
+    title: 'Pizza',
+    amount: 15.0,
+    date: DateTime(2023, 1, 3),
+    accountId: 'a1',
+    categoryId: tCategoryId1,
+    categorizationStatusValue: 'uncategorized',
+  );
+  final tExpense4 = ExpenseModel(
+    id: '4',
+    title: 'Unknown',
+    amount: 20.0,
+    date: DateTime(2023, 1, 4),
+    accountId: 'a1',
+    categoryId: 'c3', // Non-existent category
+    categorizationStatusValue: 'uncategorized',
+  );
+  final tExpense5 = ExpenseModel(
+    id: '5',
+    title: 'No Cat',
+    amount: 30.0,
+    date: DateTime(2023, 1, 5),
+    accountId: 'a1',
+    categoryId: null, // Null category
+    categorizationStatusValue: 'uncategorized',
+  );
+
+  test('getExpenseSummary returns correct summary', () async {
+    // Arrange
+    when(() => mockDataSource.getExpenses(
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+        )).thenAnswer(
+        (_) async => [tExpense1, tExpense2, tExpense3, tExpense4, tExpense5]);
+
+    when(() => mockCategoryRepository.getAllCategories())
+        .thenAnswer((_) async => Right([tCategory1, tCategory2]));
+
+    // Act
+    final result = await repository.getExpenseSummary();
+
+    // Assert
+    expect(result.isRight(), true);
+    final summary = result.getOrElse(() => throw Exception());
+
+    // Total: 10 + 5 + 15 + 20 + 30 = 80
+    expect(summary.totalExpenses, 80.0);
+
+    // Breakdown:
+    // Food: 10 + 15 = 25
+    // Transport: 5
+    // Uncategorized (Unknown + No Cat): 20 + 30 = 50
+
+    // Sort logic: By value descending.
+    // 50 (Uncategorized) > 25 (Food) > 5 (Transport)
+
+    expect(summary.categoryBreakdown.length, 3);
+
+    // Map iteration order is guaranteed to be insertion order in Dart if LinkedHashMap (default).
+    // The implementation sorts and creates a new map.
+    // So keys should be ordered.
+    final keys = summary.categoryBreakdown.keys.toList();
+    expect(keys, ['Uncategorized', 'Food', 'Transport']);
+
+    expect(summary.categoryBreakdown['Food'], 25.0);
+    expect(summary.categoryBreakdown['Transport'], 5.0);
+    expect(summary.categoryBreakdown['Uncategorized'], 50.0);
+  });
+
+  test('getExpenseSummary returns failure when datasource fails', () async {
+    when(() => mockDataSource.getExpenses(
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+        )).thenThrow(const CacheFailure('Error'));
+
+    final result = await repository.getExpenseSummary();
+
+    expect(result.isLeft(), true);
+  });
+
+  test('getExpenseSummary returns failure when category repo fails', () async {
+    when(() => mockDataSource.getExpenses(
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+        )).thenAnswer((_) async => []);
+
+    when(() => mockCategoryRepository.getAllCategories())
+        .thenAnswer((_) async => const Left(CacheFailure('Cat Error')));
+
+    final result = await repository.getExpenseSummary();
+
+    expect(result.isLeft(), true);
+  });
+}

--- a/test/features/reports/domain/helpers/csv_export_helper_test.dart
+++ b/test/features/reports/domain/helpers/csv_export_helper_test.dart
@@ -1,0 +1,117 @@
+import 'package:expense_tracker/core/services/downloader_service.dart';
+import 'package:expense_tracker/features/reports/domain/entities/report_data.dart';
+import 'package:expense_tracker/features/reports/domain/helpers/csv_export_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockDownloaderService extends Mock implements DownloaderService {}
+
+void main() {
+  late MockDownloaderService mockDownloaderService;
+  late CsvExportHelper helper;
+
+  setUp(() {
+    mockDownloaderService = MockDownloaderService();
+    helper = CsvExportHelper(downloaderService: mockDownloaderService);
+  });
+
+  group('exportSpendingCategoryReport', () {
+    test('generates correct CSV string without comparison', () async {
+      final data = SpendingCategoryReportData(
+        totalSpending:
+            const ComparisonValue(currentValue: 100.0, previousValue: 80.0),
+        spendingByCategory: [
+          CategorySpendingData(
+            categoryId: 'c1',
+            categoryName: 'Food',
+            categoryColor: Colors.red,
+            totalAmount:
+                const ComparisonValue(currentValue: 60.0, previousValue: 50.0),
+            percentage: 0.6,
+          ),
+          CategorySpendingData(
+            categoryId: 'c2',
+            categoryName: 'Transport',
+            categoryColor: Colors.blue,
+            totalAmount:
+                const ComparisonValue(currentValue: 40.0, previousValue: 30.0),
+            percentage: 0.4,
+          ),
+        ],
+      );
+
+      final result = await helper.exportSpendingCategoryReport(data, '\$');
+
+      expect(result.isLeft(), true);
+      final csv = result.fold((l) => l, (r) => throw Exception('Expected Left'));
+
+      // Check headers
+      // The exact string depends on CsvToListConverter, usually adds CRLF
+      expect(csv, contains('Category,Amount (\$),Percentage'));
+
+      // Check rows
+      expect(csv, contains('Food,60.00,60.0%'));
+      expect(csv, contains('Transport,40.00,40.0%'));
+      expect(csv, contains('TOTAL,100.00,100.0%'));
+    });
+
+    test('generates correct CSV string with comparison', () async {
+      final data = SpendingCategoryReportData(
+        totalSpending:
+            const ComparisonValue(currentValue: 100.0, previousValue: 80.0),
+        spendingByCategory: [
+          CategorySpendingData(
+            categoryId: 'c1',
+            categoryName: 'Food',
+            categoryColor: Colors.red,
+            totalAmount:
+                const ComparisonValue(currentValue: 60.0, previousValue: 50.0),
+            percentage: 0.6,
+          ),
+        ],
+      );
+
+      final result = await helper.exportSpendingCategoryReport(data, '\$',
+          showComparison: true);
+
+      expect(result.isLeft(), true);
+      final csv = result.fold((l) => l, (r) => throw Exception('Expected Left'));
+
+      // Check headers
+      expect(csv, contains(
+          'Category,Amount (\$),Percentage,Previous Amount (\$),Change (%)'));
+
+      // Check rows
+      // 50.00 previous, 60.00 current. Change: (10/50)*100 = 20%
+      expect(csv, contains('Food,60.00,60.0%,50.00,+20.0%'));
+
+      // Total
+      // 80.00 previous, 100.00 current. Change: (20/80)*100 = 25%
+      expect(csv, contains('TOTAL,100.00,100.0%,80.00,+25.0%'));
+    });
+  });
+
+  group('exportIncomeExpenseReport', () {
+    test('generates correct CSV string', () async {
+       final data = IncomeExpenseReportData(
+        periodType: IncomeExpensePeriodType.monthly,
+        periodData: [
+           IncomeExpensePeriodData(
+             periodStart: DateTime(2023, 1, 1),
+             totalIncome: const ComparisonValue(currentValue: 2000.0),
+             totalExpense: const ComparisonValue(currentValue: 1000.0),
+           )
+        ]
+       );
+
+       final result = await helper.exportIncomeExpenseReport(data, '\$');
+
+       expect(result.isLeft(), true);
+       final csv = result.fold((l) => l, (r) => throw Exception('Expected Left'));
+
+       expect(csv, contains('Period Start,Income (\$),Expense (\$),Net Flow (\$)'));
+       expect(csv, contains('2023-Jan,2000.00,1000.00,1000.00'));
+    });
+  });
+}


### PR DESCRIPTION
Added unit and widget tests for ExpenseSummary, GetExpenseSummaryUseCase, SummaryBloc, SummaryCard, ExpenseRepositoryImpl summary logic, and CsvExportHelper. Refactored SummaryBloc and SummaryCard to support optimistic UI updates by persisting previous summary data during loading states. This includes:
- Added `previousSummary` to `SummaryLoading` state.
- Updated `SummaryBloc` to pass `previousSummary`.
- Updated `SummaryCard` to use `previousSummary`.
- Added tests for `ExpenseSummary` entity.
- Added tests for `GetExpenseSummaryUseCase`.
- Added tests for `SummaryBloc` (loading, reloading, resetting).
- Added widget tests for `SummaryCard`.
- Added tests for `ExpenseRepositoryImpl.getExpenseSummary`.
- Added unit tests for `CsvExportHelper` (CSV generation).

---
*PR created automatically by Jules for task [17423099880557837895](https://jules.google.com/task/17423099880557837895) started by @Aditya-Bichave*