### PR TITLE
🎨 Palette: Add visual indicators for required form fields

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Explicit Required Field Indicators]
+**Learning:** Users often struggle to differentiate between optional and required fields in forms without explicit indicators. Relying solely on validation errors after submission leads to frustration.
+**Action:** Always mark required fields visually (e.g., with a red asterisk) to set clear expectations before interaction. This improves accessibility and reduces form submission errors.

--- a/lib/core/widgets/app_text_form_field.dart
+++ b/lib/core/widgets/app_text_form_field.dart
@@ -20,6 +20,7 @@ class AppTextFormField extends StatefulWidget {
   final TextCapitalization textCapitalization;
   final int? maxLines;
   final ValueChanged<String>? onChanged; // Added onChanged callback
+  final bool isRequired; // Added isRequired flag
 
   const AppTextFormField({
     super.key,
@@ -39,6 +40,7 @@ class AppTextFormField extends StatefulWidget {
     this.textCapitalization = TextCapitalization.none,
     this.maxLines = 1,
     this.onChanged, // Added onChanged
+    this.isRequired = false, // Default to false
   });
 
   @override
@@ -87,10 +89,26 @@ class _AppTextFormFieldState extends State<AppTextFormField> {
     final inputTheme = theme.inputDecorationTheme;
     final modeTheme = context.modeTheme;
 
+    // Construct label with asterisk if required
+    final Widget? labelWidget = widget.isRequired
+        ? Text.rich(
+            TextSpan(
+              text: widget.labelText,
+              children: [
+                TextSpan(
+                  text: ' *',
+                  style: TextStyle(color: theme.colorScheme.error),
+                ),
+              ],
+            ),
+          )
+        : null;
+
     return TextFormField(
       controller: widget.controller,
       decoration: InputDecoration(
-        labelText: widget.labelText,
+        labelText: widget.isRequired ? null : widget.labelText,
+        label: labelWidget,
         hintText: widget.hintText,
         border: inputTheme.border ?? const OutlineInputBorder(),
         enabledBorder: inputTheme.enabledBorder,

--- a/lib/core/widgets/common_form_fields.dart
+++ b/lib/core/widgets/common_form_fields.dart
@@ -54,6 +54,7 @@ class CommonFormFields {
     IconData fallbackIcon = Icons.label_outline,
     TextCapitalization textCapitalization = TextCapitalization.words,
     String? Function(String?)? validator,
+    bool isRequired = false,
   }) {
     return AppTextFormField(
       controller: controller,
@@ -71,6 +72,7 @@ class CommonFormFields {
             final isValid = RegExp(r'^[a-zA-Z0-9 ]+$').hasMatch(value.trim());
             return isValid ? null : 'Only letters and numbers allowed';
           },
+      isRequired: isRequired,
     );
   }
 
@@ -84,6 +86,7 @@ class CommonFormFields {
     IconData fallbackIcon = Icons.attach_money,
     String? Function(String?)? validator,
     ValueChanged<String>? onChanged,
+    bool isRequired = false,
   }) {
     return AppTextFormField(
       controller: controller,
@@ -108,6 +111,7 @@ class CommonFormFields {
             return null;
           },
       onChanged: onChanged,
+      isRequired: isRequired,
     );
   }
 
@@ -120,6 +124,7 @@ class CommonFormFields {
     int maxLines = 3,
     String iconKey = 'notes',
     IconData fallbackIcon = Icons.note_alt_outlined,
+    bool isRequired = false,
   }) {
     return AppTextFormField(
       controller: controller,
@@ -129,6 +134,7 @@ class CommonFormFields {
       maxLines: maxLines,
       textCapitalization: TextCapitalization.sentences,
       validator: null,
+      isRequired: isRequired,
     );
   }
 
@@ -184,6 +190,7 @@ class CommonFormFields {
     String? Function(String?)? validator,
     String labelText = 'Account',
     String hintText = 'Select Account',
+    bool isRequired = false,
   }) {
     return AccountSelectorDropdown(
       selectedAccountId: selectedAccountId,
@@ -193,6 +200,7 @@ class CommonFormFields {
           (value) => value == null ? 'Please select an account' : null,
       labelText: labelText,
       hintText: hintText,
+      isRequired: isRequired,
     );
   }
 

--- a/lib/features/accounts/presentation/widgets/account_selector_dropdown.dart
+++ b/lib/features/accounts/presentation/widgets/account_selector_dropdown.dart
@@ -10,6 +10,7 @@ class AccountSelectorDropdown extends StatelessWidget {
   final String? Function(String?)? validator;
   final String labelText;
   final String hintText;
+  final bool isRequired;
 
   const AccountSelectorDropdown({
     super.key,
@@ -18,6 +19,7 @@ class AccountSelectorDropdown extends StatelessWidget {
     this.validator,
     this.labelText = 'Account',
     this.hintText = 'Select Account',
+    this.isRequired = false,
   });
 
   @override
@@ -56,11 +58,27 @@ class AccountSelectorDropdown extends StatelessWidget {
           displayValue = null;
         }
 
+        // Construct label with asterisk if required
+        final Widget? labelWidget = isRequired
+            ? Text.rich(
+                TextSpan(
+                  text: labelText,
+                  children: [
+                    TextSpan(
+                      text: ' *',
+                      style: TextStyle(color: theme.colorScheme.error),
+                    ),
+                  ],
+                ),
+              )
+            : null;
+
         return DropdownButtonFormField<String>(
           value: displayValue,
           isExpanded: true,
           decoration: InputDecoration(
-            labelText: labelText,
+            labelText: isRequired ? null : labelText,
+            label: labelWidget,
             hintText: isLoading && accounts.isEmpty ? 'Loading...' : hintText,
             border: const OutlineInputBorder(),
             errorText: errorMessage,

--- a/lib/features/transactions/presentation/widgets/transaction_form.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_form.dart
@@ -312,6 +312,7 @@ class TransactionFormState extends State<TransactionForm> {
             fallbackIcon:
                 isExpense ? Icons.description_outlined : Icons.source_outlined,
             textCapitalization: TextCapitalization.sentences,
+            isRequired: true,
           ),
           const SizedBox(height: 16),
 
@@ -321,6 +322,7 @@ class TransactionFormState extends State<TransactionForm> {
             controller: _amountController,
             labelText: 'Amount',
             currencySymbol: currencySymbol,
+            isRequired: true,
           ),
           const SizedBox(height: 16),
 
@@ -345,6 +347,7 @@ class TransactionFormState extends State<TransactionForm> {
                 "[TransactionForm] Account selected: $_selectedAccountId",
               );
             },
+            isRequired: true,
           ),
           const SizedBox(height: 16),
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -649,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1126,26 +1126,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/test/core/widgets/app_text_form_field_test.dart
+++ b/test/core/widgets/app_text_form_field_test.dart
@@ -174,5 +174,23 @@ void main() {
       // ASSERT
       expect(textField.obscureText, isTrue);
     });
+
+    testWidgets('renders asterisk when isRequired is true', (tester) async {
+      // ARRANGE
+      await pumpWidgetWithProviders(
+        tester: tester,
+        widget: Material(
+          child: AppTextFormField(
+            controller: controller,
+            labelText: 'Required Field',
+            isRequired: true,
+          ),
+        ),
+      );
+
+      // ASSERT
+      // The RichText should contain the label and the asterisk
+      expect(find.text('Required Field *', findRichText: true), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
Added a visual indicator (red asterisk) to required form fields in the Transaction Form. This was achieved by updating `AppTextFormField` and `AccountSelectorDropdown` to accept an `isRequired` parameter, which modifies the label to include the asterisk using `Text.rich`. This change improves UX by setting clear expectations for users.

---
*PR created automatically by Jules for task [6298336572583269470](https://jules.google.com/task/6298336572583269470) started by @Aditya-Bichave*