### PR TITLE
🎨 Palette: Improve FAB tooltip context

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Context-Aware Tooltips
+**Learning:** Generic tooltips like "Add" are insufficient for multi-context buttons (FABs). Screen reader users miss context (Add what?) and sighted users lose clarity.
+**Action:** Always map FAB actions to their specific context (e.g., "Add Transaction", "Add Account") using the current navigation index.

--- a/lib/main_shell.dart
+++ b/lib/main_shell.dart
@@ -67,6 +67,21 @@ class MainShell extends StatelessWidget {
     }
   }
 
+  // Helper to get the tooltip for the FAB based on the current tab
+  String _getFabTooltip(int index) {
+    switch (index) {
+      case 0: // Dashboard
+      case 1: // Transactions
+        return 'Add Transaction';
+      case 3: // Accounts
+        return 'Add Account';
+      case 4: // Recurring
+        return 'Add Recurring Transaction';
+      default:
+        return 'Add';
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -151,7 +166,7 @@ class MainShell extends StatelessWidget {
                     return; // Should not happen if showFab is false for other tabs
                 }
               },
-              tooltip: 'Add',
+              tooltip: _getFabTooltip(currentTabIndex),
               child: const Icon(Icons.add),
             )
           : null,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -649,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1126,26 +1126,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/test/main_shell_test.dart
+++ b/test/main_shell_test.dart
@@ -1,0 +1,112 @@
+import 'package:expense_tracker/main_shell.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'helpers/pump_app.dart';
+
+// Fake implementation of StatefulNavigationShell
+// It must be a StatefulWidget to match the expected type in the widget tree
+class FakeStatefulNavigationShell extends StatefulWidget
+    implements StatefulNavigationShell {
+  final int index;
+
+  const FakeStatefulNavigationShell({
+    super.key,
+    this.index = 0,
+  });
+
+  @override
+  int get currentIndex => index;
+
+  @override
+  void goBranch(int index, {bool? initialLocation}) {}
+
+  @override
+  State<FakeStatefulNavigationShell> createState() =>
+      _FakeStatefulNavigationShellState();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeStatefulNavigationShellState
+    extends State<FakeStatefulNavigationShell> {
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeStatefulNavigationShell());
+  });
+
+  group('MainShell', () {
+    testWidgets(
+        'renders FAB with "Add Transaction" tooltip for Dashboard (index 0)',
+        (tester) async {
+      await pumpWidgetWithProviders(
+        tester: tester,
+        widget: const MainShell(
+          navigationShell: FakeStatefulNavigationShell(index: 0),
+        ),
+      );
+
+      final fabFinder = find.byType(FloatingActionButton);
+      expect(fabFinder, findsOneWidget);
+
+      final tooltipFinder = find.byTooltip('Add Transaction');
+      expect(tooltipFinder, findsOneWidget);
+    });
+
+    testWidgets(
+        'renders FAB with "Add Transaction" tooltip for Transactions (index 1)',
+        (tester) async {
+      await pumpWidgetWithProviders(
+        tester: tester,
+        widget: const MainShell(
+          navigationShell: FakeStatefulNavigationShell(index: 1),
+        ),
+      );
+
+      expect(find.byTooltip('Add Transaction'), findsOneWidget);
+    });
+
+    testWidgets('renders FAB with "Add Account" tooltip for Accounts (index 3)',
+        (tester) async {
+      await pumpWidgetWithProviders(
+        tester: tester,
+        widget: const MainShell(
+          navigationShell: FakeStatefulNavigationShell(index: 3),
+        ),
+      );
+
+      expect(find.byTooltip('Add Account'), findsOneWidget);
+    });
+
+    testWidgets(
+        'renders FAB with "Add Recurring Transaction" tooltip for Recurring (index 4)',
+        (tester) async {
+      await pumpWidgetWithProviders(
+        tester: tester,
+        widget: const MainShell(
+          navigationShell: FakeStatefulNavigationShell(index: 4),
+        ),
+      );
+
+      expect(find.byTooltip('Add Recurring Transaction'), findsOneWidget);
+    });
+
+    testWidgets('does not render FAB for Settings (index 5)', (tester) async {
+      await pumpWidgetWithProviders(
+        tester: tester,
+        widget: const MainShell(
+          navigationShell: FakeStatefulNavigationShell(index: 5),
+        ),
+      );
+
+      expect(find.byType(FloatingActionButton), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
This PR improves the accessibility and UX of the main Floating Action Button (FAB). 

Previously, the FAB always had the tooltip "Add", regardless of whether it was adding a transaction, an account, or a recurring transaction. This was ambiguous for screen reader users and less helpful for all users.

Now, the tooltip dynamically updates based on the current tab:
- **Dashboard/Transactions:** "Add Transaction"
- **Accounts:** "Add Account"
- **Recurring:** "Add Recurring Transaction"

A new test file `test/main_shell_test.dart` has been added to verify this behavior.

---
*PR created automatically by Jules for task [7996457168227497357](https://jules.google.com/task/7996457168227497357) started by @Aditya-Bichave*