### PR TITLE
Phase 2B: Viral Loop & Access Control

### DIFF
--- a/.memory/learnings.md
+++ b/.memory/learnings.md
@@ -1,0 +1,1 @@
+Learning recorded

--- a/lib/core/utils/app_dialogs.dart
+++ b/lib/core/utils/app_dialogs.dart
@@ -1,4 +1,3 @@
-// lib/core/utils/app_dialogs.dart
 import 'package:flutter/material.dart';
 
 class AppDialogs {
@@ -58,6 +57,28 @@ class AppDialogs {
         confirmText: confirmText,
         confirmationPhrase: confirmationPhrase,
         confirmColor: confirmColor,
+      ),
+    );
+  }
+
+  static void showSuccessSnackbar(BuildContext context, String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message), backgroundColor: Colors.green),
+    );
+  }
+
+  static void showErrorDialog(BuildContext context, String message) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Error'),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -3,6 +3,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 abstract class AuthRemoteDataSource {
   Future<void> signInWithOtp({required String phone});
   Future<void> signInWithMagicLink({required String email});
+  Future<AuthResponse> signInAnonymously();
   Future<AuthResponse> verifyOtp({
     required String phone,
     required String token,
@@ -28,6 +29,11 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
       email: email,
       emailRedirectTo: 'io.supabase.expensetracker://login-callback',
     );
+  }
+
+  @override
+  Future<AuthResponse> signInAnonymously() async {
+    return await _client.auth.signInAnonymously();
   }
 
   @override

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -33,6 +33,16 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   @override
+  Future<Either<Failure, AuthResponse>> signInAnonymously() async {
+    try {
+      final response = await _remoteDataSource.signInAnonymously();
+      return Right(response);
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
   Future<Either<Failure, AuthResponse>> verifyOtp({
     required String phone,
     required String token,

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -5,6 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 abstract class AuthRepository {
   Future<Either<Failure, void>> signInWithOtp(String phone);
   Future<Either<Failure, void>> signInWithMagicLink(String email);
+  Future<Either<Failure, AuthResponse>> signInAnonymously();
   Future<Either<Failure, AuthResponse>> verifyOtp({
     required String phone,
     required String token,

--- a/lib/features/deep_link/presentation/bloc/deep_link_bloc.dart
+++ b/lib/features/deep_link/presentation/bloc/deep_link_bloc.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+import 'package:app_links/app_links.dart';
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:expense_tracker/features/auth/domain/repositories/auth_repository.dart';
+import 'package:expense_tracker/features/groups/domain/repositories/groups_repository.dart';
+
+part 'deep_link_event.dart';
+part 'deep_link_state.dart';
+
+class DeepLinkBloc extends Bloc<DeepLinkEvent, DeepLinkState> {
+  final AppLinks _appLinks;
+  final GroupsRepository _groupsRepository;
+  final AuthRepository _authRepository;
+  StreamSubscription<Uri>? _linkSubscription;
+
+  DeepLinkBloc(this._appLinks, this._groupsRepository, this._authRepository)
+    : super(DeepLinkInitial()) {
+    on<DeepLinkStarted>(_onStarted);
+    on<DeepLinkReceived>(_onReceived);
+    on<DeepLinkManualEntry>(_onManualEntry);
+  }
+
+  Future<void> _onStarted(
+    DeepLinkStarted event,
+    Emitter<DeepLinkState> emit,
+  ) async {
+    // Handle initial link
+    final initialUri = await _appLinks.getInitialLink();
+    if (initialUri != null) {
+      add(DeepLinkReceived(initialUri));
+    }
+
+    // Handle stream
+    _linkSubscription = _appLinks.uriLinkStream.listen((uri) {
+      add(DeepLinkReceived(uri));
+    });
+  }
+
+  Future<void> _onReceived(
+    DeepLinkReceived event,
+    Emitter<DeepLinkState> emit,
+  ) async {
+    // Check if it is a join link
+    // https://spendos.app/join?token=... or spendos://join?token=...
+    if (event.uri.path.contains('/join')) {
+      final token = event.uri.queryParameters['token'];
+      if (token != null) {
+        await _handleJoin(token, emit);
+      }
+    }
+  }
+
+  Future<void> _onManualEntry(
+    DeepLinkManualEntry event,
+    Emitter<DeepLinkState> emit,
+  ) async {
+    await _handleJoin(event.token, emit);
+  }
+
+  Future<void> _handleJoin(String token, Emitter<DeepLinkState> emit) async {
+    emit(DeepLinkProcessing());
+
+    try {
+      // 1. Check Auth
+      final currentUser = _authRepository.getCurrentUser().fold(
+        (_) => null,
+        (user) => user,
+      );
+      if (currentUser == null) {
+        // Log in anonymously
+        final authResult = await _authRepository.signInAnonymously();
+        if (authResult.isLeft()) {
+          emit(const DeepLinkError("Failed to sign in anonymously"));
+          return;
+        }
+      }
+
+      // 2. Call Edge Function
+      final result = await _groupsRepository.acceptInvite(token);
+      await result.fold(
+        (failure) async => emit(DeepLinkError(failure.message)),
+        (data) async {
+          final groupId = data['group_id'] as String;
+          final groupName = data['group_name'] as String?;
+
+          // 3. Sync groups to ensure the new group is visible locally
+          await _groupsRepository.syncGroups();
+
+          emit(DeepLinkSuccess(groupId: groupId, groupName: groupName));
+        },
+      );
+    } catch (e) {
+      emit(DeepLinkError(e.toString()));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _linkSubscription?.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/deep_link/presentation/bloc/deep_link_event.dart
+++ b/lib/features/deep_link/presentation/bloc/deep_link_event.dart
@@ -1,0 +1,28 @@
+part of 'deep_link_bloc.dart';
+
+abstract class DeepLinkEvent extends Equatable {
+  const DeepLinkEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class DeepLinkStarted extends DeepLinkEvent {}
+
+class DeepLinkReceived extends DeepLinkEvent {
+  final Uri uri;
+
+  const DeepLinkReceived(this.uri);
+
+  @override
+  List<Object?> get props => [uri];
+}
+
+class DeepLinkManualEntry extends DeepLinkEvent {
+  final String token;
+
+  const DeepLinkManualEntry(this.token);
+
+  @override
+  List<Object?> get props => [token];
+}

--- a/lib/features/deep_link/presentation/bloc/deep_link_event.dart
+++ b/lib/features/deep_link/presentation/bloc/deep_link_event.dart
@@ -7,7 +7,9 @@ abstract class DeepLinkEvent extends Equatable {
   List<Object?> get props => [];
 }
 
-class DeepLinkStarted extends DeepLinkEvent {}
+class DeepLinkStarted extends DeepLinkEvent {
+  const DeepLinkStarted();
+}
 
 class DeepLinkReceived extends DeepLinkEvent {
   final Uri uri;

--- a/lib/features/deep_link/presentation/bloc/deep_link_state.dart
+++ b/lib/features/deep_link/presentation/bloc/deep_link_state.dart
@@ -1,0 +1,31 @@
+part of 'deep_link_bloc.dart';
+
+abstract class DeepLinkState extends Equatable {
+  const DeepLinkState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class DeepLinkInitial extends DeepLinkState {}
+
+class DeepLinkProcessing extends DeepLinkState {}
+
+class DeepLinkSuccess extends DeepLinkState {
+  final String groupId;
+  final String? groupName;
+
+  const DeepLinkSuccess({required this.groupId, this.groupName});
+
+  @override
+  List<Object?> get props => [groupId, groupName];
+}
+
+class DeepLinkError extends DeepLinkState {
+  final String message;
+
+  const DeepLinkError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/groups/data/repositories/groups_repository_impl.dart
+++ b/lib/features/groups/data/repositories/groups_repository_impl.dart
@@ -98,19 +98,60 @@ class GroupsRepositoryImpl implements GroupsRepository {
   }
 
   @override
-  Future<Either<Failure, String>> createInvite(String groupId) async {
+  Future<Either<Failure, String>> createInvite(
+    String groupId, {
+    String role = 'member',
+    int expiryDays = 7,
+    int maxUses = 0,
+  }) async {
     try {
-      final token = await _remoteDataSource.createInvite(groupId);
-      return Right(token);
+      final url = await _remoteDataSource.createInvite(
+        groupId,
+        role: role,
+        expiryDays: expiryDays,
+        maxUses: maxUses,
+      );
+      return Right(url);
     } catch (e) {
       return Left(ServerFailure(e.toString()));
     }
   }
 
   @override
-  Future<Either<Failure, void>> acceptInvite(String token) async {
+  Future<Either<Failure, Map<String, dynamic>>> acceptInvite(
+    String token,
+  ) async {
     try {
-      await _remoteDataSource.acceptInvite(token);
+      final data = await _remoteDataSource.acceptInvite(token);
+      return Right(data);
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> updateMemberRole(
+    String groupId,
+    String userId,
+    String role,
+  ) async {
+    try {
+      await _remoteDataSource.updateMemberRole(groupId, userId, role);
+      // Sync local members if possible or just rely on realtime
+      return const Right(null);
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> removeMember(
+    String groupId,
+    String userId,
+  ) async {
+    try {
+      await _remoteDataSource.removeMember(groupId, userId);
+      // Sync local members if possible or just rely on realtime
       return const Right(null);
     } catch (e) {
       return Left(ServerFailure(e.toString()));

--- a/lib/features/groups/domain/repositories/groups_repository.dart
+++ b/lib/features/groups/domain/repositories/groups_repository.dart
@@ -8,6 +8,17 @@ abstract class GroupsRepository {
   Future<Either<Failure, List<GroupEntity>>> getGroups();
   Future<Either<Failure, List<GroupMember>>> getGroupMembers(String groupId);
   Future<Either<Failure, void>> syncGroups();
-  Future<Either<Failure, String>> createInvite(String groupId);
-  Future<Either<Failure, void>> acceptInvite(String token);
+  Future<Either<Failure, String>> createInvite(
+    String groupId, {
+    String role = 'member',
+    int expiryDays = 7,
+    int maxUses = 0,
+  });
+  Future<Either<Failure, Map<String, dynamic>>> acceptInvite(String token);
+  Future<Either<Failure, void>> updateMemberRole(
+    String groupId,
+    String userId,
+    String role,
+  );
+  Future<Either<Failure, void>> removeMember(String groupId, String userId);
 }

--- a/lib/features/groups/presentation/bloc/group_members_bloc.dart
+++ b/lib/features/groups/presentation/bloc/group_members_bloc.dart
@@ -1,0 +1,72 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_member.dart';
+import 'package:expense_tracker/features/groups/domain/repositories/groups_repository.dart';
+
+part 'group_members_event.dart';
+part 'group_members_state.dart';
+
+class GroupMembersBloc extends Bloc<GroupMembersEvent, GroupMembersState> {
+  final GroupsRepository _repository;
+
+  GroupMembersBloc(this._repository) : super(GroupMembersInitial()) {
+    on<LoadGroupMembers>(_onLoadGroupMembers);
+    on<GenerateInviteLink>(_onGenerateInviteLink);
+    on<ChangeMemberRole>(_onChangeMemberRole);
+    on<KickMember>(_onKickMember);
+  }
+
+  Future<void> _onLoadGroupMembers(
+    LoadGroupMembers event,
+    Emitter<GroupMembersState> emit,
+  ) async {
+    emit(GroupMembersLoading());
+    final result = await _repository.getGroupMembers(event.groupId);
+    result.fold(
+      (failure) => emit(GroupMembersError(failure.message)),
+      (members) => emit(GroupMembersLoaded(members)),
+    );
+  }
+
+  Future<void> _onGenerateInviteLink(
+    GenerateInviteLink event,
+    Emitter<GroupMembersState> emit,
+  ) async {
+    final result = await _repository.createInvite(
+      event.groupId,
+      role: event.role,
+      expiryDays: event.expiryDays,
+      maxUses: event.maxUses,
+    );
+    result.fold(
+      (failure) => emit(GroupInviteGenerationError(failure.message)),
+      (url) => emit(GroupInviteGenerated(url)),
+    );
+  }
+
+  Future<void> _onChangeMemberRole(
+    ChangeMemberRole event,
+    Emitter<GroupMembersState> emit,
+  ) async {
+    final result = await _repository.updateMemberRole(
+      event.groupId,
+      event.userId,
+      event.newRole,
+    );
+    result.fold(
+      (failure) => emit(GroupMembersError(failure.message)),
+      (_) => add(LoadGroupMembers(event.groupId)),
+    );
+  }
+
+  Future<void> _onKickMember(
+    KickMember event,
+    Emitter<GroupMembersState> emit,
+  ) async {
+    final result = await _repository.removeMember(event.groupId, event.userId);
+    result.fold(
+      (failure) => emit(GroupMembersError(failure.message)),
+      (_) => add(LoadGroupMembers(event.groupId)),
+    );
+  }
+}

--- a/lib/features/groups/presentation/bloc/group_members_event.dart
+++ b/lib/features/groups/presentation/bloc/group_members_event.dart
@@ -1,0 +1,59 @@
+part of 'group_members_bloc.dart';
+
+abstract class GroupMembersEvent extends Equatable {
+  const GroupMembersEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadGroupMembers extends GroupMembersEvent {
+  final String groupId;
+
+  const LoadGroupMembers(this.groupId);
+
+  @override
+  List<Object?> get props => [groupId];
+}
+
+class GenerateInviteLink extends GroupMembersEvent {
+  final String groupId;
+  final String role;
+  final int expiryDays;
+  final int maxUses;
+
+  const GenerateInviteLink({
+    required this.groupId,
+    this.role = 'member',
+    this.expiryDays = 7,
+    this.maxUses = 0,
+  });
+
+  @override
+  List<Object?> get props => [groupId, role, expiryDays, maxUses];
+}
+
+class ChangeMemberRole extends GroupMembersEvent {
+  final String groupId;
+  final String userId;
+  final String newRole;
+
+  const ChangeMemberRole({
+    required this.groupId,
+    required this.userId,
+    required this.newRole,
+  });
+
+  @override
+  List<Object?> get props => [groupId, userId, newRole];
+}
+
+class KickMember extends GroupMembersEvent {
+  final String groupId;
+  final String userId;
+
+  const KickMember({required this.groupId, required this.userId});
+
+  @override
+  List<Object?> get props => [groupId, userId];
+}

--- a/lib/features/groups/presentation/bloc/group_members_state.dart
+++ b/lib/features/groups/presentation/bloc/group_members_state.dart
@@ -1,0 +1,48 @@
+part of 'group_members_bloc.dart';
+
+abstract class GroupMembersState extends Equatable {
+  const GroupMembersState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class GroupMembersInitial extends GroupMembersState {}
+
+class GroupMembersLoading extends GroupMembersState {}
+
+class GroupMembersLoaded extends GroupMembersState {
+  final List<GroupMember> members;
+
+  const GroupMembersLoaded(this.members);
+
+  @override
+  List<Object?> get props => [members];
+}
+
+class GroupMembersError extends GroupMembersState {
+  final String message;
+
+  const GroupMembersError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}
+
+class GroupInviteGenerated extends GroupMembersState {
+  final String url;
+
+  const GroupInviteGenerated(this.url);
+
+  @override
+  List<Object?> get props => [url];
+}
+
+class GroupInviteGenerationError extends GroupMembersState {
+  final String message;
+
+  const GroupInviteGenerationError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/groups/presentation/pages/group_detail_page.dart
+++ b/lib/features/groups/presentation/pages/group_detail_page.dart
@@ -1,12 +1,17 @@
+import 'package:expense_tracker/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:expense_tracker/features/group_expenses/domain/repositories/group_expenses_repository.dart';
 import 'package:expense_tracker/features/group_expenses/presentation/bloc/group_expenses_bloc.dart';
 import 'package:expense_tracker/features/group_expenses/presentation/pages/add_group_expense_page.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_role.dart';
+import 'package:expense_tracker/features/groups/presentation/bloc/group_members_bloc.dart';
+import 'package:expense_tracker/features/groups/presentation/widgets/stitch/group_members_tab.dart';
+import 'package:expense_tracker/features/groups/presentation/widgets/stitch/invite_generation_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:expense_tracker/features/groups/presentation/bloc/groups_bloc.dart';
-import 'package:expense_tracker/features/groups/domain/repositories/groups_repository.dart';
-import 'package:get_it/get_it.dart';
+import 'package:expense_tracker/core/di/service_locator.dart';
+import 'package:expense_tracker/core/utils/app_dialogs.dart';
 
 class GroupDetailPage extends StatefulWidget {
   final String groupId;
@@ -17,13 +22,35 @@ class GroupDetailPage extends StatefulWidget {
   State<GroupDetailPage> createState() => _GroupDetailPageState();
 }
 
-class _GroupDetailPageState extends State<GroupDetailPage> {
+class _GroupDetailPageState extends State<GroupDetailPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (context) =>
-          GroupExpensesBloc(GetIt.I<GroupExpensesRepository>())
-            ..add(LoadGroupExpenses(widget.groupId)),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(
+          create: (context) =>
+              GroupExpensesBloc(sl())..add(LoadGroupExpenses(widget.groupId)),
+        ),
+        BlocProvider(
+          create: (context) =>
+              sl<GroupMembersBloc>()..add(LoadGroupMembers(widget.groupId)),
+        ),
+      ],
       child: Builder(
         builder: (context) {
           final groupsState = context.watch<GroupsBloc>().state;
@@ -37,52 +64,147 @@ class _GroupDetailPageState extends State<GroupDetailPage> {
             } catch (_) {}
           }
 
-          return Scaffold(
-            appBar: AppBar(
-              title: Text(groupName),
-              actions: [
-                IconButton(
-                  icon: const Icon(Icons.person_add),
-                  onPressed: () => _generateInvite(context),
-                ),
-              ],
-            ),
-            floatingActionButton: FloatingActionButton(
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => BlocProvider.value(
-                      value: context.read<GroupExpensesBloc>(),
-                      child: AddGroupExpensePage(groupId: widget.groupId),
+          return BlocListener<GroupMembersBloc, GroupMembersState>(
+            listener: (context, state) {
+              if (state is GroupInviteGenerated) {
+                Clipboard.setData(ClipboardData(text: state.url));
+                AppDialogs.showSuccessSnackbar(
+                  context,
+                  'Invite link copied to clipboard',
+                );
+              } else if (state is GroupInviteGenerationError) {
+                AppDialogs.showErrorDialog(context, state.message);
+              }
+            },
+            child: BlocBuilder<GroupMembersBloc, GroupMembersState>(
+              builder: (context, membersState) {
+                bool canAddExpense = false;
+                bool isAdmin = false;
+                bool canEdit = false;
+
+                if (membersState is GroupMembersLoaded) {
+                  final currentUser =
+                      (context.read<AuthBloc>().state as AuthAuthenticated)
+                          .user;
+                  try {
+                    final member = membersState.members.firstWhere(
+                      (m) => m.userId == currentUser.id,
+                    );
+                    isAdmin = member.role == GroupRole.admin;
+                    // Viewers cannot add, edit, or settle
+                    canAddExpense = member.role != GroupRole.viewer;
+                    canEdit = member.role != GroupRole.viewer;
+                  } catch (_) {}
+                }
+
+                return Scaffold(
+                  appBar: AppBar(
+                    title: Text(groupName),
+                    actions: [
+                      // Invite Member (Admin Only)
+                      if (isAdmin)
+                        IconButton(
+                          icon: const Icon(Icons.person_add),
+                          onPressed: () => _showInviteSheet(context),
+                          tooltip: 'Invite Members',
+                        ),
+                      // Group Settings (Admin Only) or Info (Member)
+                      IconButton(
+                        icon: const Icon(Icons.settings),
+                        onPressed: () {
+                          if (isAdmin) {
+                            // Navigate to Group Settings (Placeholder)
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Group Settings (Admin Only)'),
+                              ),
+                            );
+                          } else {
+                            // Show Read-Only Info
+                            _showGroupInfoDialog(context, groupName);
+                          }
+                        },
+                      ),
+                    ],
+                    bottom: TabBar(
+                      controller: _tabController,
+                      tabs: const [
+                        Tab(text: 'Expenses'),
+                        Tab(text: 'Members'),
+                      ],
                     ),
                   ),
+                  floatingActionButton: canAddExpense
+                      ? FloatingActionButton(
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (_) => BlocProvider.value(
+                                  value: context.read<GroupExpensesBloc>(),
+                                  child: AddGroupExpensePage(
+                                    groupId: widget.groupId,
+                                  ),
+                                ),
+                              ),
+                            );
+                          },
+                          child: const Icon(Icons.add),
+                        )
+                      : null,
+                  body: TabBarView(
+                    controller: _tabController,
+                    children: [
+                      BlocBuilder<GroupExpensesBloc, GroupExpensesState>(
+                        builder: (context, state) {
+                          if (state is GroupExpensesLoading) {
+                            return const Center(
+                              child: CircularProgressIndicator(),
+                            );
+                          } else if (state is GroupExpensesLoaded) {
+                            if (state.expenses.isEmpty) {
+                              return const Center(
+                                child: Text('No expenses yet.'),
+                              );
+                            }
+                            return ListView.builder(
+                              itemCount: state.expenses.length,
+                              itemBuilder: (context, index) {
+                                final expense = state.expenses[index];
+                                return ListTile(
+                                  title: Text(expense.title),
+                                  trailing: Text(
+                                    '${expense.amount} ${expense.currency}',
+                                  ),
+                                  subtitle: Text(
+                                    'Paid by ${expense.createdBy}',
+                                  ),
+                                  onTap: canEdit
+                                      ? () {
+                                          // Navigate to Edit Expense (Placeholder)
+                                          ScaffoldMessenger.of(
+                                            context,
+                                          ).showSnackBar(
+                                            const SnackBar(
+                                              content: Text('Edit Expense'),
+                                            ),
+                                          );
+                                        }
+                                      : null, // Disable tap for viewers
+                                );
+                              },
+                            );
+                          } else if (state is GroupExpensesError) {
+                            return Center(
+                              child: Text('Error: ${state.message}'),
+                            );
+                          }
+                          return const SizedBox.shrink();
+                        },
+                      ),
+                      const GroupMembersTab(),
+                    ],
+                  ),
                 );
-              },
-              child: const Icon(Icons.add),
-            ),
-            body: BlocBuilder<GroupExpensesBloc, GroupExpensesState>(
-              builder: (context, state) {
-                if (state is GroupExpensesLoading) {
-                  return const Center(child: CircularProgressIndicator());
-                } else if (state is GroupExpensesLoaded) {
-                  if (state.expenses.isEmpty) {
-                    return const Center(child: Text('No expenses yet.'));
-                  }
-                  return ListView.builder(
-                    itemCount: state.expenses.length,
-                    itemBuilder: (context, index) {
-                      final expense = state.expenses[index];
-                      return ListTile(
-                        title: Text(expense.title),
-                        trailing: Text('${expense.amount} ${expense.currency}'),
-                        subtitle: Text('Paid by ${expense.createdBy}'),
-                      );
-                    },
-                  );
-                } else if (state is GroupExpensesError) {
-                  return Center(child: Text('Error: ${state.message}'));
-                }
-                return const SizedBox.shrink();
               },
             ),
           );
@@ -91,26 +213,38 @@ class _GroupDetailPageState extends State<GroupDetailPage> {
     );
   }
 
-  Future<void> _generateInvite(BuildContext context) async {
-    try {
-      final repo = GetIt.I<GroupsRepository>();
-      final result = await repo.createInvite(widget.groupId);
-      result.fold(
-        (failure) => ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(failure.message))),
-        (token) {
-          final link = 'expenses://invite?token=$token';
-          Clipboard.setData(ClipboardData(text: link));
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Invite link copied to clipboard')),
+  void _showInviteSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => InviteGenerationSheet(
+        onGenerate: (role, expiry, limit) {
+          context.read<GroupMembersBloc>().add(
+            GenerateInviteLink(
+              groupId: widget.groupId,
+              role: role,
+              expiryDays: expiry,
+              maxUses: limit,
+            ),
           );
         },
-      );
-    } catch (e) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Error: $e')));
-    }
+      ),
+    );
+  }
+
+  void _showGroupInfoDialog(BuildContext context, String groupName) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Group Info'),
+        content: Text('Name: $groupName\nRole: Member/Viewer'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/features/groups/presentation/pages/group_detail_page.dart
+++ b/lib/features/groups/presentation/pages/group_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:expense_tracker/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:expense_tracker/features/auth/presentation/bloc/auth_state.dart'; // Added
 import 'package:expense_tracker/features/group_expenses/domain/repositories/group_expenses_repository.dart';
 import 'package:expense_tracker/features/group_expenses/presentation/bloc/group_expenses_bloc.dart';
 import 'package:expense_tracker/features/group_expenses/presentation/pages/add_group_expense_page.dart';

--- a/lib/features/groups/presentation/pages/group_list_page.dart
+++ b/lib/features/groups/presentation/pages/group_list_page.dart
@@ -1,3 +1,4 @@
+import 'package:expense_tracker/features/deep_link/presentation/bloc/deep_link_bloc.dart';
 import 'package:expense_tracker/features/groups/presentation/bloc/groups_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -28,6 +29,7 @@ class _GroupListPageState extends State<GroupListPage> {
           IconButton(
             icon: const Icon(Icons.link),
             onPressed: () => _showJoinGroupDialog(context),
+            tooltip: 'Join via Code',
           ),
         ],
       ),
@@ -126,7 +128,8 @@ class _GroupListPageState extends State<GroupListPage> {
               onPressed: () {
                 final token = tokenController.text.trim();
                 if (token.isNotEmpty) {
-                  context.read<GroupsBloc>().add(JoinGroupRequested(token));
+                  // Use DeepLinkBloc for consistent logic
+                  context.read<DeepLinkBloc>().add(DeepLinkManualEntry(token));
                   Navigator.pop(context);
                 }
               },

--- a/lib/features/groups/presentation/widgets/stitch/group_members_tab.dart
+++ b/lib/features/groups/presentation/widgets/stitch/group_members_tab.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:expense_tracker/features/groups/presentation/bloc/group_members_bloc.dart';
 import 'package:expense_tracker/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:expense_tracker/features/auth/presentation/bloc/auth_state.dart'; // Added
 import 'package:expense_tracker/features/groups/domain/entities/group_role.dart';
 import 'package:expense_tracker/core/utils/app_dialogs.dart';
 

--- a/lib/features/groups/presentation/widgets/stitch/group_members_tab.dart
+++ b/lib/features/groups/presentation/widgets/stitch/group_members_tab.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:expense_tracker/features/groups/presentation/bloc/group_members_bloc.dart';
+import 'package:expense_tracker/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_role.dart';
+import 'package:expense_tracker/core/utils/app_dialogs.dart';
+
+class GroupMembersTab extends StatelessWidget {
+  const GroupMembersTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<GroupMembersBloc, GroupMembersState>(
+      builder: (context, state) {
+        if (state is GroupMembersLoading) {
+          return const Center(child: CircularProgressIndicator());
+        } else if (state is GroupMembersLoaded) {
+          final currentUser =
+              (context.read<AuthBloc>().state as AuthAuthenticated).user;
+          final currentMember = state.members.firstWhere(
+            (m) => m.userId == currentUser.id,
+            orElse: () => state.members.first, // Fallback, though unlikely
+          );
+          final isAdmin = currentMember.role == GroupRole.admin;
+
+          return ListView.builder(
+            itemCount: state.members.length,
+            itemBuilder: (context, index) {
+              final member = state.members[index];
+              final isMe = member.userId == currentUser.id;
+
+              return ListTile(
+                leading: CircleAvatar(
+                  child: Text(member.userId.substring(0, 2).toUpperCase()),
+                ),
+                title: Text('${member.role.name} ${isMe ? '(You)' : ''}'),
+                subtitle: Text(member.userId), // Or display name if available
+                trailing: (isAdmin && !isMe)
+                    ? IconButton(
+                        icon: const Icon(Icons.more_vert),
+                        onPressed: () => _showMemberOptions(
+                          context,
+                          member.groupId,
+                          member.userId,
+                          member.role.name,
+                        ),
+                      )
+                    : null,
+              );
+            },
+          );
+        } else if (state is GroupMembersError) {
+          return Center(child: Text('Error: ${state.message}'));
+        }
+        return const Center(child: Text('No members loaded'));
+      },
+    );
+  }
+
+  void _showMemberOptions(
+    BuildContext context,
+    String groupId,
+    String userId,
+    String currentRole,
+  ) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.security),
+                title: const Text('Change Role'),
+                onTap: () {
+                  Navigator.pop(context);
+                  _showChangeRoleDialog(context, groupId, userId, currentRole);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.person_remove, color: Colors.red),
+                title: const Text(
+                  'Remove Member',
+                  style: TextStyle(color: Colors.red),
+                ),
+                onTap: () {
+                  Navigator.pop(context);
+                  _confirmKickMember(context, groupId, userId);
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _showChangeRoleDialog(
+    BuildContext context,
+    String groupId,
+    String userId,
+    String currentRole,
+  ) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return SimpleDialog(
+          title: const Text('Select Role'),
+          children: ['admin', 'member', 'viewer'].map((role) {
+            return SimpleDialogOption(
+              onPressed: () {
+                context.read<GroupMembersBloc>().add(
+                  ChangeMemberRole(
+                    groupId: groupId,
+                    userId: userId,
+                    newRole: role,
+                  ),
+                );
+                Navigator.pop(context);
+              },
+              child: Row(
+                children: [
+                  if (role == currentRole) const Icon(Icons.check, size: 16),
+                  const SizedBox(width: 8),
+                  Text(role.toUpperCase()),
+                ],
+              ),
+            );
+          }).toList(),
+        );
+      },
+    );
+  }
+
+  void _confirmKickMember(BuildContext context, String groupId, String userId) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Remove Member?'),
+          content: const Text(
+            'Are you sure you want to remove this member? This action cannot be undone.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                context.read<GroupMembersBloc>().add(
+                  KickMember(groupId: groupId, userId: userId),
+                );
+                Navigator.pop(context);
+              },
+              child: const Text('Remove', style: TextStyle(color: Colors.red)),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/groups/presentation/widgets/stitch/invite_generation_sheet.dart
+++ b/lib/features/groups/presentation/widgets/stitch/invite_generation_sheet.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:expense_tracker/core/widgets/app_dropdown_form_field.dart';
 
 class InviteGenerationSheet extends StatefulWidget {
-  final Function(String role, int expiry, int limit) onGenerate;
+  final void Function(String role, int expiry, int limit) onGenerate;
 
   const InviteGenerationSheet({super.key, required this.onGenerate});
 
@@ -31,7 +31,7 @@ class _InviteGenerationSheetState extends State<InviteGenerationSheet> {
           Text('Invite Members', style: Theme.of(context).textTheme.titleLarge),
           const SizedBox(height: 16),
           AppDropdownFormField<String>(
-            label: 'Role',
+            labelText: 'Role',
             value: _role,
             items: const [
               DropdownMenuItem(value: 'member', child: Text('Member')),
@@ -41,18 +41,18 @@ class _InviteGenerationSheetState extends State<InviteGenerationSheet> {
           ),
           const SizedBox(height: 12),
           AppDropdownFormField<int>(
-            label: 'Expires In',
+            labelText: 'Expires In',
             value: _expiry,
             items: const [
               DropdownMenuItem(value: 1, child: Text('1 Day')),
               DropdownMenuItem(value: 7, child: Text('7 Days')),
-              DropdownMenuItem(value: 36500, child: Text('Never')),
+              DropdownMenuItem(value: 0, child: Text('Never')),
             ],
             onChanged: (val) => setState(() => _expiry = val!),
           ),
           const SizedBox(height: 12),
           AppDropdownFormField<int>(
-            label: 'Usage Limit',
+            labelText: 'Usage Limit',
             value: _limit,
             items: const [
               DropdownMenuItem(value: 0, child: Text('Unlimited')),

--- a/lib/features/groups/presentation/widgets/stitch/invite_generation_sheet.dart
+++ b/lib/features/groups/presentation/widgets/stitch/invite_generation_sheet.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:expense_tracker/core/widgets/app_dropdown_form_field.dart';
+
+class InviteGenerationSheet extends StatefulWidget {
+  final Function(String role, int expiry, int limit) onGenerate;
+
+  const InviteGenerationSheet({super.key, required this.onGenerate});
+
+  @override
+  State<InviteGenerationSheet> createState() => _InviteGenerationSheetState();
+}
+
+class _InviteGenerationSheetState extends State<InviteGenerationSheet> {
+  String _role = 'member';
+  int _expiry = 7;
+  int _limit = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+        left: 16,
+        right: 16,
+        top: 16,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text('Invite Members', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 16),
+          AppDropdownFormField<String>(
+            label: 'Role',
+            value: _role,
+            items: const [
+              DropdownMenuItem(value: 'member', child: Text('Member')),
+              DropdownMenuItem(value: 'viewer', child: Text('Viewer')),
+            ],
+            onChanged: (val) => setState(() => _role = val!),
+          ),
+          const SizedBox(height: 12),
+          AppDropdownFormField<int>(
+            label: 'Expires In',
+            value: _expiry,
+            items: const [
+              DropdownMenuItem(value: 1, child: Text('1 Day')),
+              DropdownMenuItem(value: 7, child: Text('7 Days')),
+              DropdownMenuItem(value: 36500, child: Text('Never')),
+            ],
+            onChanged: (val) => setState(() => _expiry = val!),
+          ),
+          const SizedBox(height: 12),
+          AppDropdownFormField<int>(
+            label: 'Usage Limit',
+            value: _limit,
+            items: const [
+              DropdownMenuItem(value: 0, child: Text('Unlimited')),
+              DropdownMenuItem(value: 1, child: Text('Single Use')),
+            ],
+            onChanged: (val) => setState(() => _limit = val!),
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pop(context);
+              widget.onGenerate(_role, _expiry, _limit);
+            },
+            child: const Text('Generate Link'),
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+}

--- a/supabase/functions/join_group_via_invite/index.ts
+++ b/supabase/functions/join_group_via_invite/index.ts
@@ -1,0 +1,134 @@
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
+import { crypto } from "https://deno.land/std@0.177.0/crypto/mod.ts";
+import { encode as base64url } from "https://deno.land/std@0.177.0/encoding/base64url.ts";
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  // Artificial delay to mitigate brute-force timing attacks (1 second)
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  try {
+    const { token } = await req.json()
+    if (!token) throw new Error('Missing token')
+
+    // Initialize Supabase Admin client (Service Role) to bypass RLS for invite lookup & member insertion
+    const supabaseAdmin = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    )
+
+    // Verify user from Authorization header
+    const authHeader = req.headers.get('Authorization')!
+    const { data: { user }, error: userError } = await supabaseAdmin.auth.getUser(authHeader.replace('Bearer ', ''))
+
+    if (userError || !user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      })
+    }
+
+    // Hash token to lookup
+    const tokenHashBuffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+    const tokenHash = base64url(new Uint8Array(tokenHashBuffer));
+
+    // Find invite
+    const { data: invite, error: inviteError } = await supabaseAdmin
+      .from('group_invites')
+      .select('*')
+      .eq('token_hash', tokenHash)
+      .single()
+
+    if (inviteError || !invite) {
+      return new Response(JSON.stringify({ error: 'Invalid or expired invite' }), {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      })
+    }
+
+    // Check expiry
+    if (new Date(invite.expires_at) < new Date()) {
+      return new Response(JSON.stringify({ error: 'Invite expired' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      })
+    }
+
+    // Check usage limit
+    if (invite.max_uses > 0 && invite.uses_count >= invite.max_uses) {
+      return new Response(JSON.stringify({ error: 'Invite limit reached' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      })
+    }
+
+    // Check if already a member
+    const { data: existingMember } = await supabaseAdmin
+      .from('group_members')
+      .select('id, role')
+      .eq('group_id', invite.group_id)
+      .eq('user_id', user.id)
+      .maybeSingle()
+
+    if (existingMember) {
+      // Already member, just return success + group info
+       const { data: group } = await supabaseAdmin
+        .from('groups')
+        .select('id, name')
+        .eq('id', invite.group_id)
+        .single()
+
+      return new Response(JSON.stringify({
+        message: 'Already a member',
+        group_id: invite.group_id,
+        group_name: group?.name,
+        role: existingMember.role
+      }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 200
+      })
+    }
+
+    // Add to group
+    const { error: insertError } = await supabaseAdmin
+      .from('group_members')
+      .insert({
+        group_id: invite.group_id,
+        user_id: user.id,
+        role: invite.role
+      })
+
+    if (insertError) throw insertError
+
+    // Increment usage atomically via RPC
+    await supabaseAdmin.rpc('increment_invite_uses', { invite_id: invite.id })
+
+    // Get group info for UI
+    const { data: group } = await supabaseAdmin
+        .from('groups')
+        .select('id, name')
+        .eq('id', invite.group_id)
+        .single()
+
+    return new Response(JSON.stringify({
+      message: 'Joined group successfully',
+      group_id: invite.group_id,
+      group_name: group?.name,
+      role: invite.role
+    }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 200
+    })
+
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 400
+    })
+  }
+})

--- a/supabase/migrations/20240524000000_viral_loop.sql
+++ b/supabase/migrations/20240524000000_viral_loop.sql
@@ -1,0 +1,87 @@
+-- Drop existing invites table to recreate with new schema
+DROP TABLE IF EXISTS invites;
+
+-- Create group_invites table
+CREATE TABLE group_invites (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    token_hash TEXT UNIQUE NOT NULL,
+    role member_role DEFAULT 'member'::member_role,
+    created_by UUID NOT NULL REFERENCES profiles(user_id),
+    expires_at TIMESTAMPTZ NOT NULL,
+    max_uses INT DEFAULT 0, -- 0 means unlimited
+    uses_count INT DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Enable RLS
+ALTER TABLE group_invites ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Admins manage invites
+-- Only users who are admins of the group can SELECT/INSERT/UPDATE/DELETE
+CREATE POLICY "Admins manage invites" ON group_invites
+    FOR ALL
+    USING (
+        EXISTS (
+            SELECT 1 FROM group_members
+            WHERE group_members.group_id = group_invites.group_id
+            AND group_members.user_id = auth.uid()
+            AND group_members.role = 'admin'
+        )
+    );
+
+-- Enforce created_by is current user on INSERT
+-- (Supabase might need explicit CHECK for this in policy or trigger, but POLICY WITH CHECK is good)
+-- The above "ALL" policy covers INSERT WITH CHECK as well.
+
+-- Update group_members policies for Admin powers
+-- Admin can UPDATE roles
+CREATE POLICY "Admins can update member roles" ON group_members
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM group_members AS admin_check
+            WHERE admin_check.group_id = group_members.group_id
+            AND admin_check.user_id = auth.uid()
+            AND admin_check.role = 'admin'
+        )
+    );
+
+-- Admin can DELETE members (Kick)
+CREATE POLICY "Admins can kick members" ON group_members
+    FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM group_members AS admin_check
+            WHERE admin_check.group_id = group_members.group_id
+            AND admin_check.user_id = auth.uid()
+            AND admin_check.role = 'admin'
+        )
+    );
+
+-- User can DELETE own membership (Leave)
+-- Placeholder: In future check for balance=0
+CREATE POLICY "Users can leave group" ON group_members
+    FOR DELETE
+    USING (
+        user_id = auth.uid()
+    );
+
+-- Function to handle new user profile creation if not exists
+-- (Refining the existing one if needed, but 'handle_new_user' exists in previous migrations)
+-- Ensuring it covers anonymous users too (auth.users inserts usually trigger it)
+
+-- Create function to atomically increment invite uses
+CREATE OR REPLACE FUNCTION increment_invite_uses(invite_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+    UPDATE group_invites
+    SET uses_count = uses_count + 1,
+        updated_at = NOW()
+    WHERE id = invite_id;
+END;
+$$;

--- a/test/core/utils/logger_test.dart
+++ b/test/core/utils/logger_test.dart
@@ -23,6 +23,9 @@ void main() {
   });
 
   test('sendToServer sends POST request with correct data', () async {
+    // Avoid throttling from previous tests
+    await Future.delayed(const Duration(milliseconds: 150));
+
     final mockClient = MockHttpClient();
     debugLogClient = mockClient;
 

--- a/test/features/auth/data/repositories/auth_repository_impl_test.dart
+++ b/test/features/auth/data/repositories/auth_repository_impl_test.dart
@@ -5,6 +5,8 @@ import 'package:expense_tracker/features/auth/data/repositories/auth_repository_
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:expense_tracker/core/services/secure_storage_service.dart';
+import 'package:expense_tracker/core/di/service_locator.dart';
 
 class MockAuthRemoteDataSource extends Mock implements AuthRemoteDataSource {}
 
@@ -12,9 +14,19 @@ class MockUser extends Mock implements User {}
 
 class MockAuthResponse extends Mock implements AuthResponse {}
 
+class MockSecureStorageService extends Mock implements SecureStorageService {}
+
 void main() {
   late AuthRepositoryImpl repository;
   late MockAuthRemoteDataSource mockRemoteDataSource;
+
+  setUpAll(() {
+    // Register fallback if needed or mock sl if necessary for signOut
+    // signOut uses sl<SecureStorageService>() which might crash if sl not setup
+    // But repository implementation uses try-catch, so it might be fine, or we need to setup sl.
+    // The existing test for signOut passed, so maybe it catches the error or sl is ignored.
+    // Let's check signOut implementation again. It has try catch for sl.
+  });
 
   setUp(() {
     mockRemoteDataSource = MockAuthRemoteDataSource();
@@ -53,6 +65,32 @@ void main() {
         (failure) => expect(failure, isA<ServerFailure>()),
         (_) => fail('Should have failed'),
       );
+    });
+  });
+
+  group('signInAnonymously', () {
+    final tAuthResponse = MockAuthResponse();
+
+    test('should return Right(AuthResponse) when successful', () async {
+      when(
+        () => mockRemoteDataSource.signInAnonymously(),
+      ).thenAnswer((_) async => tAuthResponse);
+
+      final result = await repository.signInAnonymously();
+
+      expect(result, Right(tAuthResponse));
+      verify(() => mockRemoteDataSource.signInAnonymously()).called(1);
+    });
+
+    test('should return ServerFailure when call fails', () async {
+      when(
+        () => mockRemoteDataSource.signInAnonymously(),
+      ).thenThrow(Exception('Error'));
+
+      final result = await repository.signInAnonymously();
+
+      expect(result.isLeft(), true);
+      expect(result.fold((l) => l, (r) => null), isA<ServerFailure>());
     });
   });
 

--- a/test/features/deep_link/presentation/bloc/deep_link_bloc_test.dart
+++ b/test/features/deep_link/presentation/bloc/deep_link_bloc_test.dart
@@ -19,18 +19,22 @@ class MockAuthRepository extends Mock implements AuthRepository {}
 
 class MockUser extends Mock implements User {}
 
+class MockAuthResponse extends Mock implements AuthResponse {}
+
 void main() {
   late DeepLinkBloc bloc;
   late MockAppLinks mockAppLinks;
   late MockGroupsRepository mockGroupsRepository;
   late MockAuthRepository mockAuthRepository;
   late MockUser mockUser;
+  late MockAuthResponse mockAuthResponse;
 
   setUp(() {
     mockAppLinks = MockAppLinks();
     mockGroupsRepository = MockGroupsRepository();
     mockAuthRepository = MockAuthRepository();
     mockUser = MockUser();
+    mockAuthResponse = MockAuthResponse();
 
     when(
       () => mockAppLinks.uriLinkStream,
@@ -49,6 +53,34 @@ void main() {
       expect(bloc.state, DeepLinkInitial());
     });
 
+    // Test Initial Link
+    blocTest<DeepLinkBloc, DeepLinkState>(
+      'emits success when initial link is a valid join link',
+      setUp: () {
+        when(() => mockAppLinks.getInitialLink()).thenAnswer(
+          (_) async => Uri.parse('https://spendos.app/join?token=123'),
+        );
+        when(
+          () => mockAuthRepository.getCurrentUser(),
+        ).thenReturn(Right(mockUser));
+        when(() => mockGroupsRepository.acceptInvite(any())).thenAnswer(
+          (_) async =>
+              const Right({'group_id': '123', 'group_name': 'Initial Group'}),
+        );
+        when(
+          () => mockGroupsRepository.syncGroups(),
+        ).thenAnswer((_) async => const Right(null));
+      },
+      build: () =>
+          DeepLinkBloc(mockAppLinks, mockGroupsRepository, mockAuthRepository),
+      act: (bloc) => bloc.add(const DeepLinkStarted()),
+      expect: () => [
+        DeepLinkProcessing(),
+        const DeepLinkSuccess(groupId: '123', groupName: 'Initial Group'),
+      ],
+    );
+
+    // Test Manual Entry Success
     blocTest<DeepLinkBloc, DeepLinkState>(
       'emits [DeepLinkProcessing, DeepLinkSuccess] when DeepLinkManualEntry is added and join is successful',
       setUp: () {
@@ -71,6 +103,7 @@ void main() {
       ],
     );
 
+    // Test Manual Entry Failure
     blocTest<DeepLinkBloc, DeepLinkState>(
       'emits [DeepLinkProcessing, DeepLinkError] when DeepLinkManualEntry fails',
       setUp: () {
@@ -86,6 +119,84 @@ void main() {
       expect: () => [
         DeepLinkProcessing(),
         const DeepLinkError('Invalid token'),
+      ],
+    );
+
+    // Test Anonymous Auth Success
+    blocTest<DeepLinkBloc, DeepLinkState>(
+      'signs in anonymously if user is null',
+      setUp: () {
+        when(
+          () => mockAuthRepository.getCurrentUser(),
+        ).thenReturn(Left(CacheFailure('No user')));
+        when(() => mockAuthResponse.user).thenReturn(mockUser);
+        when(
+          () => mockAuthRepository.signInAnonymously(),
+        ).thenAnswer((_) async => Right(mockAuthResponse));
+        when(() => mockGroupsRepository.acceptInvite(any())).thenAnswer(
+          (_) async =>
+              const Right({'group_id': '123', 'group_name': 'Anon Group'}),
+        );
+        when(
+          () => mockGroupsRepository.syncGroups(),
+        ).thenAnswer((_) async => const Right(null));
+      },
+      build: () => bloc,
+      act: (bloc) => bloc.add(const DeepLinkManualEntry('token')),
+      expect: () => [
+        DeepLinkProcessing(),
+        const DeepLinkSuccess(groupId: '123', groupName: 'Anon Group'),
+      ],
+      verify: (_) {
+        verify(() => mockAuthRepository.signInAnonymously()).called(1);
+      },
+    );
+
+    // Test Anonymous Auth Failure
+    blocTest<DeepLinkBloc, DeepLinkState>(
+      'emits error if anonymous sign in fails',
+      setUp: () {
+        when(
+          () => mockAuthRepository.getCurrentUser(),
+        ).thenReturn(Left(CacheFailure('No user')));
+        when(
+          () => mockAuthRepository.signInAnonymously(),
+        ).thenAnswer((_) async => const Left(ServerFailure('Auth failed')));
+      },
+      build: () => bloc,
+      act: (bloc) => bloc.add(const DeepLinkManualEntry('token')),
+      expect: () => [
+        DeepLinkProcessing(),
+        const DeepLinkError("Failed to sign in anonymously"),
+      ],
+    );
+
+    // Test Stream Handling
+    blocTest<DeepLinkBloc, DeepLinkState>(
+      'emits success when link received from stream',
+      setUp: () {
+        when(() => mockAppLinks.uriLinkStream).thenAnswer(
+          (_) => Stream.fromIterable([
+            Uri.parse('https://spendos.app/join?token=stream'),
+          ]),
+        );
+        when(
+          () => mockAuthRepository.getCurrentUser(),
+        ).thenReturn(Right(mockUser));
+        when(() => mockGroupsRepository.acceptInvite(any())).thenAnswer(
+          (_) async =>
+              const Right({'group_id': '456', 'group_name': 'Stream Group'}),
+        );
+        when(
+          () => mockGroupsRepository.syncGroups(),
+        ).thenAnswer((_) async => const Right(null));
+      },
+      build: () =>
+          DeepLinkBloc(mockAppLinks, mockGroupsRepository, mockAuthRepository),
+      act: (bloc) => bloc.add(const DeepLinkStarted()),
+      expect: () => [
+        DeepLinkProcessing(),
+        const DeepLinkSuccess(groupId: '456', groupName: 'Stream Group'),
       ],
     );
   });

--- a/test/features/deep_link/presentation/bloc/deep_link_bloc_test.dart
+++ b/test/features/deep_link/presentation/bloc/deep_link_bloc_test.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/auth/domain/repositories/auth_repository.dart';
+import 'package:expense_tracker/features/deep_link/presentation/bloc/deep_link_bloc.dart';
+import 'package:expense_tracker/features/groups/domain/repositories/groups_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class MockAppLinks extends Mock implements AppLinks {}
+
+class MockGroupsRepository extends Mock implements GroupsRepository {}
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockUser extends Mock implements User {}
+
+void main() {
+  late DeepLinkBloc bloc;
+  late MockAppLinks mockAppLinks;
+  late MockGroupsRepository mockGroupsRepository;
+  late MockAuthRepository mockAuthRepository;
+  late MockUser mockUser;
+
+  setUp(() {
+    mockAppLinks = MockAppLinks();
+    mockGroupsRepository = MockGroupsRepository();
+    mockAuthRepository = MockAuthRepository();
+    mockUser = MockUser();
+
+    when(
+      () => mockAppLinks.uriLinkStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(() => mockAppLinks.getInitialLink()).thenAnswer((_) async => null);
+
+    bloc = DeepLinkBloc(mockAppLinks, mockGroupsRepository, mockAuthRepository);
+  });
+
+  tearDown(() {
+    bloc.close();
+  });
+
+  group('DeepLinkBloc', () {
+    test('initial state is DeepLinkInitial', () {
+      expect(bloc.state, DeepLinkInitial());
+    });
+
+    blocTest<DeepLinkBloc, DeepLinkState>(
+      'emits [DeepLinkProcessing, DeepLinkSuccess] when DeepLinkManualEntry is added and join is successful',
+      setUp: () {
+        when(
+          () => mockAuthRepository.getCurrentUser(),
+        ).thenReturn(Right(mockUser));
+        when(() => mockGroupsRepository.acceptInvite(any())).thenAnswer(
+          (_) async =>
+              const Right({'group_id': '123', 'group_name': 'Test Group'}),
+        );
+        when(
+          () => mockGroupsRepository.syncGroups(),
+        ).thenAnswer((_) async => const Right(null));
+      },
+      build: () => bloc,
+      act: (bloc) => bloc.add(const DeepLinkManualEntry('token123')),
+      expect: () => [
+        DeepLinkProcessing(),
+        const DeepLinkSuccess(groupId: '123', groupName: 'Test Group'),
+      ],
+    );
+
+    blocTest<DeepLinkBloc, DeepLinkState>(
+      'emits [DeepLinkProcessing, DeepLinkError] when DeepLinkManualEntry fails',
+      setUp: () {
+        when(
+          () => mockAuthRepository.getCurrentUser(),
+        ).thenReturn(Right(mockUser));
+        when(
+          () => mockGroupsRepository.acceptInvite(any()),
+        ).thenAnswer((_) async => const Left(ServerFailure('Invalid token')));
+      },
+      build: () => bloc,
+      act: (bloc) => bloc.add(const DeepLinkManualEntry('invalid')),
+      expect: () => [
+        DeepLinkProcessing(),
+        const DeepLinkError('Invalid token'),
+      ],
+    );
+  });
+}

--- a/test/features/groups/data/repositories/groups_repository_impl_test.dart
+++ b/test/features/groups/data/repositories/groups_repository_impl_test.dart
@@ -173,4 +173,120 @@ void main() {
       verifyNever(() => mockRemoteDataSource.getGroups());
     });
   });
+
+  group('createInvite', () {
+    test('should call remoteDataSource.createInvite', () async {
+      when(
+        () => mockRemoteDataSource.createInvite(
+          any(),
+          role: any(named: 'role'),
+          expiryDays: any(named: 'expiryDays'),
+          maxUses: any(named: 'maxUses'),
+        ),
+      ).thenAnswer((_) async => 'https://link.com');
+
+      final result = await repository.createInvite('1');
+
+      expect(result.isRight(), true);
+      result.fold((l) => null, (r) => expect(r, 'https://link.com'));
+      verify(
+        () => mockRemoteDataSource.createInvite(
+          '1',
+          role: 'member',
+          expiryDays: 7,
+          maxUses: 0,
+        ),
+      ).called(1);
+    });
+
+    test('should return ServerFailure on exception', () async {
+      when(
+        () => mockRemoteDataSource.createInvite(
+          any(),
+          role: any(named: 'role'),
+          expiryDays: any(named: 'expiryDays'),
+          maxUses: any(named: 'maxUses'),
+        ),
+      ).thenThrow(Exception('Error'));
+
+      final result = await repository.createInvite('1');
+
+      expect(result.isLeft(), true);
+      expect(result.fold((l) => l, (r) => null), isA<ServerFailure>());
+    });
+  });
+
+  group('acceptInvite', () {
+    test('should call remoteDataSource.acceptInvite', () async {
+      when(
+        () => mockRemoteDataSource.acceptInvite(any()),
+      ).thenAnswer((_) async => {'group_id': '1'});
+
+      final result = await repository.acceptInvite('token');
+
+      expect(result.isRight(), true);
+      verify(() => mockRemoteDataSource.acceptInvite('token')).called(1);
+    });
+
+    test('should return ServerFailure on exception', () async {
+      when(
+        () => mockRemoteDataSource.acceptInvite(any()),
+      ).thenThrow(Exception('Error'));
+
+      final result = await repository.acceptInvite('token');
+
+      expect(result.isLeft(), true);
+      expect(result.fold((l) => l, (r) => null), isA<ServerFailure>());
+    });
+  });
+
+  group('updateMemberRole', () {
+    test('should call remoteDataSource.updateMemberRole', () async {
+      when(
+        () => mockRemoteDataSource.updateMemberRole(any(), any(), any()),
+      ).thenAnswer((_) async {});
+
+      final result = await repository.updateMemberRole('1', 'u1', 'admin');
+
+      expect(result.isRight(), true);
+      verify(
+        () => mockRemoteDataSource.updateMemberRole('1', 'u1', 'admin'),
+      ).called(1);
+    });
+
+    test('should return ServerFailure on exception', () async {
+      when(
+        () => mockRemoteDataSource.updateMemberRole(any(), any(), any()),
+      ).thenThrow(Exception('Error'));
+
+      final result = await repository.updateMemberRole('1', 'u1', 'admin');
+
+      expect(result.isLeft(), true);
+      expect(result.fold((l) => l, (r) => null), isA<ServerFailure>());
+    });
+  });
+
+  group('removeMember', () {
+    test('should call remoteDataSource.removeMember', () async {
+      when(
+        () => mockRemoteDataSource.removeMember(any(), any()),
+      ).thenAnswer((_) async {});
+
+      final result = await repository.removeMember('1', 'u1');
+
+      expect(result.isRight(), true);
+      verify(() => mockRemoteDataSource.removeMember('1', 'u1')).called(1);
+    });
+
+    test('should return ServerFailure on exception', () async {
+      when(
+        () => mockRemoteDataSource.removeMember(any(), any()),
+      ).thenThrow(Exception('Error'));
+
+      final result = await repository.removeMember('1', 'u1');
+
+      expect(result.isLeft(), true);
+      expect(result.fold((l) => l, (r) => null), isA<ServerFailure>());
+    });
+  });
 }

--- a/test/features/groups/presentation/bloc/group_members_bloc_test.dart
+++ b/test/features/groups/presentation/bloc/group_members_bloc_test.dart
@@ -1,0 +1,70 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
+import 'package:expense_tracker/core/error/failure.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_member.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_role.dart';
+import 'package:expense_tracker/features/groups/domain/repositories/groups_repository.dart';
+import 'package:expense_tracker/features/groups/presentation/bloc/group_members_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockGroupsRepository extends Mock implements GroupsRepository {}
+
+void main() {
+  late GroupMembersBloc bloc;
+  late MockGroupsRepository mockGroupsRepository;
+
+  setUp(() {
+    mockGroupsRepository = MockGroupsRepository();
+    bloc = GroupMembersBloc(mockGroupsRepository);
+  });
+
+  tearDown(() {
+    bloc.close();
+  });
+
+  group('GroupMembersBloc', () {
+    test('initial state is GroupMembersInitial', () {
+      expect(bloc.state, GroupMembersInitial());
+    });
+
+    final members = [
+      GroupMember(
+        id: '1',
+        groupId: 'g1',
+        userId: 'u1',
+        role: GroupRole.admin,
+        joinedAt: DateTime.now(),
+      ),
+    ];
+
+    blocTest<GroupMembersBloc, GroupMembersState>(
+      'emits [GroupMembersLoading, GroupMembersLoaded] when LoadGroupMembers is added and successful',
+      setUp: () {
+        when(
+          () => mockGroupsRepository.getGroupMembers(any()),
+        ).thenAnswer((_) async => Right(members));
+      },
+      build: () => bloc,
+      act: (bloc) => bloc.add(const LoadGroupMembers('g1')),
+      expect: () => [GroupMembersLoading(), GroupMembersLoaded(members)],
+    );
+
+    blocTest<GroupMembersBloc, GroupMembersState>(
+      'emits [GroupInviteGenerated] when GenerateInviteLink is successful',
+      setUp: () {
+        when(
+          () => mockGroupsRepository.createInvite(
+            any(),
+            role: any(named: 'role'),
+            expiryDays: any(named: 'expiryDays'),
+            maxUses: any(named: 'maxUses'),
+          ),
+        ).thenAnswer((_) async => const Right('https://link.com'));
+      },
+      build: () => bloc,
+      act: (bloc) => bloc.add(const GenerateInviteLink(groupId: 'g1')),
+      expect: () => [const GroupInviteGenerated('https://link.com')],
+    );
+  });
+}


### PR DESCRIPTION
Implemented Phase 2B: Viral Loop & Access Control

-   **Database**: Added `supabase/migrations/20240524000000_viral_loop.sql` to refactor `invites` to `group_invites` with token hashing and RLS.
-   **Edge Functions**:
    -   Implemented `create-invite` with secure token generation.
    -   Refactored `accept-invite` to `join_group_via_invite` with validation and atomic usage increment.
    -   Added `_shared/cors.ts`.
-   **Flutter**:
    -   Updated `AuthRepository` for `signInAnonymously`.
    -   Implemented `DeepLinkBloc` to handle invite links.
    -   Implemented `GroupMembersBloc` for member management.
    -   Updated `GroupDetailPage` with Invite UI, Member List, and Role Enforcement.
    -   Updated `GroupsRepository` to use new edge functions.
    -   Registered new dependencies in `service_locator.dart`.

---
*PR created automatically by Jules for task [9780861333797010394](https://jules.google.com/task/9780861333797010394) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token-based group invites with role, expiry and usage limits; accepting an invite returns group details.
  * Deep link support and manual code entry to join groups (auto-auth flow, UI feedback).
  * Admin UI: generate invite links, change member roles, remove members; Members tab and invite sheet.
  * Anonymous sign-in to support seamless join flow.

* **Tests**
  * Unit tests added for deep link and group-members flows.

* **Chores**
  * Added a brief project learning note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->