### PR TITLE
⚡ Optimize TransactionListView rendering performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-05 - Hoisting Bloc Subscriptions for List Items
+**Learning:** `ExpenseCard` and `IncomeCard` were each subscribing to `AccountListBloc` and performing a linear search to find the account name. In a list of N transactions, this created N listeners and O(N * M) lookup complexity (where M is accounts).
+**Action:** Always hoist shared data dependencies (like account names or currency settings) to the parent list widget (`TransactionListView`) and pass the resolved data down to the items. This makes the list item simpler (stateless regarding that data) and reduces the complexity to O(N) map lookups.

--- a/lib/features/expenses/presentation/widgets/expense_card.dart
+++ b/lib/features/expenses/presentation/widgets/expense_card.dart
@@ -2,7 +2,6 @@
 // MODIFIED FILE (Implement interactive prompts)
 
 import 'package:expense_tracker/core/theme/app_mode_theme.dart';
-import 'package:expense_tracker/features/accounts/presentation/bloc/account_list/account_list_bloc.dart';
 import 'package:expense_tracker/features/categories/domain/entities/categorization_status.dart';
 import 'package:expense_tracker/features/categories/domain/entities/category.dart';
 import 'package:flutter/material.dart';
@@ -19,6 +18,7 @@ import 'package:expense_tracker/features/transactions/presentation/widgets/categ
 
 class ExpenseCard extends StatelessWidget {
   final Expense expense;
+  final String accountName;
   final Function(Expense expense)? onCardTap;
   final Function(Expense expense, Category selectedCategory)? onUserCategorized;
   final Function(Expense expense)? onChangeCategoryRequest;
@@ -26,6 +26,7 @@ class ExpenseCard extends StatelessWidget {
   const ExpenseCard({
     super.key,
     required this.expense,
+    required this.accountName,
     this.onCardTap,
     this.onUserCategorized,
     this.onChangeCategoryRequest,
@@ -100,19 +101,7 @@ class ExpenseCard extends StatelessWidget {
     final currencySymbol = settingsState.currencySymbol;
     final modeTheme = context.modeTheme;
     final category = expense.category ?? Category.uncategorized;
-    final accountState = context.watch<AccountListBloc>().state;
-    String accountName = '...';
-    if (accountState is AccountListLoaded) {
-      try {
-        accountName = accountState.items
-            .firstWhere((acc) => acc.id == expense.accountId)
-            .name;
-      } catch (_) {
-        accountName = 'Deleted';
-      }
-    } else if (accountState is AccountListError) {
-      accountName = 'Error';
-    }
+
     return AppCard(
       onTap: () => onCardTap?.call(expense),
       child: Row(

--- a/lib/features/income/presentation/widgets/income_card.dart
+++ b/lib/features/income/presentation/widgets/income_card.dart
@@ -2,7 +2,6 @@
 // MODIFIED FILE (Implement interactive prompts)
 
 import 'package:expense_tracker/core/theme/app_mode_theme.dart';
-import 'package:expense_tracker/features/accounts/presentation/bloc/account_list/account_list_bloc.dart';
 import 'package:expense_tracker/features/categories/domain/entities/categorization_status.dart';
 import 'package:expense_tracker/features/categories/domain/entities/category.dart';
 import 'package:flutter/material.dart';
@@ -19,6 +18,7 @@ import 'package:expense_tracker/features/transactions/presentation/widgets/categ
 
 class IncomeCard extends StatelessWidget {
   final Income income;
+  final String accountName;
   final Function(Income income)? onCardTap;
   final Function(Income income, Category selectedCategory)? onUserCategorized;
   final Function(Income income)? onChangeCategoryRequest;
@@ -26,6 +26,7 @@ class IncomeCard extends StatelessWidget {
   const IncomeCard({
     super.key,
     required this.income,
+    required this.accountName,
     this.onCardTap,
     this.onUserCategorized,
     this.onChangeCategoryRequest,
@@ -90,19 +91,7 @@ class IncomeCard extends StatelessWidget {
     final currencySymbol = settingsState.currencySymbol;
     final modeTheme = context.modeTheme;
     final category = income.category ?? Category.uncategorized;
-    final accountState = context.watch<AccountListBloc>().state;
-    String accountName = '...';
-    if (accountState is AccountListLoaded) {
-      try {
-        accountName = accountState.items
-            .firstWhere((acc) => acc.id == income.accountId)
-            .name;
-      } catch (_) {
-        accountName = 'Deleted';
-      }
-    } else if (accountState is AccountListError) {
-      accountName = 'Error';
-    }
+
     final Color incomeAmountColor =
         modeTheme?.incomeGlowColor ?? Colors.green.shade700;
     return AppCard(

--- a/lib/features/transactions/presentation/pages/transaction_list_page.dart
+++ b/lib/features/transactions/presentation/pages/transaction_list_page.dart
@@ -399,13 +399,36 @@ class _TransactionListPageState extends State<TransactionListPage> {
                           )
                         : KeyedSubtree(
                             key: const ValueKey('list_view'),
-                            child: TransactionListView(
-                              state: state,
-                              settings: settings,
-                              navigateToDetailOrEdit: _navigateToDetailOrEdit,
-                              handleChangeCategoryRequest:
-                                  _handleChangeCategoryRequest,
-                              confirmDeletion: _confirmDeletion,
+                            child:
+                                BlocBuilder<AccountListBloc, AccountListState>(
+                              builder: (context, accountState) {
+                                final accountNameMap =
+                                    accountState is AccountListLoaded
+                                        ? {
+                                            for (var a in accountState.accounts)
+                                              a.id: a.name
+                                          }
+                                        : <String, String>{};
+
+                                String defaultAccountName = 'Deleted';
+                                if (accountState is AccountListLoading) {
+                                  defaultAccountName = '...';
+                                } else if (accountState is AccountListError) {
+                                  defaultAccountName = 'Error';
+                                }
+
+                                return TransactionListView(
+                                  state: state,
+                                  settings: settings,
+                                  accountNameMap: accountNameMap,
+                                  defaultAccountName: defaultAccountName,
+                                  navigateToDetailOrEdit:
+                                      _navigateToDetailOrEdit,
+                                  handleChangeCategoryRequest:
+                                      _handleChangeCategoryRequest,
+                                  confirmDeletion: _confirmDeletion,
+                                );
+                              },
                             ),
                           ),
                   ),

--- a/lib/features/transactions/presentation/widgets/transaction_list_view.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_list_view.dart
@@ -24,6 +24,8 @@ class TransactionListView extends StatelessWidget {
   final Function(BuildContext, TransactionEntity) handleChangeCategoryRequest;
   final Function(BuildContext, TransactionEntity) confirmDeletion;
   final bool enableAnimations;
+  final Map<String, String> accountNameMap;
+  final String defaultAccountName;
   // --- END Handlers ---
 
   const TransactionListView({
@@ -34,6 +36,8 @@ class TransactionListView extends StatelessWidget {
     // --- Add to constructor ---
     required this.handleChangeCategoryRequest,
     required this.confirmDeletion,
+    required this.accountNameMap,
+    this.defaultAccountName = 'Deleted',
     this.enableAnimations = true,
     // --- End Add ---
   });
@@ -109,9 +113,13 @@ class TransactionListView extends StatelessWidget {
 
         // --- USE ExpenseCard or IncomeCard based on type ---
         Widget cardItem;
+        final accountName =
+            accountNameMap[transaction.accountId] ?? defaultAccountName;
+
         if (transaction.type == TransactionType.expense) {
           cardItem = ExpenseCard(
             expense: transaction.expense!,
+            accountName: accountName,
             onCardTap: (exp) {
               // Pass original Expense
               if (state.isInBatchEditMode) {
@@ -140,6 +148,7 @@ class TransactionListView extends StatelessWidget {
           // Income
           cardItem = IncomeCard(
             income: transaction.income!,
+            accountName: accountName,
             onCardTap: (inc) {
               // Pass original Income
               if (state.isInBatchEditMode) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -649,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1126,26 +1126,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/test/features/transactions/presentation/widgets/transaction_list_view_test.dart
+++ b/test/features/transactions/presentation/widgets/transaction_list_view_test.dart
@@ -66,6 +66,7 @@ void main() {
         handleChangeCategoryRequest: mockCallbacks.handleChangeCategoryRequest,
         confirmDeletion: mockCallbacks.confirmDeletion,
         enableAnimations: false,
+        accountNameMap: const {'a1': 'Test Account'},
       ),
     );
   }


### PR DESCRIPTION
⚡ Optimize TransactionListView rendering performance

Hoisted AccountListBloc subscription from individual ExpenseCard/IncomeCard widgets to the parent TransactionListPage.
This reduces the complexity of account name lookups from O(N*M) to O(N) and eliminates N redundant Bloc listeners, where N is the number of transactions.

* Modified TransactionListView to accept an accountNameMap and defaultAccountName.
* Updated ExpenseCard and IncomeCard to accept accountName directly.
* Updated TransactionListPage to compute the account map once and pass it down.
* Updated tests to reflect these changes.

---
*PR created automatically by Jules for task [10206043909892326642](https://jules.google.com/task/10206043909892326642) started by @Aditya-Bichave*