### PR TITLE
Add actions to Goal Progress Page (comparison toggle, export)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.gitignore
+.dockerignore
+.dart_tool/
+build/
+.idea/
+.vscode/
+android/
+ios/
+linux/
+macos/
+windows/
+test/
+coverage/
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN flutter pub get
 
 # Build Flutter web release
 ARG API_BASE_URL
-RUN flutter build web --release --dart-define=API_BASE_URL=${API_BASE_URL}
+# Use --no-wasm-dry-run to suppress warnings about dart:ffi which is not supported on web
+# Use quoted dart-define to handle spaces/empty values safely
+RUN flutter build web --release --no-wasm-dry-run "--dart-define=API_BASE_URL=${API_BASE_URL}"
 
 # ---------- Run stage ----------
 FROM nginx:alpine

--- a/lib/features/reports/presentation/bloc/goal_progress_report/goal_progress_report_event.dart
+++ b/lib/features/reports/presentation/bloc/goal_progress_report/goal_progress_report_event.dart
@@ -1,4 +1,3 @@
-// lib/features/reports/presentation/bloc/goal_progress_report/goal_progress_report_event.dart
 part of 'goal_progress_report_bloc.dart';
 
 abstract class GoalProgressReportEvent extends Equatable {
@@ -15,4 +14,8 @@ class LoadGoalProgressReport extends GoalProgressReportEvent {
 // Internal event for filter changes
 class _FilterChanged extends GoalProgressReportEvent {
   const _FilterChanged();
+}
+
+class ToggleComparison extends GoalProgressReportEvent {
+  const ToggleComparison();
 }

--- a/lib/features/reports/presentation/bloc/goal_progress_report/goal_progress_report_state.dart
+++ b/lib/features/reports/presentation/bloc/goal_progress_report/goal_progress_report_state.dart
@@ -1,4 +1,3 @@
-// lib/features/reports/presentation/bloc/goal_progress_report/goal_progress_report_state.dart
 part of 'goal_progress_report_bloc.dart';
 
 abstract class GoalProgressReportState extends Equatable {
@@ -13,9 +12,15 @@ class GoalProgressReportLoading extends GoalProgressReportState {}
 
 class GoalProgressReportLoaded extends GoalProgressReportState {
   final GoalProgressReportData reportData;
-  const GoalProgressReportLoaded(this.reportData);
+  final bool isComparisonEnabled;
+
+  const GoalProgressReportLoaded(
+    this.reportData, {
+    this.isComparisonEnabled = false,
+  });
+
   @override
-  List<Object?> get props => [reportData];
+  List<Object?> get props => [reportData, isComparisonEnabled];
 }
 
 class GoalProgressReportError extends GoalProgressReportState {

--- a/test/features/reports/presentation/bloc/goal_progress_report/goal_progress_report_bloc_test.dart
+++ b/test/features/reports/presentation/bloc/goal_progress_report/goal_progress_report_bloc_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:dartz/dartz.dart';
 import 'package:expense_tracker/core/error/failure.dart';
@@ -77,4 +78,82 @@ void main() {
       ),
     ],
   );
+
+  blocTest<GoalProgressReportBloc, GoalProgressReportState>(
+    'toggles comparison enabled and reloads report',
+    build: () {
+      when(
+        () => mockUseCase(any()),
+      ).thenAnswer((_) async => Right(tReportData));
+      return GoalProgressReportBloc(
+        getGoalProgressReportUseCase: mockUseCase,
+        reportFilterBloc: mockFilterBloc,
+      );
+    },
+    // Skip initial loading states
+    skip: 2,
+    act: (bloc) => bloc.add(const ToggleComparison()),
+    expect: () => [
+      // Should emit Loading then Loaded with isComparisonEnabled = true
+      isA<GoalProgressReportLoading>(),
+      isA<GoalProgressReportLoaded>()
+          .having((s) => s.reportData, 'data', tReportData)
+          .having((s) => s.isComparisonEnabled, 'isComparisonEnabled', true),
+    ],
+    verify: (bloc) {
+      // Verify use case was called with comparison = true
+      verify(
+        () => mockUseCase(
+          any(
+            that: isA<GetGoalProgressReportParams>().having(
+              (p) => p.calculateComparisonRate,
+              'calculateComparisonRate',
+              true,
+            ),
+          ),
+        ),
+      ).called(1);
+    },
+  );
+
+  test('calls filter changed listener and reloads', () async {
+    when(() => mockUseCase(any())).thenAnswer((_) async => Right(tReportData));
+
+    // Create a controller to simulate stream events
+    final filterStreamController = StreamController<ReportFilterState>();
+    when(
+      () => mockFilterBloc.stream,
+    ).thenAnswer((_) => filterStreamController.stream);
+
+    bloc = GoalProgressReportBloc(
+      getGoalProgressReportUseCase: mockUseCase,
+      reportFilterBloc: mockFilterBloc,
+    );
+
+    // Initial load expectations
+    await expectLater(
+      bloc.stream,
+      emitsInOrder([
+        isA<GoalProgressReportLoading>(),
+        isA<GoalProgressReportLoaded>(),
+      ]),
+    );
+
+    // Act: Emit new filter state
+    filterStreamController.add(
+      ReportFilterState.initial().copyWith(selectedGoalIds: ['goal1']),
+    );
+
+    // Expect: Loading -> Loaded
+    await expectLater(
+      bloc.stream,
+      emitsInOrder([
+        isA<GoalProgressReportLoading>(),
+        isA<GoalProgressReportLoaded>(),
+      ]),
+    );
+
+    await bloc.close();
+    await filterStreamController.close();
+  });
 }

--- a/test/features/reports/presentation/pages/goal_progress_page_test.dart
+++ b/test/features/reports/presentation/pages/goal_progress_page_test.dart
@@ -1,0 +1,216 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/di/service_locator.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/goals/domain/entities/goal.dart';
+import 'package:expense_tracker/features/goals/domain/entities/goal_contribution.dart';
+import 'package:expense_tracker/features/goals/domain/entities/goal_status.dart';
+import 'package:expense_tracker/features/reports/domain/entities/report_data.dart';
+import 'package:expense_tracker/features/reports/domain/helpers/csv_export_helper.dart';
+import 'package:expense_tracker/features/reports/presentation/bloc/goal_progress_report/goal_progress_report_bloc.dart';
+import 'package:expense_tracker/features/reports/presentation/pages/goal_progress_page.dart';
+import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+
+// Mocks
+class MockGoalProgressReportBloc
+    extends MockBloc<GoalProgressReportEvent, GoalProgressReportState>
+    implements GoalProgressReportBloc {}
+
+class MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
+    implements SettingsBloc {}
+
+class MockCsvExportHelper extends Mock implements CsvExportHelper {}
+
+// Helpers
+final tGoal = Goal(
+  id: '1',
+  name: 'Test Goal',
+  targetAmount: 1000,
+  totalSaved: 500,
+  status: GoalStatus.active,
+  createdAt: DateTime(2023, 1, 1),
+  targetDate: DateTime(2023, 12, 31),
+  iconName: 'savings',
+  description: 'Test Description',
+);
+
+final tGoalData = GoalProgressData(
+  goal: tGoal,
+  contributions: [
+    GoalContribution(
+      id: 'c1',
+      goalId: '1',
+      amount: 100,
+      date: DateTime(2023, 6, 1),
+      note: 'Test',
+      createdAt: DateTime(2023, 6, 1),
+    ),
+  ],
+  requiredDailySaving: 10.0,
+  requiredMonthlySaving: 300.0,
+  estimatedCompletionDate: DateTime(2023, 10, 1),
+);
+
+final tReportData = GoalProgressReportData(progressData: [tGoalData]);
+
+void main() {
+  late MockGoalProgressReportBloc mockBloc;
+  late MockSettingsBloc mockSettingsBloc;
+  late MockCsvExportHelper mockCsvExportHelper;
+
+  setUpAll(() {
+    registerFallbackValue(const ToggleComparison());
+    registerFallbackValue(tReportData);
+  });
+
+  setUp(() {
+    mockBloc = MockGoalProgressReportBloc();
+    mockSettingsBloc = MockSettingsBloc();
+    mockCsvExportHelper = MockCsvExportHelper();
+
+    // Ensure GetIt is reset and registered
+    GetIt.instance.reset();
+    GetIt.instance.registerLazySingleton<CsvExportHelper>(
+      () => mockCsvExportHelper,
+    );
+
+    when(
+      () => mockSettingsBloc.state,
+    ).thenReturn(const SettingsState(selectedCountryCode: 'US'));
+  });
+
+  tearDown(() {
+    GetIt.instance.reset();
+  });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider<GoalProgressReportBloc>.value(value: mockBloc),
+          BlocProvider<SettingsBloc>.value(value: mockSettingsBloc),
+        ],
+        child: const GoalProgressPage(),
+      ),
+    );
+  }
+
+  testWidgets('renders loading state', (tester) async {
+    when(() => mockBloc.state).thenReturn(GoalProgressReportLoading());
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('renders error state', (tester) async {
+    when(
+      () => mockBloc.state,
+    ).thenReturn(const GoalProgressReportError('Failed'));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.text('Error: Failed'), findsOneWidget);
+  });
+
+  testWidgets('renders empty state', (tester) async {
+    when(() => mockBloc.state).thenReturn(
+      const GoalProgressReportLoaded(GoalProgressReportData(progressData: [])),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.text('No active goals found.'), findsOneWidget);
+  });
+
+  testWidgets('renders report data without pacing info by default', (
+    tester,
+  ) async {
+    when(
+      () => mockBloc.state,
+    ).thenReturn(GoalProgressReportLoaded(tReportData));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.text('Test Goal'), findsOneWidget);
+    expect(find.text('50%'), findsOneWidget);
+    expect(find.text('Pacing Information'), findsNothing);
+  });
+
+  testWidgets('renders report data WITH pacing info when enabled', (
+    tester,
+  ) async {
+    // Increase screen size
+    tester.binding.window.physicalSizeTestValue = const Size(1000, 2000);
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+
+    when(() => mockBloc.state).thenReturn(
+      GoalProgressReportLoaded(tReportData, isComparisonEnabled: true),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.text('Pacing Information'), findsOneWidget);
+    expect(find.text('Req. Daily'), findsOneWidget);
+    expect(find.text('\$10.00'), findsOneWidget);
+  });
+
+  testWidgets('triggers toggle comparison event', (tester) async {
+    when(() => mockBloc.state).thenReturn(
+      GoalProgressReportLoaded(tReportData, isComparisonEnabled: false),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    await tester.tap(find.byIcon(Icons.compare_arrows_outlined));
+    await tester.pump();
+
+    verify(() => mockBloc.add(const ToggleComparison())).called(1);
+  });
+
+  testWidgets('triggers CSV export', (tester) async {
+    // Explicitly re-register to be safe, though setUp should handle it
+    if (!GetIt.instance.isRegistered<CsvExportHelper>()) {
+      GetIt.instance.registerLazySingleton<CsvExportHelper>(
+        () => mockCsvExportHelper,
+      );
+    }
+
+    when(
+      () => mockBloc.state,
+    ).thenReturn(GoalProgressReportLoaded(tReportData));
+
+    when(
+      () => mockCsvExportHelper.exportGoalProgressReport(any(), any()),
+    ).thenAnswer((_) async => const Left<String, Failure>('csv,data'));
+
+    when(
+      () => mockCsvExportHelper.saveCsvFile(
+        context: any(named: 'context'),
+        csvData: any(named: 'csvData'),
+        fileName: any(named: 'fileName'),
+      ),
+    ).thenAnswer((_) async => {});
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    // Open menu
+    await tester.tap(find.byIcon(Icons.download_outlined));
+    await tester.pumpAndSettle();
+
+    // Tap Export CSV
+    await tester.tap(find.text('Export as CSV'));
+    await tester.pumpAndSettle();
+
+    // Verify export called
+    verify(
+      () => mockCsvExportHelper.exportGoalProgressReport(tReportData, '\$'),
+    ).called(1);
+  });
+}


### PR DESCRIPTION
- Added `ToggleComparison` event and `isComparisonEnabled` state to `GoalProgressReportBloc`.
- Implemented Toggle Comparison logic in Bloc to reload report with comparison flag.
- Updated `GoalProgressPage` to show Toggle Button and Export CSV button.
- Implemented CSV export using `CsvExportHelper`.
- Rendered Pacing Information (Daily/Monthly saving required) when comparison is enabled.

---
*PR created automatically by Jules for task [17727351246135859456](https://jules.google.com/task/17727351246135859456) started by @Aditya-Bichave*