### PR TITLE
Add unit tests for Reports domain and CsvExportHelper

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -649,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1126,26 +1126,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/test/features/reports/domain/helpers/csv_export_helper_test.dart
+++ b/test/features/reports/domain/helpers/csv_export_helper_test.dart
@@ -1,0 +1,192 @@
+import 'package:expense_tracker/core/services/downloader_service.dart';
+import 'package:expense_tracker/features/budgets/domain/entities/budget.dart';
+import 'package:expense_tracker/features/budgets/domain/entities/budget_enums.dart';
+import 'package:expense_tracker/features/budgets/domain/entities/budget_status.dart';
+import 'package:expense_tracker/features/goals/domain/entities/goal.dart';
+import 'package:expense_tracker/features/goals/domain/entities/goal_contribution.dart';
+import 'package:expense_tracker/features/goals/domain/entities/goal_status.dart';
+import 'package:expense_tracker/features/reports/domain/entities/report_data.dart';
+import 'package:expense_tracker/features/reports/domain/helpers/csv_export_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockDownloaderService extends Mock implements DownloaderService {}
+
+void main() {
+  late CsvExportHelper helper;
+  late MockDownloaderService mockDownloaderService;
+
+  setUp(() {
+    mockDownloaderService = MockDownloaderService();
+    // DownloaderService is required by the constructor but only used in saveCsvFile,
+    // which is not being tested here (we are testing CSV generation logic).
+    helper = CsvExportHelper(downloaderService: mockDownloaderService);
+  });
+
+  const String currencySymbol = '\$';
+
+  group('CsvExportHelper', () {
+    // Note: The CsvExportHelper currently returns Left(String) for success (the CSV content)
+    // and Right(Failure) for errors. This is unconventional but verified against implementation.
+    test('exportSpendingCategoryReport generates correct CSV', () async {
+      final data = SpendingCategoryReportData(
+        totalSpending: const ComparisonValue(
+            currentValue: 300.0, previousValue: 200.0),
+        spendingByCategory: [
+          CategorySpendingData(
+            categoryId: '1',
+            categoryName: 'Food',
+            categoryColor: Colors.red,
+            totalAmount: const ComparisonValue(
+                currentValue: 100.0, previousValue: 50.0),
+            percentage: 0.33,
+          ),
+          CategorySpendingData(
+            categoryId: '2',
+            categoryName: 'Transport',
+            categoryColor: Colors.blue,
+            totalAmount: const ComparisonValue(
+                currentValue: 200.0, previousValue: 150.0),
+            percentage: 0.66,
+          ),
+        ],
+      );
+
+      final result = await helper.exportSpendingCategoryReport(
+          data, currencySymbol, showComparison: true);
+
+      expect(result.isLeft(), true);
+      result.fold((csv) {
+        expect(csv, contains('Category,Amount (\$),Percentage,Previous Amount (\$),Change (%)'));
+        expect(csv, contains('Food,100.00,33.0%,50.00,+100.0%'));
+        expect(csv, contains('Transport,200.00,66.0%,150.00,+33.3%'));
+        expect(csv, contains('TOTAL,300.00,100.0%,200.00,+50.0%'));
+      }, (failure) => fail('Should returns CSV string'));
+    });
+
+    test('exportSpendingTimeReport generates correct CSV', () async {
+      final data = SpendingTimeReportData(
+        granularity: TimeSeriesGranularity.daily,
+        spendingData: [
+          TimeSeriesDataPoint(
+            date: DateTime(2023, 1, 1),
+            amount: const ComparisonValue(currentValue: 50.0, previousValue: 40.0),
+          ),
+          TimeSeriesDataPoint(
+            date: DateTime(2023, 1, 2),
+            amount: const ComparisonValue(currentValue: 60.0, previousValue: null),
+          ),
+        ],
+      );
+
+      final result = await helper.exportSpendingTimeReport(
+          data, currencySymbol, showComparison: true);
+
+      expect(result.isLeft(), true);
+      result.fold((csv) {
+        expect(csv, contains('Period Start,Amount (\$),Previous Amount (\$),Change (%)'));
+        expect(csv, contains('2023-01-01,50.00,40.00,+25.0%'));
+        expect(csv, contains('2023-01-02,60.00,N/A,N/A'));
+      }, (failure) => fail('Should returns CSV string'));
+    });
+
+    test('exportIncomeExpenseReport generates correct CSV', () async {
+      final data = IncomeExpenseReportData(
+        periodType: IncomeExpensePeriodType.monthly,
+        periodData: [
+          IncomeExpensePeriodData(
+            periodStart: DateTime(2023, 1),
+            totalIncome: const ComparisonValue(currentValue: 1000.0, previousValue: 900.0),
+            totalExpense: const ComparisonValue(currentValue: 500.0, previousValue: 450.0),
+          ),
+        ],
+      );
+
+      final result = await helper.exportIncomeExpenseReport(
+          data, currencySymbol, showComparison: true);
+
+      expect(result.isLeft(), true);
+      result.fold((csv) {
+        expect(csv, contains('Period Start,Income (\$),Expense (\$),Net Flow (\$),Prev Income (\$),Prev Expense (\$),Prev Net Flow (\$),Net Change (%)'));
+        expect(csv, contains('2023-Jan,1000.00,500.00,500.00,900.00,450.00,450.00,+11.1%'));
+      }, (failure) => fail('Should returns CSV string'));
+    });
+
+    test('exportBudgetPerformanceReport generates correct CSV', () async {
+      final budget = Budget(
+        id: '1',
+        name: 'Groceries',
+        type: BudgetType.categorySpecific,
+        targetAmount: 500.0,
+        period: BudgetPeriodType.recurringMonthly,
+        createdAt: DateTime.now(),
+      );
+
+      final data = BudgetPerformanceReportData(
+        performanceData: [
+          BudgetPerformanceData(
+            budget: budget,
+            actualSpending: const ComparisonValue(currentValue: 400.0),
+            varianceAmount: const ComparisonValue(currentValue: 100.0),
+            currentVariancePercent: 20.0,
+            health: BudgetHealth.thriving,
+            statusColor: Colors.green,
+            previousVariancePercent: 10.0,
+          ),
+        ],
+        previousPerformanceData: [
+          BudgetPerformanceData(
+            budget: budget,
+            actualSpending: const ComparisonValue(currentValue: 450.0),
+            varianceAmount: const ComparisonValue(currentValue: 50.0),
+            currentVariancePercent: 10.0,
+            health: BudgetHealth.thriving,
+            statusColor: Colors.green,
+          ),
+        ],
+      );
+
+      final result = await helper.exportBudgetPerformanceReport(
+          data, currencySymbol, showComparison: true);
+
+      expect(result.isLeft(), true);
+      result.fold((csv) {
+        expect(csv, contains('Budget,Target (\$),Actual (\$),Variance (\$),Variance (%),Prev Actual (\$),Prev Variance (\$),Prev Variance (%),Var Δ%'));
+        expect(csv, contains('Groceries,500.00,400.00,100.00,20.0%,450.00,50.00,10.0%,+10.0%'));
+      }, (failure) => fail('Should returns CSV string'));
+    });
+
+    test('exportGoalProgressReport generates correct CSV', () async {
+      final goal = Goal(
+        id: '1',
+        name: 'Vacation',
+        targetAmount: 1000.0,
+        status: GoalStatus.active,
+        totalSaved: 200.0,
+        createdAt: DateTime(2023, 1, 1),
+        targetDate: DateTime(2023, 12, 31),
+      );
+
+      final data = GoalProgressReportData(
+        progressData: [
+          GoalProgressData(
+            goal: goal,
+            contributions: [],
+            requiredDailySaving: 5.0,
+            requiredMonthlySaving: 150.0,
+          ),
+        ],
+      );
+
+      final result = await helper.exportGoalProgressReport(data, currencySymbol);
+
+      expect(result.isLeft(), true);
+      result.fold((csv) {
+        expect(csv, contains('Goal,Target (\$),Saved (\$),Remaining (\$),Progress (%),Target Date,Status,Est. Daily Save,Est. Monthly Save,Est. Completion'));
+        // Adjusted expectation for date format (MM/dd/yyyy) and currency formatting ($5.00)
+        expect(csv, contains('Vacation,1000.00,200.00,800.00,20.0,12/31/2023,Active,\$5.00,\$150.00,N/A'));
+      }, (failure) => fail('Should returns CSV string'));
+    });
+  });
+}

--- a/test/features/reports/domain/usecases/get_budget_performance_report_test.dart
+++ b/test/features/reports/domain/usecases/get_budget_performance_report_test.dart
@@ -1,0 +1,55 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/features/reports/domain/entities/report_data.dart';
+import 'package:expense_tracker/features/reports/domain/repositories/report_repository.dart';
+import 'package:expense_tracker/features/reports/domain/usecases/get_budget_performance_report.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockReportRepository extends Mock implements ReportRepository {}
+
+void main() {
+  late GetBudgetPerformanceReportUseCase useCase;
+  late MockReportRepository mockReportRepository;
+
+  setUp(() {
+    mockReportRepository = MockReportRepository();
+    useCase = GetBudgetPerformanceReportUseCase(mockReportRepository);
+  });
+
+  final tStartDate = DateTime(2023, 1, 1);
+  final tEndDate = DateTime(2023, 1, 31);
+  const tBudgetIds = ['1', '2'];
+  const tAccountIds = ['A', 'B'];
+
+  const tReportData = BudgetPerformanceReportData(performanceData: []);
+
+  test('should call getBudgetPerformance from repository', () async {
+    // Arrange
+    when(() => mockReportRepository.getBudgetPerformance(
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          budgetIds: any(named: 'budgetIds'),
+          accountIds: any(named: 'accountIds'),
+          compareToPrevious: any(named: 'compareToPrevious'),
+        )).thenAnswer((_) async => const Right(tReportData));
+
+    // Act
+    final result = await useCase(GetBudgetPerformanceReportParams(
+      startDate: tStartDate,
+      endDate: tEndDate,
+      budgetIds: tBudgetIds,
+      accountIds: tAccountIds,
+      compareToPrevious: true,
+    ));
+
+    // Assert
+    expect(result, const Right(tReportData));
+    verify(() => mockReportRepository.getBudgetPerformance(
+          startDate: tStartDate,
+          endDate: tEndDate,
+          budgetIds: tBudgetIds,
+          accountIds: tAccountIds,
+          compareToPrevious: true,
+        )).called(1);
+  });
+}

--- a/test/features/reports/domain/usecases/get_goal_progress_report_test.dart
+++ b/test/features/reports/domain/usecases/get_goal_progress_report_test.dart
@@ -1,0 +1,43 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/features/reports/domain/entities/report_data.dart';
+import 'package:expense_tracker/features/reports/domain/repositories/report_repository.dart';
+import 'package:expense_tracker/features/reports/domain/usecases/get_goal_progress_report.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockReportRepository extends Mock implements ReportRepository {}
+
+void main() {
+  late GetGoalProgressReportUseCase useCase;
+  late MockReportRepository mockReportRepository;
+
+  setUp(() {
+    mockReportRepository = MockReportRepository();
+    useCase = GetGoalProgressReportUseCase(mockReportRepository);
+  });
+
+  const tGoalIds = ['1', '2'];
+
+  const tReportData = GoalProgressReportData(progressData: []);
+
+  test('should call getGoalProgress from repository', () async {
+    // Arrange
+    when(() => mockReportRepository.getGoalProgress(
+          goalIds: any(named: 'goalIds'),
+          calculateComparisonRate: any(named: 'calculateComparisonRate'),
+        )).thenAnswer((_) async => const Right(tReportData));
+
+    // Act
+    final result = await useCase(const GetGoalProgressReportParams(
+      goalIds: tGoalIds,
+      calculateComparisonRate: true,
+    ));
+
+    // Assert
+    expect(result, const Right(tReportData));
+    verify(() => mockReportRepository.getGoalProgress(
+          goalIds: tGoalIds,
+          calculateComparisonRate: true,
+        )).called(1);
+  });
+}

--- a/test/features/reports/domain/usecases/get_income_expense_report_test.dart
+++ b/test/features/reports/domain/usecases/get_income_expense_report_test.dart
@@ -1,0 +1,60 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/features/reports/domain/entities/report_data.dart';
+import 'package:expense_tracker/features/reports/domain/repositories/report_repository.dart';
+import 'package:expense_tracker/features/reports/domain/usecases/get_income_expense_report.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockReportRepository extends Mock implements ReportRepository {}
+
+void main() {
+  late GetIncomeExpenseReportUseCase useCase;
+  late MockReportRepository mockReportRepository;
+
+  setUpAll(() {
+    registerFallbackValue(IncomeExpensePeriodType.monthly);
+  });
+
+  setUp(() {
+    mockReportRepository = MockReportRepository();
+    useCase = GetIncomeExpenseReportUseCase(mockReportRepository);
+  });
+
+  final tStartDate = DateTime(2023, 1, 1);
+  final tEndDate = DateTime(2023, 1, 31);
+  const tPeriodType = IncomeExpensePeriodType.monthly;
+  const tAccountIds = ['1', '2'];
+
+  const tReportData = IncomeExpenseReportData(
+    periodData: [],
+    periodType: tPeriodType,
+  );
+
+  test('should call getIncomeVsExpense from repository', () async {
+    // Arrange
+    when(() => mockReportRepository.getIncomeVsExpense(
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          periodType: any(named: 'periodType'),
+          accountIds: any(named: 'accountIds'),
+        )).thenAnswer((_) async => const Right(tReportData));
+
+    // Act
+    final result = await useCase(GetIncomeExpenseReportParams(
+      startDate: tStartDate,
+      endDate: tEndDate,
+      periodType: tPeriodType,
+      accountIds: tAccountIds,
+      compareToPrevious: false,
+    ));
+
+    // Assert
+    expect(result, const Right(tReportData));
+    verify(() => mockReportRepository.getIncomeVsExpense(
+          startDate: tStartDate,
+          endDate: tEndDate,
+          periodType: tPeriodType,
+          accountIds: tAccountIds,
+        )).called(1);
+  });
+}

--- a/test/features/reports/domain/usecases/get_spending_category_report_test.dart
+++ b/test/features/reports/domain/usecases/get_spending_category_report_test.dart
@@ -1,0 +1,52 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/features/reports/domain/entities/report_data.dart';
+import 'package:expense_tracker/features/reports/domain/repositories/report_repository.dart';
+import 'package:expense_tracker/features/reports/domain/usecases/get_spending_category_report.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockReportRepository extends Mock implements ReportRepository {}
+
+void main() {
+  late GetSpendingCategoryReportUseCase useCase;
+  late MockReportRepository mockReportRepository;
+
+  setUp(() {
+    mockReportRepository = MockReportRepository();
+    useCase = GetSpendingCategoryReportUseCase(mockReportRepository);
+  });
+
+  final tStartDate = DateTime(2023, 1, 1);
+  final tEndDate = DateTime(2023, 1, 31);
+  const tAccountIds = ['1', '2'];
+
+  const tReportData = SpendingCategoryReportData(
+    totalSpending: ComparisonValue(currentValue: 100.0),
+    spendingByCategory: [],
+  );
+
+  test('should call getSpendingByCategory from repository', () async {
+    // Arrange
+    when(() => mockReportRepository.getSpendingByCategory(
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          accountIds: any(named: 'accountIds'),
+        )).thenAnswer((_) async => const Right(tReportData));
+
+    // Act
+    final result = await useCase(GetSpendingCategoryReportParams(
+      startDate: tStartDate,
+      endDate: tEndDate,
+      accountIds: tAccountIds,
+      compareToPrevious: false,
+    ));
+
+    // Assert
+    expect(result, const Right(tReportData));
+    verify(() => mockReportRepository.getSpendingByCategory(
+          startDate: tStartDate,
+          endDate: tEndDate,
+          accountIds: tAccountIds,
+        )).called(1);
+  });
+}

--- a/test/features/reports/domain/usecases/get_spending_time_report_test.dart
+++ b/test/features/reports/domain/usecases/get_spending_time_report_test.dart
@@ -1,0 +1,64 @@
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/features/reports/domain/entities/report_data.dart';
+import 'package:expense_tracker/features/reports/domain/repositories/report_repository.dart';
+import 'package:expense_tracker/features/reports/domain/usecases/get_spending_time_report.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockReportRepository extends Mock implements ReportRepository {}
+
+void main() {
+  late GetSpendingTimeReportUseCase useCase;
+  late MockReportRepository mockReportRepository;
+
+  setUpAll(() {
+    registerFallbackValue(TimeSeriesGranularity.daily);
+  });
+
+  setUp(() {
+    mockReportRepository = MockReportRepository();
+    useCase = GetSpendingTimeReportUseCase(mockReportRepository);
+  });
+
+  final tStartDate = DateTime(2023, 1, 1);
+  final tEndDate = DateTime(2023, 1, 31);
+  const tGranularity = TimeSeriesGranularity.daily;
+  const tAccountIds = ['1', '2'];
+  const tCategoryIds = ['cat1', 'cat2'];
+
+  const tReportData = SpendingTimeReportData(
+    spendingData: [],
+    granularity: tGranularity,
+  );
+
+  test('should call getSpendingOverTime from repository', () async {
+    // Arrange
+    when(() => mockReportRepository.getSpendingOverTime(
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          granularity: any(named: 'granularity'),
+          accountIds: any(named: 'accountIds'),
+          categoryIds: any(named: 'categoryIds'),
+        )).thenAnswer((_) async => const Right(tReportData));
+
+    // Act
+    final result = await useCase(GetSpendingTimeReportParams(
+      startDate: tStartDate,
+      endDate: tEndDate,
+      granularity: tGranularity,
+      accountIds: tAccountIds,
+      categoryIds: tCategoryIds,
+      compareToPrevious: false,
+    ));
+
+    // Assert
+    expect(result, const Right(tReportData));
+    verify(() => mockReportRepository.getSpendingOverTime(
+          startDate: tStartDate,
+          endDate: tEndDate,
+          granularity: tGranularity,
+          accountIds: tAccountIds,
+          categoryIds: tCategoryIds,
+        )).called(1);
+  });
+}


### PR DESCRIPTION
This PR adds unit tests for the reports feature to increase code coverage. 
- Added `csv_export_helper_test.dart` to verify CSV generation logic.
- Added tests for `GetBudgetPerformanceReportUseCase`, `GetGoalProgressReportUseCase`, `GetIncomeExpenseReportUseCase`, `GetSpendingCategoryReportUseCase`, and `GetSpendingTimeReportUseCase`.
- Verified all tests pass.

---
*PR created automatically by Jules for task [1808919691235294941](https://jules.google.com/task/1808919691235294941) started by @Aditya-Bichave*