### PR TITLE
🛠️ Stabilizer: Fix Demo Mode refresh, Create Group button, and add Recurring Rules demo data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ ci/smoke/node_modules/
 ci/smoke/artifacts/
 ci/smoke/smoke-report.json
 ci/smoke/routes.json
+# Environment variables
+.env
+.env.*

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" >
     <application
-        android:label="expense_tracking"
+        android:label="Financial OS"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -16,7 +16,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Expense Tracking</string>
+	<string>Financial OS</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -24,7 +24,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>expense_tracking</string>
+	<string>Financial OS</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -1,7 +1,7 @@
 // lib/core/constants/app_constants.dart
 
 abstract class AppConstants {
-  static const String appName = "Spend Savvy"; // Centralized app name
+  static const String appName = "Financial OS"; // Centralized app name
 
   // Default values moved from SettingsState (can be used across app)
   // Note: ThemeMode itself doesn't fit well here, keep default in SettingsState

--- a/lib/core/data/countries.dart
+++ b/lib/core/data/countries.dart
@@ -5,11 +5,13 @@ class AppCountry {
   final String code; // e.g., 'US', 'GB', 'IN'
   final String name; // e.g., 'United States', 'United Kingdom', 'India'
   final String currencySymbol; // e.g., '$', '£', '₹'
+  final String currencyCode; // e.g., 'USD', 'GBP', 'INR'
 
   const AppCountry({
     required this.code,
     required this.name,
     required this.currencySymbol,
+    required this.currencyCode,
   });
 
   @override
@@ -27,14 +29,54 @@ abstract class AppCountries {
   static const String defaultCountryCode = 'US';
 
   static const List<AppCountry> availableCountries = [
-    AppCountry(code: 'US', name: 'United States', currencySymbol: '\$'),
-    AppCountry(code: 'GB', name: 'United Kingdom', currencySymbol: '£'),
-    AppCountry(code: 'EU', name: 'Eurozone', currencySymbol: '€'),
-    AppCountry(code: 'IN', name: 'India', currencySymbol: '₹'),
-    AppCountry(code: 'CA', name: 'Canada', currencySymbol: '\$'), // CAD
-    AppCountry(code: 'AU', name: 'Australia', currencySymbol: '\$'), // AUD
-    AppCountry(code: 'JP', name: 'Japan', currencySymbol: '¥'),
-    AppCountry(code: 'CH', name: 'Switzerland', currencySymbol: 'CHF'),
+    AppCountry(
+      code: 'US',
+      name: 'United States',
+      currencySymbol: r'$',
+      currencyCode: 'USD',
+    ),
+    AppCountry(
+      code: 'GB',
+      name: 'United Kingdom',
+      currencySymbol: '£',
+      currencyCode: 'GBP',
+    ),
+    AppCountry(
+      code: 'EU',
+      name: 'Eurozone',
+      currencySymbol: '€',
+      currencyCode: 'EUR',
+    ),
+    AppCountry(
+      code: 'IN',
+      name: 'India',
+      currencySymbol: '₹',
+      currencyCode: 'INR',
+    ),
+    AppCountry(
+      code: 'CA',
+      name: 'Canada',
+      currencySymbol: r'$',
+      currencyCode: 'CAD',
+    ),
+    AppCountry(
+      code: 'AU',
+      name: 'Australia',
+      currencySymbol: r'$',
+      currencyCode: 'AUD',
+    ),
+    AppCountry(
+      code: 'JP',
+      name: 'Japan',
+      currencySymbol: '¥',
+      currencyCode: 'JPY',
+    ),
+    AppCountry(
+      code: 'CH',
+      name: 'Switzerland',
+      currencySymbol: 'CHF',
+      currencyCode: 'CHF',
+    ),
     // Add more countries as needed
   ];
 
@@ -48,6 +90,13 @@ abstract class AppCountries {
     return availableCountries
         .firstWhere((c) => c.code == codeToUse, orElse: () => defaultCountry)
         .currencySymbol;
+  }
+
+  static String getCurrencyCodeForCountry(String? countryCode) {
+    final codeToUse = countryCode ?? defaultCountryCode;
+    return availableCountries
+        .firstWhere((c) => c.code == codeToUse, orElse: () => defaultCountry)
+        .currencyCode;
   }
 
   static AppCountry? findCountryByCode(String? code) {

--- a/lib/core/data/demo_data.dart
+++ b/lib/core/data/demo_data.dart
@@ -1,3 +1,6 @@
+import "package:expense_tracker/features/transactions/domain/entities/transaction_entity.dart";
+import "package:expense_tracker/features/recurring_transactions/domain/entities/recurring_rule_enums.dart";
+import "package:expense_tracker/features/recurring_transactions/data/models/recurring_rule_model.dart";
 import 'package:expense_tracker/features/accounts/data/models/asset_account_model.dart';
 import 'package:expense_tracker/features/accounts/domain/entities/asset_account.dart';
 import 'package:expense_tracker/features/budgets/data/models/budget_model.dart';
@@ -367,6 +370,66 @@ class DemoData {
       date: DateTime.now().subtract(const Duration(days: 10)),
       note: 'Sold old device',
       createdAt: DateTime.now().subtract(const Duration(days: 10)),
+    ),
+  ];
+
+  // --- Sample Recurring Rules ---
+  static final List<RecurringRuleModel> sampleRecurringRules = [
+    RecurringRuleModel(
+      id: _uuid.v4(),
+      amount: 14.99,
+      description: 'Netflix Subscription',
+      categoryId: catSubscriptionsId,
+      accountId: checkingAccount.id,
+      transactionTypeIndex: TransactionType.expense.index,
+      frequencyIndex: Frequency.monthly.index,
+      interval: 1,
+      startDate: DateTime.now().subtract(const Duration(days: 45)),
+      dayOfMonth: DateTime.now().subtract(const Duration(days: 45)).day,
+      endConditionTypeIndex: EndConditionType.never.index,
+      statusIndex: RuleStatus.active.index,
+      nextOccurrenceDate: DateTime.now().add(const Duration(days: 15)),
+      occurrencesGenerated: 2,
+    ),
+    RecurringRuleModel(
+      id: _uuid.v4(),
+      amount: 850.00,
+      description: 'Rent',
+      categoryId: catRentId,
+      accountId: checkingAccount.id,
+      transactionTypeIndex: TransactionType.expense.index,
+      frequencyIndex: Frequency.monthly.index,
+      interval: 1,
+      startDate: DateTime.now().subtract(const Duration(days: 60)),
+      dayOfMonth: 1,
+      endConditionTypeIndex: EndConditionType.never.index,
+      statusIndex: RuleStatus.active.index,
+      nextOccurrenceDate: DateTime(
+        DateTime.now().year,
+        DateTime.now().month + 1,
+        1,
+      ),
+      occurrencesGenerated: 2,
+    ),
+    RecurringRuleModel(
+      id: _uuid.v4(),
+      amount: 2500.00,
+      description: 'Salary',
+      categoryId: catSalaryId,
+      accountId: checkingAccount.id,
+      transactionTypeIndex: TransactionType.income.index,
+      frequencyIndex: Frequency.monthly.index,
+      interval: 1,
+      startDate: DateTime.now().subtract(const Duration(days: 60)),
+      dayOfMonth: 15,
+      endConditionTypeIndex: EndConditionType.never.index,
+      statusIndex: RuleStatus.active.index,
+      nextOccurrenceDate: DateTime(
+        DateTime.now().year,
+        DateTime.now().month + 1,
+        15,
+      ),
+      occurrencesGenerated: 2,
     ),
   ];
 }

--- a/lib/core/di/service_configurations/auth_dependencies.dart
+++ b/lib/core/di/service_configurations/auth_dependencies.dart
@@ -9,6 +9,8 @@ import 'package:expense_tracker/features/auth/domain/usecases/logout_usecase.dar
 import 'package:expense_tracker/features/auth/domain/usecases/verify_otp_usecase.dart';
 import 'package:expense_tracker/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:expense_tracker/core/auth/session_cubit.dart';
+import 'package:app_links/app_links.dart';
+import 'package:expense_tracker/features/deep_link/presentation/bloc/deep_link_bloc.dart';
 
 class AuthDependencies {
   static void register() {
@@ -27,5 +29,10 @@ class AuthDependencies {
     sl.registerFactory(() => AuthBloc(sl(), sl(), sl(), sl(), sl()));
 
     sl.registerLazySingleton(() => SessionCubit(sl(), sl(), sl()));
+
+    sl.registerLazySingleton<AppLinks>(() => AppLinks());
+    sl.registerLazySingleton(
+      () => DeepLinkBloc(sl<AppLinks>(), sl(), sl<AuthRepository>()),
+    );
   }
 }

--- a/lib/core/di/service_configurations/recurring_transactions_dependencies.dart
+++ b/lib/core/di/service_configurations/recurring_transactions_dependencies.dart
@@ -1,6 +1,8 @@
 // lib/core/di/service_configurations/recurring_transactions_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
+import 'package:expense_tracker/core/services/demo_mode_service.dart';
 import 'package:expense_tracker/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source.dart';
+import 'package:expense_tracker/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source_proxy.dart';
 import 'package:expense_tracker/features/recurring_transactions/data/repositories/recurring_transaction_repository_impl.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/repositories/recurring_transaction_repository.dart';
 import 'package:expense_tracker/features/recurring_transactions/domain/services/transaction_generation_service.dart';
@@ -20,10 +22,14 @@ import 'package:uuid/uuid.dart';
 class RecurringTransactionsDependencies {
   static void register() {
     // Data sources
+    // Register the PROXY instead of the direct implementation
     sl.registerLazySingleton<RecurringTransactionLocalDataSource>(
-      () => RecurringTransactionLocalDataSourceImpl(
-        recurringRuleBox: sl(),
-        recurringRuleAuditLogBox: sl(),
+      () => DemoAwareRecurringTransactionDataSource(
+        hiveDataSource: RecurringTransactionLocalDataSourceImpl(
+          recurringRuleBox: sl(),
+          recurringRuleAuditLogBox: sl(),
+        ),
+        demoModeService: sl<DemoModeService>(),
       ),
     );
 

--- a/lib/core/network/supabase_config.dart
+++ b/lib/core/network/supabase_config.dart
@@ -1,14 +1,10 @@
 import 'package:flutter/foundation.dart';
 
 class SupabaseConfig {
-  static const String supabaseUrl = String.fromEnvironment(
-    'SUPABASE_URL',
-    defaultValue: 'https://nzjqjsrdmbrojukbebzi.supabase.co',
-  );
+  static const String supabaseUrl = String.fromEnvironment('SUPABASE_URL');
 
   static const String supabaseAnonKey = String.fromEnvironment(
     'SUPABASE_ANON_KEY',
-    defaultValue: 'INSERT_ANON_KEY_HERE',
   );
 
   static const String supabasePersistSessionKey =
@@ -20,5 +16,7 @@ class SupabaseConfig {
   static bool get isValid =>
       supabaseUrl.isNotEmpty &&
       supabaseAnonKey.isNotEmpty &&
+      supabaseUrl !=
+          'https://placeholder.supabase.co' && // Ensure real values are used
       supabaseAnonKey != 'INSERT_ANON_KEY_HERE';
 }

--- a/lib/core/platform/logger_init.dart
+++ b/lib/core/platform/logger_init.dart
@@ -1,0 +1,1 @@
+export 'logger_init_stub.dart' if (dart.library.io) 'logger_init_io.dart';

--- a/lib/core/platform/logger_init_io.dart
+++ b/lib/core/platform/logger_init_io.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+
+File? _startupLogFile;
+
+Future<void> initFileLogger() async {
+  try {
+    final dir = await getApplicationDocumentsDirectory();
+    _startupLogFile = File('${dir.path}/startup.log');
+  } catch (_) {}
+}
+
+Future<void> writeStartupLog(String message) async {
+  try {
+    final file = _startupLogFile;
+    if (file != null) {
+      final timestamp = DateTime.now().toIso8601String();
+      await file.writeAsString('$timestamp $message\n', mode: FileMode.append);
+    }
+  } catch (_) {}
+}

--- a/lib/core/platform/logger_init_stub.dart
+++ b/lib/core/platform/logger_init_stub.dart
@@ -1,0 +1,2 @@
+Future<void> initFileLogger() async {}
+Future<void> writeStartupLog(String message) async {}

--- a/lib/core/platform/platform_init.dart
+++ b/lib/core/platform/platform_init.dart
@@ -1,0 +1,2 @@
+export 'platform_init_stub.dart'
+    if (dart.library.io) 'platform_init_windows.dart';

--- a/lib/core/platform/platform_init_stub.dart
+++ b/lib/core/platform/platform_init_stub.dart
@@ -1,0 +1,6 @@
+import 'dart:async';
+
+/// Platform-specific initialization.
+Future<void> initPlatform(List<String> args) async {
+  // Default implementation does nothing
+}

--- a/lib/core/platform/platform_init_windows.dart
+++ b/lib/core/platform/platform_init_windows.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+import 'package:windows_single_instance/windows_single_instance.dart';
+import 'package:expense_tracker/core/di/service_locator.dart';
+import 'package:expense_tracker/features/deep_link/presentation/bloc/deep_link_bloc.dart';
+import 'package:expense_tracker/core/utils/logger.dart';
+
+Future<void> initPlatform(List<String> args) async {
+  if (Platform.isWindows) {
+    await WindowsSingleInstance.ensureSingleInstance(
+      args,
+      "io.supabase.expensetracker",
+      onSecondWindow: (args) {
+        log.info("Second instance detected with args: $args");
+        if (sl.isRegistered<DeepLinkBloc>()) {
+          sl<DeepLinkBloc>().add(DeepLinkStarted(args: args));
+        }
+      },
+    );
+  }
+}

--- a/lib/core/services/demo_mode_service.dart
+++ b/lib/core/services/demo_mode_service.dart
@@ -5,6 +5,8 @@ import 'package:expense_tracker/features/expenses/data/models/expense_model.dart
 import 'package:expense_tracker/features/goals/data/models/goal_contribution_model.dart';
 import 'package:expense_tracker/features/goals/data/models/goal_model.dart';
 import 'package:expense_tracker/features/income/data/models/income_model.dart';
+import 'package:expense_tracker/features/recurring_transactions/data/models/recurring_rule_model.dart';
+import 'package:expense_tracker/features/recurring_transactions/data/models/recurring_rule_audit_log_model.dart';
 import 'package:expense_tracker/main.dart'; // logger
 
 /// Manages the demo mode state and in-memory demo data.
@@ -18,6 +20,8 @@ class DemoModeService {
   List<BudgetModel> _demoBudgets = [];
   List<GoalModel> _demoGoals = [];
   List<GoalContributionModel> _demoContributions = [];
+  List<RecurringRuleModel> _demoRecurringRules = [];
+  List<RecurringRuleAuditLogModel> _demoAuditLogs = [];
 
   // Singleton pattern
   static final DemoModeService _instance = DemoModeService._internal();
@@ -35,6 +39,7 @@ class DemoModeService {
     _demoBudgets = List.from(DemoData.sampleBudgets);
     _demoGoals = List.from(DemoData.sampleGoals);
     _demoContributions = List.from(DemoData.sampleContributions);
+    _demoRecurringRules = List.from(DemoData.sampleRecurringRules);
     log.info("[DemoModeService] Sample data loaded into memory caches.");
   }
 
@@ -48,6 +53,8 @@ class DemoModeService {
     _demoBudgets = [];
     _demoGoals = [];
     _demoContributions = [];
+    _demoRecurringRules = [];
+    _demoAuditLogs = [];
   }
 
   // --- Expense Operations ---
@@ -174,4 +181,33 @@ class DemoModeService {
   Future<void> deleteDemoContributions(List<String> ids) async {
     _demoContributions.removeWhere((c) => ids.contains(c.id));
   }
+
+  // --- Recurring Rule Operations ---
+  Future<List<RecurringRuleModel>> getDemoRecurringRules() async =>
+      _demoRecurringRules;
+  Future<RecurringRuleModel?> getDemoRecurringRuleById(String id) async =>
+      _demoRecurringRules.where((r) => r.id == id).firstOrNull;
+  Future<void> addDemoRecurringRule(RecurringRuleModel rule) async {
+    _demoRecurringRules.add(rule);
+  }
+
+  Future<void> updateDemoRecurringRule(RecurringRuleModel rule) async {
+    final index = _demoRecurringRules.indexWhere((r) => r.id == rule.id);
+    if (index != -1) {
+      _demoRecurringRules[index] = rule;
+    }
+  }
+
+  Future<void> deleteDemoRecurringRule(String id) async {
+    _demoRecurringRules.removeWhere((r) => r.id == id);
+  }
+
+  // --- Audit Logs ---
+  Future<void> addDemoRecurringAuditLog(RecurringRuleAuditLogModel log) async {
+    _demoAuditLogs.add(log);
+  }
+
+  Future<List<RecurringRuleAuditLogModel>> getDemoRecurringAuditLogsForRule(
+    String ruleId,
+  ) async => _demoAuditLogs.where((l) => l.ruleId == ruleId).toList();
 }

--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -28,8 +28,9 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   Future<void> signInWithMagicLink({required String email}) async {
     await _client.auth.signInWithOtp(
       email: email,
-      emailRedirectTo:
-          kIsWeb ? null : 'io.supabase.expensetracker://login-callback',
+      emailRedirectTo: kIsWeb
+          ? null
+          : 'io.supabase.expensetracker://login-callback',
     );
   }
 

--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 abstract class AuthRemoteDataSource {
@@ -27,7 +28,8 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   Future<void> signInWithMagicLink({required String email}) async {
     await _client.auth.signInWithOtp(
       email: email,
-      emailRedirectTo: 'io.supabase.expensetracker://login-callback',
+      emailRedirectTo:
+          kIsWeb ? null : 'io.supabase.expensetracker://login-callback',
     );
   }
 

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -60,7 +60,7 @@ class _LoginPageState extends State<LoginPage>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Login')),
+      appBar: AppBar(title: const Text('Login / Sign Up')),
       body: BlocListener<AuthBloc, AuthState>(
         listener: (context, state) {
           if (state is AuthOtpSent) {
@@ -142,6 +142,28 @@ class _LoginPageState extends State<LoginPage>
           builder: (context, state) {
             final isLoading = state is AuthLoading;
             return ElevatedButton(
+              onPressed: () {
+                final input = _phoneController.text.trim();
+                if (input.isNotEmpty) {
+                  String cleanInput = input.replaceAll(RegExp(r'\D'), '');
+                  String finalPhone;
+
+                  if (input.startsWith('+')) {
+                    finalPhone = '+$cleanInput';
+                  } else {
+                    String countryDigits =
+                        _countryCode.replaceAll(RegExp(r'\D'), '');
+                    String localDigits =
+                        cleanInput.replaceFirst(RegExp(r'^0+'), '');
+                    finalPhone = '+$countryDigits$localDigits';
+                  }
+
+                  context.read<AuthBloc>().add(
+                    AuthLoginRequested(finalPhone),
+                  );
+                }
+              },
+              child: const Text('Send OTP'),
               onPressed: isLoading ? null : _submitPhone,
               child: isLoading
                   ? SizedBox(

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -139,44 +139,46 @@ class _LoginPageState extends State<LoginPage>
         ),
         const SizedBox(height: 16),
         BlocBuilder<AuthBloc, AuthState>(
-          builder: (context, state) {
-            final isLoading = state is AuthLoading;
-            return ElevatedButton(
-              onPressed: () {
-                final input = _phoneController.text.trim();
-                if (input.isNotEmpty) {
-                  String cleanInput = input.replaceAll(RegExp(r'\D'), '');
-                  String finalPhone;
+          builder: (context, state) => ElevatedButton(
+            onPressed: state is AuthLoading
+                ? null
+                : () {
+                    final input = _phoneController.text.trim();
+                    if (input.isNotEmpty) {
+                      String cleanInput = input.replaceAll(RegExp(r'\D'), '');
+                      String finalPhone;
 
-                  if (input.startsWith('+')) {
-                    finalPhone = '+$cleanInput';
-                  } else {
-                    String countryDigits =
-                        _countryCode.replaceAll(RegExp(r'\D'), '');
-                    String localDigits =
-                        cleanInput.replaceFirst(RegExp(r'^0+'), '');
-                    finalPhone = '+$countryDigits$localDigits';
-                  }
+                      if (input.startsWith('+')) {
+                        finalPhone = '+$cleanInput';
+                      } else {
+                        String countryDigits = _countryCode.replaceAll(
+                          RegExp(r'\D'),
+                          '',
+                        );
+                        String localDigits = cleanInput.replaceFirst(
+                          RegExp(r'^0+'),
+                          '',
+                        );
+                        finalPhone = '+$countryDigits$localDigits';
+                      }
 
-                  context.read<AuthBloc>().add(
-                    AuthLoginRequested(finalPhone),
-                  );
-                }
-              },
-              child: const Text('Send OTP'),
-              onPressed: isLoading ? null : _submitPhone,
-              child: isLoading
-                  ? SizedBox(
-                      height: 20,
-                      width: 20,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: Theme.of(context).colorScheme.onPrimary,
-                      ),
-                    )
-                  : const Text('Send OTP'),
-            );
-          },
+                      context.read<AuthBloc>().add(
+                        AuthLoginRequested(finalPhone),
+                      );
+                      TextInput.finishAutofillContext(shouldSave: true);
+                    }
+                  },
+            child: state is AuthLoading
+                ? SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                  )
+                : const Text('Send OTP'),
+          ),
         ),
       ],
     );

--- a/lib/features/budgets/presentation/widgets/budget_form.dart
+++ b/lib/features/budgets/presentation/widgets/budget_form.dart
@@ -102,7 +102,7 @@ class _BudgetFormState extends State<BudgetForm> {
         if (isStartDate) {
           _selectedStartDate = DateTime(picked.year, picked.month, picked.day);
           if (_selectedEndDate != null &&
-                      _selectedStartDate != null &&
+              _selectedStartDate != null &&
               _selectedEndDate!.isBefore(_selectedStartDate!)) {
             _selectedEndDate = _selectedStartDate;
           }
@@ -116,7 +116,7 @@ class _BudgetFormState extends State<BudgetForm> {
             59,
           );
           if (_selectedStartDate != null &&
-                      _selectedEndDate != null &&
+              _selectedEndDate != null &&
               _selectedStartDate!.isAfter(_selectedEndDate!)) {
             _selectedStartDate = _selectedEndDate;
           }

--- a/lib/features/deep_link/presentation/bloc/deep_link_event.dart
+++ b/lib/features/deep_link/presentation/bloc/deep_link_event.dart
@@ -8,7 +8,11 @@ abstract class DeepLinkEvent extends Equatable {
 }
 
 class DeepLinkStarted extends DeepLinkEvent {
-  const DeepLinkStarted();
+  final List<String> args;
+  const DeepLinkStarted({this.args = const []});
+
+  @override
+  List<Object?> get props => [args];
 }
 
 class DeepLinkReceived extends DeepLinkEvent {

--- a/lib/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source_proxy.dart
+++ b/lib/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source_proxy.dart
@@ -1,0 +1,94 @@
+import 'package:expense_tracker/core/services/demo_mode_service.dart';
+import 'package:expense_tracker/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source.dart';
+import 'package:expense_tracker/features/recurring_transactions/data/models/recurring_rule_audit_log_model.dart';
+import 'package:expense_tracker/features/recurring_transactions/data/models/recurring_rule_model.dart';
+import 'package:expense_tracker/main.dart'; // logger
+
+class DemoAwareRecurringTransactionDataSource
+    implements RecurringTransactionLocalDataSource {
+  final RecurringTransactionLocalDataSource hiveDataSource;
+  final DemoModeService demoModeService;
+
+  DemoAwareRecurringTransactionDataSource({
+    required this.hiveDataSource,
+    required this.demoModeService,
+  });
+
+  @override
+  Future<void> addRecurringRule(RecurringRuleModel rule) async {
+    if (demoModeService.isDemoActive) {
+      log.fine("[DemoAwareRecurringDS] Adding demo rule: ${rule.description}");
+      return demoModeService.addDemoRecurringRule(rule);
+    } else {
+      return hiveDataSource.addRecurringRule(rule);
+    }
+  }
+
+  @override
+  Future<List<RecurringRuleModel>> getRecurringRules() async {
+    if (demoModeService.isDemoActive) {
+      log.fine("[DemoAwareRecurringDS] Getting demo rules.");
+      return demoModeService.getDemoRecurringRules();
+    } else {
+      return hiveDataSource.getRecurringRules();
+    }
+  }
+
+  @override
+  Future<RecurringRuleModel> getRecurringRuleById(String id) async {
+    if (demoModeService.isDemoActive) {
+      log.fine("[DemoAwareRecurringDS] Getting demo rule ID: $id");
+      final rule = await demoModeService.getDemoRecurringRuleById(id);
+      if (rule != null) {
+        return rule;
+      }
+      throw Exception('Demo recurring rule not found');
+    } else {
+      return hiveDataSource.getRecurringRuleById(id);
+    }
+  }
+
+  @override
+  Future<void> updateRecurringRule(RecurringRuleModel rule) async {
+    if (demoModeService.isDemoActive) {
+      log.fine(
+        "[DemoAwareRecurringDS] Updating demo rule: ${rule.description}",
+      );
+      return demoModeService.updateDemoRecurringRule(rule);
+    } else {
+      return hiveDataSource.updateRecurringRule(rule);
+    }
+  }
+
+  @override
+  Future<void> deleteRecurringRule(String id) async {
+    if (demoModeService.isDemoActive) {
+      log.fine("[DemoAwareRecurringDS] Deleting demo rule ID: $id");
+      return demoModeService.deleteDemoRecurringRule(id);
+    } else {
+      return hiveDataSource.deleteRecurringRule(id);
+    }
+  }
+
+  @override
+  Future<void> addAuditLog(RecurringRuleAuditLogModel log) async {
+    if (demoModeService.isDemoActive) {
+      // For demo mode, we can just store logs in memory or ignore them
+      // Storing in memory is better for completeness
+      return demoModeService.addDemoRecurringAuditLog(log);
+    } else {
+      return hiveDataSource.addAuditLog(log);
+    }
+  }
+
+  @override
+  Future<List<RecurringRuleAuditLogModel>> getAuditLogsForRule(
+    String ruleId,
+  ) async {
+    if (demoModeService.isDemoActive) {
+      return demoModeService.getDemoRecurringAuditLogsForRule(ruleId);
+    } else {
+      return hiveDataSource.getAuditLogsForRule(ruleId);
+    }
+  }
+}

--- a/lib/features/settings/presentation/bloc/settings_bloc.dart
+++ b/lib/features/settings/presentation/bloc/settings_bloc.dart
@@ -1,138 +1,116 @@
-// lib/features/settings/presentation/bloc/settings_bloc.dart
-import 'dart:async';
-import 'package:bloc/bloc.dart';
-import 'package:dartz/dartz.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
-import 'package:expense_tracker/core/error/failure.dart';
-import 'package:expense_tracker/features/settings/domain/repositories/settings_repository.dart';
 import 'package:expense_tracker/features/settings/domain/usecases/toggle_app_lock.dart';
-import 'package:expense_tracker/core/di/service_locator.dart';
-import 'package:expense_tracker/core/events/data_change_event.dart';
-import 'package:expense_tracker/core/theme/app_theme.dart';
+import 'package:expense_tracker/features/settings/domain/repositories/settings_repository.dart';
 import 'package:flutter/material.dart';
-import 'package:package_info_plus/package_info_plus.dart';
-import 'package:expense_tracker/main.dart';
+import 'package:expense_tracker/core/theme/app_theme.dart';
 import 'package:expense_tracker/core/data/countries.dart';
 import 'package:expense_tracker/core/constants/app_constants.dart';
+import 'package:expense_tracker/core/utils/logger.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:expense_tracker/core/services/demo_mode_service.dart';
+import 'package:expense_tracker/core/di/service_locator.dart'; // For publishDataChangedEvent
+import 'package:expense_tracker/core/events/data_change_event.dart';
 
 part 'settings_event.dart';
 part 'settings_state.dart';
 
+// Type alias for ValueGetter if not imported
+typedef ValueGetter<T> = T Function();
+
 class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   final SettingsRepository _settingsRepository;
-  final DemoModeService _demoModeService;
   final ToggleAppLockUseCase _toggleAppLockUseCase;
+  final DemoModeService _demoModeService;
 
   SettingsBloc({
     required SettingsRepository settingsRepository,
-    required DemoModeService demoModeService,
     required ToggleAppLockUseCase toggleAppLockUseCase,
+    required DemoModeService demoModeService,
   }) : _settingsRepository = settingsRepository,
-       _demoModeService = demoModeService,
        _toggleAppLockUseCase = toggleAppLockUseCase,
-       super(
-         SettingsState(
-           isInDemoMode: demoModeService.isDemoActive,
-           setupSkipped: false, // Ensure skip starts false
-         ),
-       ) {
+       _demoModeService = demoModeService,
+       super(const SettingsState()) {
     on<LoadSettings>(_onLoadSettings);
     on<UpdateTheme>(_onUpdateTheme);
     on<UpdatePaletteIdentifier>(_onUpdatePaletteIdentifier);
     on<UpdateUIMode>(_onUpdateUIMode);
     on<UpdateCountry>(_onUpdateCountry);
     on<UpdateAppLock>(_onUpdateAppLock);
+    on<ClearSettingsMessage>(_onClearMessage);
     on<EnterDemoMode>(_onEnterDemoMode);
     on<ExitDemoMode>(_onExitDemoMode);
-    on<SkipSetup>(_onSkipSetup); // ADDED Handler
-    on<ResetSkipSetupFlag>(_onResetSkipSetupFlag); // ADDED Handler
-    on<ClearSettingsMessage>(_onClearMessage);
-
-    log.info("[SettingsBloc] Initialized.");
+    on<SkipSetup>(_onSkipSetup);
   }
 
-  // --- Skip Setup Handlers --- ADDED
   void _onSkipSetup(SkipSetup event, Emitter<SettingsState> emit) {
-    log.info("[SettingsBloc] Setup skipped flag set.");
+    log.info("[SettingsBloc] Skipping setup (marking as completed).");
     emit(state.copyWith(setupSkipped: true));
   }
-
-  void _onResetSkipSetupFlag(
-    ResetSkipSetupFlag event,
-    Emitter<SettingsState> emit,
-  ) {
-    if (state.setupSkipped) {
-      log.info("[SettingsBloc] Resetting setup skipped flag.");
-      emit(state.copyWith(setupSkipped: false));
-    }
-  }
-  // --- END ADDED ---
 
   Future<void> _onLoadSettings(
     LoadSettings event,
     Emitter<SettingsState> emit,
   ) async {
-    log.info("[SettingsBloc] Received LoadSettings event.");
     emit(
       state.copyWith(
         status: SettingsStatus.loading,
         packageInfoStatus: PackageInfoStatus.loading,
         clearAllMessages: true,
-        // Ensure flags are reset on a full load (e.g., app start)
-        isInDemoMode: false,
-        setupSkipped: false,
       ),
     );
-    // ... (rest of loading logic unchanged) ...
-    PackageInfo? packageInfo;
-    String? packageInfoLoadError;
     try {
-      packageInfo = await PackageInfo.fromPlatform();
-    } catch (e, s) {
-      packageInfoLoadError = 'Failed to load app version.';
-      log.severe("[SettingsBloc] Failed to load PackageInfo$e$s");
-    }
+      log.info("[SettingsBloc] Loading settings and package info...");
 
-    ThemeMode loadedThemeMode = SettingsState.defaultThemeMode;
-    String loadedPaletteIdentifier = SettingsState.defaultPaletteIdentifier;
-    UIMode loadedUIMode = SettingsState.defaultUIMode;
-    String loadedCountryCode = SettingsState.defaultCountryCode;
-    bool loadedLock = SettingsState.defaultAppLockEnabled;
-    String? settingsLoadError;
+      // Load Package Info
+      PackageInfo? packageInfo;
+      String? packageInfoLoadError;
+      try {
+        packageInfo = await PackageInfo.fromPlatform();
+      } catch (e) {
+        log.warning("[SettingsBloc] Failed to load package info: $e");
+        packageInfoLoadError = "Failed to load app version";
+      }
 
-    try {
-      final results = await Future.wait([
-        _settingsRepository.getThemeMode(),
-        _settingsRepository.getPaletteIdentifier(),
-        _settingsRepository.getUIMode(),
-        _settingsRepository.getSelectedCountryCode(),
-        _settingsRepository.getAppLockEnabled(),
-      ]);
+      // Load Settings individually
+      ThemeMode loadedThemeMode = SettingsState.defaultThemeMode;
+      String loadedPaletteIdentifier = SettingsState.defaultPaletteIdentifier;
+      UIMode loadedUIMode = SettingsState.defaultUIMode;
+      String loadedCountryCode = SettingsState.defaultCountryCode;
+      bool loadedLock = SettingsState.defaultAppLockEnabled;
+      String? settingsLoadError;
 
-      final themeModeResult = results[0] as Either<Failure, ThemeMode>;
-      final paletteIdResult = results[1] as Either<Failure, String>;
-      final uiModeResult = results[2] as Either<Failure, UIMode>;
-      final countryResult = results[3] as Either<Failure, String?>;
-      final appLockResult = results[4] as Either<Failure, bool>;
-
-      themeModeResult.fold(
+      // Theme
+      final themeResult = await _settingsRepository.getThemeMode();
+      themeResult.fold(
         (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
         (mode) => loadedThemeMode = mode,
       );
-      paletteIdResult.fold(
+
+      // Palette
+      final paletteResult = await _settingsRepository.getPaletteIdentifier();
+      paletteResult.fold(
         (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
         (id) => loadedPaletteIdentifier = id,
       );
-      uiModeResult.fold(
+
+      // UI Mode
+      final uiResult = await _settingsRepository.getUIMode();
+      uiResult.fold(
         (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
         (mode) => loadedUIMode = mode,
       );
+
+      // Country
+      final countryResult = await _settingsRepository.getSelectedCountryCode();
       countryResult.fold(
         (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
         (code) => loadedCountryCode = code ?? SettingsState.defaultCountryCode,
       );
-      appLockResult.fold(
+
+      // App Lock
+      final lockResult = await _settingsRepository.getAppLockEnabled();
+      lockResult.fold(
         (f) => settingsLoadError = _appendError(settingsLoadError, f.message),
         (enabled) => loadedLock = enabled,
       );
@@ -155,9 +133,8 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
           appVersion: () => packageInfo != null
               ? '${packageInfo.version}+${packageInfo.buildNumber}'
               : null,
-          // Ensure isInDemoMode stays false after loading real settings
           isInDemoMode: false,
-          setupSkipped: false, // Ensure skip flag is reset on full load
+          setupSkipped: false,
         ),
       );
       log.info("[SettingsBloc] Emitted final loaded/error state.");
@@ -175,8 +152,8 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
               state.packageInfoStatus == PackageInfoStatus.loading
               ? 'Failed due to main settings error'
               : state.packageInfoError,
-          isInDemoMode: false, // Ensure demo mode is off on error too
-          setupSkipped: false, // Ensure skip flag is reset on error too
+          isInDemoMode: false,
+          setupSkipped: false,
         ),
       );
     }
@@ -188,7 +165,6 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
         : '$currentError\n$newMessage';
   }
 
-  // --- Other Event Handlers (Unchanged but added demo checks) ---
   Future<void> _onUpdateTheme(
     UpdateTheme event,
     Emitter<SettingsState> emit,
@@ -197,7 +173,6 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       log.warning("[SettingsBloc] Ignoring UpdateTheme in Demo Mode.");
       return;
     }
-    // ... rest of handler
     log.info(
       "[SettingsBloc] Received UpdateTheme event: ${event.newMode.name}",
     );
@@ -238,7 +213,6 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       );
       return;
     }
-    // ... rest of handler
     log.info(
       "[SettingsBloc] Received UpdatePaletteIdentifier event: ${event.newIdentifier}",
     );
@@ -285,7 +259,6 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       log.warning("[SettingsBloc] Ignoring UpdateUIMode in Demo Mode.");
       return;
     }
-    // ... rest of handler
     log.info(
       "[SettingsBloc] Received UpdateUIMode event: ${event.newMode.name}",
     );
@@ -321,14 +294,12 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
             break;
         }
         log.info("[SettingsBloc] Saving default palette: $defaultPalette");
-        _settingsRepository.savePaletteIdentifier(
-          defaultPalette,
-        ); // Fire and forget is ok here
+        _settingsRepository.savePaletteIdentifier(defaultPalette);
 
         emit(
           state.copyWith(
             uiMode: event.newMode,
-            paletteIdentifier: defaultPalette, // Update palette in state too
+            paletteIdentifier: defaultPalette,
             status: SettingsStatus.loaded,
             clearAllMessages: true,
           ),
@@ -345,12 +316,6 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     UpdateCountry event,
     Emitter<SettingsState> emit,
   ) async {
-    // Currency *can* be changed before entering demo
-    // if (_demoModeService.isDemoActive) {
-    //   log.warning("[SettingsBloc] Ignoring UpdateCountry in Demo Mode.");
-    //   return;
-    // }
-    // ... rest of handler
     log.info(
       "[SettingsBloc] Received UpdateCountry event: ${event.newCountryCode}",
     );
@@ -426,25 +391,20 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     );
   }
 
-  // --- Demo Mode Handlers ---
   void _onEnterDemoMode(EnterDemoMode event, Emitter<SettingsState> emit) {
     log.info("[SettingsBloc] Entering Demo Mode.");
     _demoModeService.enterDemoMode();
-    emit(
-      state.copyWith(isInDemoMode: true, setupSkipped: false),
-    ); // Entering demo clears skip flag
+    emit(state.copyWith(isInDemoMode: true, setupSkipped: false));
     publishDataChangedEvent(
       type: DataChangeType.system,
-      reason: DataChangeReason.updated,
+      reason: DataChangeReason.reset,
     );
   }
 
   void _onExitDemoMode(ExitDemoMode event, Emitter<SettingsState> emit) {
     log.info("[SettingsBloc] Exiting Demo Mode.");
     _demoModeService.exitDemoMode();
-    emit(
-      state.copyWith(isInDemoMode: false, setupSkipped: false),
-    ); // Exiting demo clears skip flag
+    emit(state.copyWith(isInDemoMode: false, setupSkipped: false));
     publishDataChangedEvent(
       type: DataChangeType.system,
       reason: DataChangeReason.reset,

--- a/lib/features/transactions/presentation/bloc/transaction_list_bloc.dart
+++ b/lib/features/transactions/presentation/bloc/transaction_list_bloc.dart
@@ -286,7 +286,8 @@ class TransactionListBloc
     emit(
       state.copyWith(
         searchTerm: event.searchTerm,
-        clearSearchTerm: event.searchTerm == null ||
+        clearSearchTerm:
+            event.searchTerm == null ||
             (event.searchTerm != null && event.searchTerm!.isEmpty),
         isInBatchEditMode: false,
         selectedTransactionIds: {},

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -937,10 +937,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1470,26 +1470,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.11"
   timing:
     dependency: transitive
     description:
@@ -1674,6 +1674,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  windows_single_instance:
+    dependency: "direct main"
+    description:
+      name: windows_single_instance
+      sha256: "27ac7ef70a2930a42431d94263941c76884036f797c6d749d1ce5d9d386e66d9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: expense_tracker
-description: A basic expense tracking application.
+description: Financial OS - Advanced Expense Tracking & Financial Management
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
@@ -71,6 +71,7 @@ dependencies:
   image_picker: ^1.2.1
   country_code_picker: ^3.4.1
   rxdart: ^0.28.0
+  windows_single_instance: ^1.1.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/core/constants/app_constants_test.dart
+++ b/test/core/constants/app_constants_test.dart
@@ -3,6 +3,6 @@ import 'package:expense_tracker/core/constants/app_constants.dart';
 
 void main() {
   test('AppConstants values are correct', () {
-    expect(AppConstants.appName, 'Spend Savvy');
+    expect(AppConstants.appName, 'Financial OS');
   });
 }

--- a/test/core/data/countries_test.dart
+++ b/test/core/data/countries_test.dart
@@ -5,23 +5,30 @@ void main() {
   group('AppCountries', () {
     test('defaultCountry is US', () {
       expect(AppCountries.defaultCountry.code, 'US');
-      expect(AppCountries.defaultCountry.currencySymbol, '\$');
+      expect(AppCountries.defaultCountry.currencySymbol, r'$');
     });
 
     test('getCurrencyForCountry returns correct symbol', () {
-      expect(AppCountries.getCurrencyForCountry('US'), '\$');
+      expect(AppCountries.getCurrencyForCountry('US'), r'$');
       expect(AppCountries.getCurrencyForCountry('GB'), '£');
       expect(AppCountries.getCurrencyForCountry('EU'), '€');
       expect(AppCountries.getCurrencyForCountry('IN'), '₹');
       expect(AppCountries.getCurrencyForCountry('JP'), '¥');
     });
 
+    test('getCurrencyCodeForCountry returns correct code', () {
+      expect(AppCountries.getCurrencyCodeForCountry('US'), 'USD');
+      expect(AppCountries.getCurrencyCodeForCountry('GB'), 'GBP');
+      expect(AppCountries.getCurrencyCodeForCountry('EU'), 'EUR');
+      expect(AppCountries.getCurrencyCodeForCountry('IN'), 'INR');
+    });
+
     test('getCurrencyForCountry returns default for null', () {
-      expect(AppCountries.getCurrencyForCountry(null), '\$');
+      expect(AppCountries.getCurrencyForCountry(null), r'$');
     });
 
     test('getCurrencyForCountry returns default for unknown code', () {
-      expect(AppCountries.getCurrencyForCountry('XX'), '\$');
+      expect(AppCountries.getCurrencyForCountry('XX'), r'$');
     });
 
     test('findCountryByCode returns correct country', () {
@@ -46,17 +53,20 @@ void main() {
       const country1 = AppCountry(
         code: 'US',
         name: 'United States',
-        currencySymbol: '\$',
+        currencySymbol: r'$',
+        currencyCode: 'USD',
       );
       const country2 = AppCountry(
         code: 'US',
         name: 'United States',
-        currencySymbol: '\$',
+        currencySymbol: r'$',
+        currencyCode: 'USD',
       );
       const country3 = AppCountry(
         code: 'GB',
         name: 'United Kingdom',
         currencySymbol: '£',
+        currencyCode: 'GBP',
       );
 
       expect(country1, equals(country2));
@@ -67,12 +77,14 @@ void main() {
       const country1 = AppCountry(
         code: 'US',
         name: 'United States',
-        currencySymbol: '\$',
+        currencySymbol: r'$',
+        currencyCode: 'USD',
       );
       const country2 = AppCountry(
         code: 'US',
         name: 'United States',
-        currencySymbol: '\$',
+        currencySymbol: r'$',
+        currencyCode: 'USD',
       );
 
       expect(country1.hashCode, equals(country2.hashCode));

--- a/test/features/auth/presentation/pages/login_page_test.dart
+++ b/test/features/auth/presentation/pages/login_page_test.dart
@@ -1,5 +1,5 @@
-import 'package:bloc_test/bloc_test.dart';
 import 'package:expense_tracker/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:bloc_test/bloc_test.dart';
 import 'package:expense_tracker/features/auth/presentation/bloc/auth_event.dart';
 import 'package:expense_tracker/features/auth/presentation/bloc/auth_state.dart';
 import 'package:expense_tracker/features/auth/presentation/pages/login_page.dart';
@@ -9,10 +9,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockAuthBloc extends MockBloc<AuthEvent, AuthState> implements AuthBloc {}
+// Mock AuthBloc
+class MockAuthBloc extends Mock implements AuthBloc {}
 
 void main() {
   late MockAuthBloc mockAuthBloc;
 
+  setUp(() {
+    mockAuthBloc = MockAuthBloc();
+    when(() => mockAuthBloc.state).thenReturn(AuthInitial());
+    when(() => mockAuthBloc.stream).thenAnswer((_) => const Stream.empty());
   setUpAll(() {
     registerFallbackValue(const AuthLoginRequested(''));
     registerFallbackValue(const AuthLoginWithMagicLinkRequested(''));
@@ -56,6 +62,33 @@ void main() {
             contains('1234567890'),
           ),
         ),
+  testWidgets('LoginPage renders correctly', (tester) async {
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.text('Login / Sign Up'), findsOneWidget);
+    expect(find.text('Phone'), findsOneWidget);
+    expect(find.text('Email'), findsOneWidget);
+    expect(find.text('Send OTP'), findsOneWidget);
+  });
+
+  testWidgets('Sending OTP with local number formats correctly', (tester) async {
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pumpAndSettle(); // Wait for CountryCodePicker?
+
+    // Assuming default Country Code is +91 (from source)
+    // Find phone text field. It's the one under Phone tab.
+    // There are two text fields (one for email too, but it's hidden or in another tab).
+    // By default Phone tab is active.
+
+    // Enter local number
+    await tester.enterText(find.byType(TextField).first, '1234567890');
+    await tester.tap(find.text('Send OTP'));
+    await tester.pump();
+
+    // Verify AuthLoginRequested with +911234567890
+    verify(
+      () => mockAuthBloc.add(
+        const AuthLoginRequested('+911234567890'),
       ),
     ).called(1);
   });
@@ -79,6 +112,19 @@ void main() {
             'test@example.com',
           ),
         ),
+  testWidgets('Sending OTP with leading + uses input as is', (tester) async {
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pumpAndSettle();
+
+    // Enter number with + code
+    await tester.enterText(find.byType(TextField).first, '+15551234567');
+    await tester.tap(find.text('Send OTP'));
+    await tester.pump();
+
+    // Verify uses input
+    verify(
+      () => mockAuthBloc.add(
+        const AuthLoginRequested('+15551234567'),
       ),
     ).called(1);
   });
@@ -95,5 +141,20 @@ void main() {
       find.text('Send OTP'),
       findsNothing,
     ); // Button text replaced by spinner
+  testWidgets('Sending OTP strips leading zero from local number', (tester) async {
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pumpAndSettle();
+
+    // Enter number with leading 0
+    await tester.enterText(find.byType(TextField).first, '09876543210');
+    await tester.tap(find.text('Send OTP'));
+    await tester.pump();
+
+    // Verify +919876543210 (strips 0)
+    verify(
+      () => mockAuthBloc.add(
+        const AuthLoginRequested('+919876543210'),
+      ),
+    ).called(1);
   });
 }

--- a/test/features/auth/presentation/pages/login_page_test.dart
+++ b/test/features/auth/presentation/pages/login_page_test.dart
@@ -9,16 +9,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockAuthBloc extends MockBloc<AuthEvent, AuthState> implements AuthBloc {}
-// Mock AuthBloc
-class MockAuthBloc extends Mock implements AuthBloc {}
 
 void main() {
   late MockAuthBloc mockAuthBloc;
 
-  setUp(() {
-    mockAuthBloc = MockAuthBloc();
-    when(() => mockAuthBloc.state).thenReturn(AuthInitial());
-    when(() => mockAuthBloc.stream).thenAnswer((_) => const Stream.empty());
   setUpAll(() {
     registerFallbackValue(const AuthLoginRequested(''));
     registerFallbackValue(const AuthLoginWithMagicLinkRequested(''));
@@ -27,6 +21,7 @@ void main() {
   setUp(() {
     mockAuthBloc = MockAuthBloc();
     when(() => mockAuthBloc.state).thenReturn(AuthInitial());
+    when(() => mockAuthBloc.stream).thenAnswer((_) => const Stream.empty());
   });
 
   Widget createWidgetUnderTest() {
@@ -38,123 +33,113 @@ void main() {
     );
   }
 
-  testWidgets('renders login page with tabs', (tester) async {
-    await tester.pumpWidget(createWidgetUnderTest());
-    expect(find.text('Login'), findsOneWidget);
-    expect(find.text('Phone'), findsOneWidget);
-    expect(find.text('Email'), findsOneWidget);
-  });
+  group('LoginPage', () {
+    testWidgets('renders login page with tabs and correct initial state', (
+      tester,
+    ) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+      expect(find.text('Login / Sign Up'), findsOneWidget);
+      expect(find.text('Phone'), findsOneWidget);
+      expect(find.text('Email'), findsOneWidget);
+      expect(find.text('Send OTP'), findsOneWidget);
+    });
 
-  testWidgets('submits phone login', (tester) async {
-    await tester.pumpWidget(createWidgetUnderTest());
-    // Find phone text field (first one usually or by label)
-    final phoneField = find.widgetWithText(TextField, 'Phone Number');
-    await tester.enterText(phoneField, '1234567890');
-    await tester.tap(find.text('Send OTP'));
-    await tester.pump();
+    testWidgets('switches between phone and email tabs', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
 
-    verify(
-      () => mockAuthBloc.add(
-        any(
-          that: isA<AuthLoginRequested>().having(
-            (e) => e.phone,
-            'phone',
-            contains('1234567890'),
-          ),
+      // Initially in Phone tab
+      expect(find.text('Phone Number'), findsOneWidget);
+      expect(find.text('Email Address'), findsNothing);
+
+      // Switch to Email tab
+      await tester.tap(find.text('Email'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Phone Number'), findsNothing);
+      expect(find.text('Email Address'), findsOneWidget);
+    });
+
+    group('Phone Login Formatting', () {
+      testWidgets('submits with default country code (+91)', (tester) async {
+        await tester.pumpWidget(createWidgetUnderTest());
+
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Phone Number'),
+          '1234567890',
+        );
+        await tester.tap(find.text('Send OTP'));
+        await tester.pump();
+
+        verify(
+          () => mockAuthBloc.add(const AuthLoginRequested('+911234567890')),
+        ).called(1);
+      });
+
+      testWidgets('strips leading zero from local number', (tester) async {
+        await tester.pumpWidget(createWidgetUnderTest());
+
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Phone Number'),
+          '09876543210',
+        );
+        await tester.tap(find.text('Send OTP'));
+        await tester.pump();
+
+        verify(
+          () => mockAuthBloc.add(const AuthLoginRequested('+919876543210')),
+        ).called(1);
+      });
+
+      testWidgets('uses manual plus code (+1) correctly', (tester) async {
+        await tester.pumpWidget(createWidgetUnderTest());
+
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Phone Number'),
+          '+15551234567',
+        );
+        await tester.tap(find.text('Send OTP'));
+        await tester.pump();
+
+        verify(
+          () => mockAuthBloc.add(const AuthLoginRequested('+15551234567')),
+        ).called(1);
+      });
+    });
+
+    testWidgets('submits email login', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.tap(find.text('Email'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Email Address'),
+        'test@example.com',
+      );
+      await tester.tap(find.text('Send Magic Link'));
+      await tester.pump();
+
+      verify(
+        () => mockAuthBloc.add(
+          const AuthLoginWithMagicLinkRequested('test@example.com'),
         ),
-  testWidgets('LoginPage renders correctly', (tester) async {
-    await tester.pumpWidget(createWidgetUnderTest());
+      ).called(1);
+    });
 
-    expect(find.text('Login / Sign Up'), findsOneWidget);
-    expect(find.text('Phone'), findsOneWidget);
-    expect(find.text('Email'), findsOneWidget);
-    expect(find.text('Send OTP'), findsOneWidget);
-  });
+    testWidgets(
+      'shows loading indicator and disables buttons when state is AuthLoading',
+      (tester) async {
+        when(() => mockAuthBloc.state).thenReturn(AuthLoading());
+        await tester.pumpWidget(createWidgetUnderTest());
+        await tester.pump();
 
-  testWidgets('Sending OTP with local number formats correctly', (tester) async {
-    await tester.pumpWidget(createWidgetUnderTest());
-    await tester.pumpAndSettle(); // Wait for CountryCodePicker?
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.text('Send OTP'), findsNothing);
 
-    // Assuming default Country Code is +91 (from source)
-    // Find phone text field. It's the one under Phone tab.
-    // There are two text fields (one for email too, but it's hidden or in another tab).
-    // By default Phone tab is active.
-
-    // Enter local number
-    await tester.enterText(find.byType(TextField).first, '1234567890');
-    await tester.tap(find.text('Send OTP'));
-    await tester.pump();
-
-    // Verify AuthLoginRequested with +911234567890
-    verify(
-      () => mockAuthBloc.add(
-        const AuthLoginRequested('+911234567890'),
-      ),
-    ).called(1);
-  });
-
-  testWidgets('submits email login', (tester) async {
-    await tester.pumpWidget(createWidgetUnderTest());
-    await tester.tap(find.text('Email'));
-    await tester.pumpAndSettle();
-
-    final emailField = find.widgetWithText(TextField, 'Email Address');
-    await tester.enterText(emailField, 'test@example.com');
-    await tester.tap(find.text('Send Magic Link'));
-    await tester.pump();
-
-    verify(
-      () => mockAuthBloc.add(
-        any(
-          that: isA<AuthLoginWithMagicLinkRequested>().having(
-            (e) => e.email,
-            'email',
-            'test@example.com',
-          ),
-        ),
-  testWidgets('Sending OTP with leading + uses input as is', (tester) async {
-    await tester.pumpWidget(createWidgetUnderTest());
-    await tester.pumpAndSettle();
-
-    // Enter number with + code
-    await tester.enterText(find.byType(TextField).first, '+15551234567');
-    await tester.tap(find.text('Send OTP'));
-    await tester.pump();
-
-    // Verify uses input
-    verify(
-      () => mockAuthBloc.add(
-        const AuthLoginRequested('+15551234567'),
-      ),
-    ).called(1);
-  });
-
-  testWidgets('shows loading indicator when state is AuthLoading', (
-    tester,
-  ) async {
-    when(() => mockAuthBloc.state).thenReturn(AuthLoading());
-    await tester.pumpWidget(createWidgetUnderTest());
-    await tester.pump(); // Allow StreamBuilder/BlocBuilder to emit
-
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
-    expect(
-      find.text('Send OTP'),
-      findsNothing,
-    ); // Button text replaced by spinner
-  testWidgets('Sending OTP strips leading zero from local number', (tester) async {
-    await tester.pumpWidget(createWidgetUnderTest());
-    await tester.pumpAndSettle();
-
-    // Enter number with leading 0
-    await tester.enterText(find.byType(TextField).first, '09876543210');
-    await tester.tap(find.text('Send OTP'));
-    await tester.pump();
-
-    // Verify +919876543210 (strips 0)
-    verify(
-      () => mockAuthBloc.add(
-        const AuthLoginRequested('+919876543210'),
-      ),
-    ).called(1);
+        final button = tester.widget<ElevatedButton>(
+          find.byType(ElevatedButton),
+        );
+        expect(button.onPressed, isNull);
+      },
+    );
   });
 }

--- a/test/features/groups/presentation/pages/create_group_page_test.dart
+++ b/test/features/groups/presentation/pages/create_group_page_test.dart
@@ -1,134 +1,145 @@
 import 'package:bloc_test/bloc_test.dart';
-import 'package:expense_tracker/core/di/service_locator.dart';
-import 'package:supabase_flutter/supabase_flutter.dart' hide AuthState;
 import 'package:expense_tracker/features/auth/presentation/bloc/auth_bloc.dart';
-import 'package:expense_tracker/features/auth/presentation/bloc/auth_event.dart';
-import 'package:expense_tracker/features/auth/presentation/bloc/auth_state.dart';
-import 'package:expense_tracker/features/groups/domain/entities/group_entity.dart';
-import 'package:expense_tracker/features/groups/domain/entities/group_type.dart';
+import 'package:expense_tracker/features/auth/presentation/bloc/auth_state.dart' as app_auth_state;
+import 'package:expense_tracker/features/auth/presentation/bloc/auth_event.dart'; // Import AuthEvent
 import 'package:expense_tracker/features/groups/presentation/bloc/create_group/create_group_bloc.dart';
 import 'package:expense_tracker/features/groups/presentation/bloc/create_group/create_group_event.dart';
 import 'package:expense_tracker/features/groups/presentation/bloc/create_group/create_group_state.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_type.dart'; // Import GroupType
 import 'package:expense_tracker/features/groups/presentation/pages/create_group_page.dart';
+import 'package:expense_tracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart'; // For User
 
+// Mock AuthState using the app's state, not gotrue's
 class MockCreateGroupBloc extends MockBloc<CreateGroupEvent, CreateGroupState>
     implements CreateGroupBloc {}
 
-class MockAuthBloc extends MockBloc<AuthEvent, AuthState> implements AuthBloc {}
+class MockAuthBloc extends MockBloc<AuthEvent, app_auth_state.AuthState> implements AuthBloc {}
 
-class FakeCreateGroupEvent extends Fake implements CreateGroupEvent {}
+class MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
+    implements SettingsBloc {}
+
+class MockUser extends Mock implements User {
+  @override
+  String get id => 'test-user-id';
+}
 
 void main() {
   late MockCreateGroupBloc mockCreateGroupBloc;
   late MockAuthBloc mockAuthBloc;
+  late MockSettingsBloc mockSettingsBloc;
 
   setUpAll(() {
-    registerFallbackValue(FakeCreateGroupEvent());
+    registerFallbackValue(CreateGroupSubmitted(name: 'dummy', userId: 'dummy', type: GroupType.trip, currency: 'USD'));
   });
 
   setUp(() {
     mockCreateGroupBloc = MockCreateGroupBloc();
     mockAuthBloc = MockAuthBloc();
+    mockSettingsBloc = MockSettingsBloc();
 
-    if (sl.isRegistered<CreateGroupBloc>()) {
-      sl.unregister<CreateGroupBloc>();
-    }
+    final sl = GetIt.instance;
+    sl.reset();
     sl.registerFactory<CreateGroupBloc>(() => mockCreateGroupBloc);
   });
 
-  tearDown(() {
-    sl.reset();
-  });
-
-  Widget buildTestWidget() {
-    return MaterialApp(
-      home: BlocProvider<AuthBloc>.value(
-        value: mockAuthBloc,
-        child: const CreateGroupPage(),
-      ),
+  Widget createWidgetUnderTest() {
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<AuthBloc>(create: (_) => mockAuthBloc),
+        BlocProvider<SettingsBloc>(create: (_) => mockSettingsBloc),
+      ],
+      child: const MaterialApp(home: CreateGroupPage()),
     );
   }
 
-  final tUser = User(
-    id: 'usr1',
-    aud: 'authenticated',
-    createdAt: DateTime.now().toIso8601String(),
-    appMetadata: {},
-    userMetadata: {},
-  );
-
-  testWidgets('renders CreateGroupPage components', (tester) async {
+  testWidgets('renders correctly', (tester) async {
     when(() => mockCreateGroupBloc.state).thenReturn(CreateGroupInitial());
-    when(() => mockAuthBloc.state).thenReturn(AuthAuthenticated(tUser));
+    when(() => mockAuthBloc.state)
+        .thenReturn(app_auth_state.AuthAuthenticated(MockUser())); // Authenticated
+    when(() => mockSettingsBloc.state).thenReturn(const SettingsState());
 
-    await tester.pumpWidget(buildTestWidget());
+    await tester.pumpWidget(createWidgetUnderTest());
 
     expect(find.text('Create New Group'), findsOneWidget);
-    expect(find.byType(TextFormField), findsOneWidget);
-    expect(find.byType(DropdownButtonFormField<GroupType>), findsOneWidget);
-    expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
-    expect(find.byType(ElevatedButton), findsOneWidget);
+    expect(find.text('Group Name'), findsOneWidget);
+    expect(find.text('Group Type'), findsOneWidget);
+    expect(find.text('Currency'), findsOneWidget);
+    expect(find.text('Create Group'), findsOneWidget);
   });
 
-  testWidgets('shows validation error when form is empty', (tester) async {
+  testWidgets('initializes currency from settings', (tester) async {
     when(() => mockCreateGroupBloc.state).thenReturn(CreateGroupInitial());
-    when(() => mockAuthBloc.state).thenReturn(AuthAuthenticated(tUser));
+    when(() => mockAuthBloc.state).thenReturn(app_auth_state.AuthAuthenticated(MockUser()));
+    when(() => mockSettingsBloc.state).thenReturn(
+      const SettingsState(selectedCountryCode: 'GB'),
+    ); // UK -> GBP
 
-    await tester.pumpWidget(buildTestWidget());
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pumpAndSettle();
+
+    // Verify initial currency is GBP (UK)
+    final dropdownFinder = find.widgetWithText(
+      DropdownButtonFormField<String>,
+      'GBP',
+    );
+    expect(find.text('GBP (£)'), findsOneWidget);
+  });
+
+  testWidgets('shows error snackbar when not authenticated', (tester) async {
+    when(() => mockCreateGroupBloc.state).thenReturn(CreateGroupInitial());
+    when(() => mockAuthBloc.state).thenReturn(app_auth_state.AuthUnauthenticated());
+    when(() => mockSettingsBloc.state).thenReturn(const SettingsState());
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    await tester.enterText(find.byType(TextFormField), 'Test Group');
     await tester.tap(find.text('Create Group'));
     await tester.pump();
 
-    expect(find.text('Please enter a name'), findsOneWidget);
+    expect(
+      find.text('You must be logged in to create a group.'),
+      findsOneWidget,
+    );
     verifyNever(() => mockCreateGroupBloc.add(any()));
   });
 
-  testWidgets('submits form when valid', (tester) async {
-    when(() => mockCreateGroupBloc.state).thenReturn(CreateGroupInitial());
-    when(() => mockAuthBloc.state).thenReturn(AuthAuthenticated(tUser));
-
-    await tester.pumpWidget(buildTestWidget());
-
-    await tester.enterText(find.byType(TextFormField), 'My Vacation');
-    await tester.pump();
-
-    await tester.tap(find.text('Create Group'));
-    await tester.pump();
-
-    verify(
-      () => mockCreateGroupBloc.add(any(that: isA<CreateGroupSubmitted>())),
-    ).called(1);
-  });
-
-  testWidgets('shows loading indicator when state is CreateGroupLoading', (
+  testWidgets('adds CreateGroupSubmitted event when valid and authenticated', (
     tester,
   ) async {
-    when(() => mockCreateGroupBloc.state).thenReturn(CreateGroupLoading());
-    when(() => mockAuthBloc.state).thenReturn(AuthAuthenticated(tUser));
+    when(() => mockCreateGroupBloc.state).thenReturn(CreateGroupInitial());
+    when(() => mockAuthBloc.state).thenReturn(app_auth_state.AuthAuthenticated(MockUser()));
+    when(() => mockSettingsBloc.state).thenReturn(const SettingsState());
 
-    await tester.pumpWidget(buildTestWidget());
+    await tester.pumpWidget(createWidgetUnderTest());
 
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
-  });
-
-  testWidgets('shows SnackBar on failure', (tester) async {
-    whenListen(
-      mockCreateGroupBloc,
-      Stream.fromIterable([
-        CreateGroupInitial(),
-        const CreateGroupFailure('Error creating group'),
-      ]),
-      initialState: CreateGroupInitial(),
-    );
-    when(() => mockAuthBloc.state).thenReturn(AuthAuthenticated(tUser));
-
-    await tester.pumpWidget(buildTestWidget());
+    await tester.enterText(find.byType(TextFormField), 'Test Group');
     await tester.pumpAndSettle();
 
-    expect(find.byType(SnackBar), findsOneWidget);
-    expect(find.text('Error creating group'), findsOneWidget);
+    final createButton = find.widgetWithText(ElevatedButton, 'Create Group');
+    // Ensure visibility by scrolling if needed
+    await tester.ensureVisible(createButton);
+    await tester.pumpAndSettle();
+
+    // Tap it
+    await tester.tap(createButton);
+    await tester.pump();
+
+    // Capture the argument
+    final captured = verify(() => mockCreateGroupBloc.add(captureAny())).captured;
+
+    // Manual assertions on the captured event
+    expect(captured.length, 1);
+    final event = captured.first;
+    expect(event, isA<CreateGroupSubmitted>());
+    if (event is CreateGroupSubmitted) {
+        expect(event.name, 'Test Group');
+        expect(event.userId, 'test-user-id');
+    }
   });
 }

--- a/test/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source_proxy_test.dart
+++ b/test/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source_proxy_test.dart
@@ -37,196 +37,268 @@ void main() {
   });
 
   group('addRecurringRule', () {
-    test('should delegate to DemoModeService when demo mode is active', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
-      when(() => mockDemoModeService.addDemoRecurringRule(any()))
-          .thenAnswer((_) async {});
-      final rule = MockRecurringRuleModel();
+    test(
+      'should delegate to DemoModeService when demo mode is active',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+        when(
+          () => mockDemoModeService.addDemoRecurringRule(any()),
+        ).thenAnswer((_) async {});
+        final rule = MockRecurringRuleModel();
 
-      await proxy.addRecurringRule(rule);
+        await proxy.addRecurringRule(rule);
 
-      verify(() => mockDemoModeService.addDemoRecurringRule(rule)).called(1);
-      verifyZeroInteractions(mockHiveDataSource);
-    });
+        verify(() => mockDemoModeService.addDemoRecurringRule(rule)).called(1);
+        verifyZeroInteractions(mockHiveDataSource);
+      },
+    );
 
-    test('should delegate to HiveDataSource when demo mode is inactive', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
-      when(() => mockHiveDataSource.addRecurringRule(any()))
-          .thenAnswer((_) async {});
-      final rule = MockRecurringRuleModel();
+    test(
+      'should delegate to HiveDataSource when demo mode is inactive',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+        when(
+          () => mockHiveDataSource.addRecurringRule(any()),
+        ).thenAnswer((_) async {});
+        final rule = MockRecurringRuleModel();
 
-      await proxy.addRecurringRule(rule);
+        await proxy.addRecurringRule(rule);
 
-      verify(() => mockHiveDataSource.addRecurringRule(rule)).called(1);
-      verifyNever(() => mockDemoModeService.addDemoRecurringRule(any()));
-    });
+        verify(() => mockHiveDataSource.addRecurringRule(rule)).called(1);
+        verifyNever(() => mockDemoModeService.addDemoRecurringRule(any()));
+      },
+    );
   });
 
   group('getRecurringRules', () {
-    test('should delegate to DemoModeService when demo mode is active', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
-      final rules = [MockRecurringRuleModel()];
-      when(() => mockDemoModeService.getDemoRecurringRules())
-          .thenAnswer((_) async => rules);
+    test(
+      'should delegate to DemoModeService when demo mode is active',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+        final rules = [MockRecurringRuleModel()];
+        when(
+          () => mockDemoModeService.getDemoRecurringRules(),
+        ).thenAnswer((_) async => rules);
 
-      final result = await proxy.getRecurringRules();
+        final result = await proxy.getRecurringRules();
 
-      expect(result, rules);
-      verify(() => mockDemoModeService.getDemoRecurringRules()).called(1);
-      verifyZeroInteractions(mockHiveDataSource);
-    });
+        expect(result, rules);
+        verify(() => mockDemoModeService.getDemoRecurringRules()).called(1);
+        verifyZeroInteractions(mockHiveDataSource);
+      },
+    );
 
-    test('should delegate to HiveDataSource when demo mode is inactive', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
-      final rules = [MockRecurringRuleModel()];
-      when(() => mockHiveDataSource.getRecurringRules())
-          .thenAnswer((_) async => rules);
+    test(
+      'should delegate to HiveDataSource when demo mode is inactive',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+        final rules = [MockRecurringRuleModel()];
+        when(
+          () => mockHiveDataSource.getRecurringRules(),
+        ).thenAnswer((_) async => rules);
 
-      final result = await proxy.getRecurringRules();
+        final result = await proxy.getRecurringRules();
 
-      expect(result, rules);
-      verify(() => mockHiveDataSource.getRecurringRules()).called(1);
-      verifyNever(() => mockDemoModeService.getDemoRecurringRules());
-    });
+        expect(result, rules);
+        verify(() => mockHiveDataSource.getRecurringRules()).called(1);
+        verifyNever(() => mockDemoModeService.getDemoRecurringRules());
+      },
+    );
   });
 
   group('getRecurringRuleById', () {
-    test('should delegate to DemoModeService when demo mode is active', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
-      final rule = MockRecurringRuleModel();
-      when(() => mockDemoModeService.getDemoRecurringRuleById(any()))
-          .thenAnswer((_) async => rule);
+    test(
+      'should delegate to DemoModeService when demo mode is active',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+        final rule = MockRecurringRuleModel();
+        when(
+          () => mockDemoModeService.getDemoRecurringRuleById(any()),
+        ).thenAnswer((_) async => rule);
 
-      final result = await proxy.getRecurringRuleById('id');
+        final result = await proxy.getRecurringRuleById('id');
 
-      expect(result, rule);
-      verify(() => mockDemoModeService.getDemoRecurringRuleById('id')).called(1);
-      verifyZeroInteractions(mockHiveDataSource);
-    });
+        expect(result, rule);
+        verify(
+          () => mockDemoModeService.getDemoRecurringRuleById('id'),
+        ).called(1);
+        verifyZeroInteractions(mockHiveDataSource);
+      },
+    );
 
-    test('should throw Exception when demo mode is active and rule not found', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
-      when(() => mockDemoModeService.getDemoRecurringRuleById(any()))
-          .thenAnswer((_) async => null);
+    test(
+      'should throw Exception when demo mode is active and rule not found',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+        when(
+          () => mockDemoModeService.getDemoRecurringRuleById(any()),
+        ).thenAnswer((_) async => null);
 
-      expect(() => proxy.getRecurringRuleById('id'), throwsException);
-    });
+        expect(() => proxy.getRecurringRuleById('id'), throwsException);
+      },
+    );
 
-    test('should delegate to HiveDataSource when demo mode is inactive', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
-      final rule = MockRecurringRuleModel();
-      when(() => mockHiveDataSource.getRecurringRuleById(any()))
-          .thenAnswer((_) async => rule);
+    test(
+      'should delegate to HiveDataSource when demo mode is inactive',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+        final rule = MockRecurringRuleModel();
+        when(
+          () => mockHiveDataSource.getRecurringRuleById(any()),
+        ).thenAnswer((_) async => rule);
 
-      final result = await proxy.getRecurringRuleById('id');
+        final result = await proxy.getRecurringRuleById('id');
 
-      expect(result, rule);
-      verify(() => mockHiveDataSource.getRecurringRuleById('id')).called(1);
-      verifyNever(() => mockDemoModeService.getDemoRecurringRuleById(any()));
-    });
+        expect(result, rule);
+        verify(() => mockHiveDataSource.getRecurringRuleById('id')).called(1);
+        verifyNever(() => mockDemoModeService.getDemoRecurringRuleById(any()));
+      },
+    );
   });
 
   group('updateRecurringRule', () {
-    test('should delegate to DemoModeService when demo mode is active', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
-      when(() => mockDemoModeService.updateDemoRecurringRule(any()))
-          .thenAnswer((_) async {});
-      final rule = MockRecurringRuleModel();
+    test(
+      'should delegate to DemoModeService when demo mode is active',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+        when(
+          () => mockDemoModeService.updateDemoRecurringRule(any()),
+        ).thenAnswer((_) async {});
+        final rule = MockRecurringRuleModel();
 
-      await proxy.updateRecurringRule(rule);
+        await proxy.updateRecurringRule(rule);
 
-      verify(() => mockDemoModeService.updateDemoRecurringRule(rule)).called(1);
-      verifyZeroInteractions(mockHiveDataSource);
-    });
+        verify(
+          () => mockDemoModeService.updateDemoRecurringRule(rule),
+        ).called(1);
+        verifyZeroInteractions(mockHiveDataSource);
+      },
+    );
 
-    test('should delegate to HiveDataSource when demo mode is inactive', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
-      when(() => mockHiveDataSource.updateRecurringRule(any()))
-          .thenAnswer((_) async {});
-      final rule = MockRecurringRuleModel();
+    test(
+      'should delegate to HiveDataSource when demo mode is inactive',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+        when(
+          () => mockHiveDataSource.updateRecurringRule(any()),
+        ).thenAnswer((_) async {});
+        final rule = MockRecurringRuleModel();
 
-      await proxy.updateRecurringRule(rule);
+        await proxy.updateRecurringRule(rule);
 
-      verify(() => mockHiveDataSource.updateRecurringRule(rule)).called(1);
-      verifyNever(() => mockDemoModeService.updateDemoRecurringRule(any()));
-    });
+        verify(() => mockHiveDataSource.updateRecurringRule(rule)).called(1);
+        verifyNever(() => mockDemoModeService.updateDemoRecurringRule(any()));
+      },
+    );
   });
 
   group('deleteRecurringRule', () {
-    test('should delegate to DemoModeService when demo mode is active', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
-      when(() => mockDemoModeService.deleteDemoRecurringRule(any()))
-          .thenAnswer((_) async {});
+    test(
+      'should delegate to DemoModeService when demo mode is active',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+        when(
+          () => mockDemoModeService.deleteDemoRecurringRule(any()),
+        ).thenAnswer((_) async {});
 
-      await proxy.deleteRecurringRule('id');
+        await proxy.deleteRecurringRule('id');
 
-      verify(() => mockDemoModeService.deleteDemoRecurringRule('id')).called(1);
-      verifyZeroInteractions(mockHiveDataSource);
-    });
+        verify(
+          () => mockDemoModeService.deleteDemoRecurringRule('id'),
+        ).called(1);
+        verifyZeroInteractions(mockHiveDataSource);
+      },
+    );
 
-    test('should delegate to HiveDataSource when demo mode is inactive', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
-      when(() => mockHiveDataSource.deleteRecurringRule(any()))
-          .thenAnswer((_) async {});
+    test(
+      'should delegate to HiveDataSource when demo mode is inactive',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+        when(
+          () => mockHiveDataSource.deleteRecurringRule(any()),
+        ).thenAnswer((_) async {});
 
-      await proxy.deleteRecurringRule('id');
+        await proxy.deleteRecurringRule('id');
 
-      verify(() => mockHiveDataSource.deleteRecurringRule('id')).called(1);
-      verifyNever(() => mockDemoModeService.deleteDemoRecurringRule(any()));
-    });
+        verify(() => mockHiveDataSource.deleteRecurringRule('id')).called(1);
+        verifyNever(() => mockDemoModeService.deleteDemoRecurringRule(any()));
+      },
+    );
   });
 
   group('addAuditLog', () {
-    test('should delegate to DemoModeService when demo mode is active', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
-      when(() => mockDemoModeService.addDemoRecurringAuditLog(any()))
-          .thenAnswer((_) async {});
-      final log = MockRecurringRuleAuditLogModel();
+    test(
+      'should delegate to DemoModeService when demo mode is active',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+        when(
+          () => mockDemoModeService.addDemoRecurringAuditLog(any()),
+        ).thenAnswer((_) async {});
+        final log = MockRecurringRuleAuditLogModel();
 
-      await proxy.addAuditLog(log);
+        await proxy.addAuditLog(log);
 
-      verify(() => mockDemoModeService.addDemoRecurringAuditLog(log)).called(1);
-      verifyZeroInteractions(mockHiveDataSource);
-    });
+        verify(
+          () => mockDemoModeService.addDemoRecurringAuditLog(log),
+        ).called(1);
+        verifyZeroInteractions(mockHiveDataSource);
+      },
+    );
 
-    test('should delegate to HiveDataSource when demo mode is inactive', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
-      when(() => mockHiveDataSource.addAuditLog(any())).thenAnswer((_) async {});
-      final log = MockRecurringRuleAuditLogModel();
+    test(
+      'should delegate to HiveDataSource when demo mode is inactive',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+        when(
+          () => mockHiveDataSource.addAuditLog(any()),
+        ).thenAnswer((_) async {});
+        final log = MockRecurringRuleAuditLogModel();
 
-      await proxy.addAuditLog(log);
+        await proxy.addAuditLog(log);
 
-      verify(() => mockHiveDataSource.addAuditLog(log)).called(1);
-      verifyNever(() => mockDemoModeService.addDemoRecurringAuditLog(any()));
-    });
+        verify(() => mockHiveDataSource.addAuditLog(log)).called(1);
+        verifyNever(() => mockDemoModeService.addDemoRecurringAuditLog(any()));
+      },
+    );
   });
 
   group('getAuditLogsForRule', () {
-    test('should delegate to DemoModeService when demo mode is active', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
-      final logs = [MockRecurringRuleAuditLogModel()];
-      when(() => mockDemoModeService.getDemoRecurringAuditLogsForRule(any()))
-          .thenAnswer((_) async => logs);
+    test(
+      'should delegate to DemoModeService when demo mode is active',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+        final logs = [MockRecurringRuleAuditLogModel()];
+        when(
+          () => mockDemoModeService.getDemoRecurringAuditLogsForRule(any()),
+        ).thenAnswer((_) async => logs);
 
-      final result = await proxy.getAuditLogsForRule('id');
+        final result = await proxy.getAuditLogsForRule('id');
 
-      expect(result, logs);
-      verify(() => mockDemoModeService.getDemoRecurringAuditLogsForRule('id'))
-          .called(1);
-      verifyZeroInteractions(mockHiveDataSource);
-    });
+        expect(result, logs);
+        verify(
+          () => mockDemoModeService.getDemoRecurringAuditLogsForRule('id'),
+        ).called(1);
+        verifyZeroInteractions(mockHiveDataSource);
+      },
+    );
 
-    test('should delegate to HiveDataSource when demo mode is inactive', () async {
-      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
-      final logs = [MockRecurringRuleAuditLogModel()];
-      when(() => mockHiveDataSource.getAuditLogsForRule(any()))
-          .thenAnswer((_) async => logs);
+    test(
+      'should delegate to HiveDataSource when demo mode is inactive',
+      () async {
+        when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+        final logs = [MockRecurringRuleAuditLogModel()];
+        when(
+          () => mockHiveDataSource.getAuditLogsForRule(any()),
+        ).thenAnswer((_) async => logs);
 
-      final result = await proxy.getAuditLogsForRule('id');
+        final result = await proxy.getAuditLogsForRule('id');
 
-      expect(result, logs);
-      verify(() => mockHiveDataSource.getAuditLogsForRule('id')).called(1);
-      verifyNever(() => mockDemoModeService.getDemoRecurringAuditLogsForRule(any()));
-    });
+        expect(result, logs);
+        verify(() => mockHiveDataSource.getAuditLogsForRule('id')).called(1);
+        verifyNever(
+          () => mockDemoModeService.getDemoRecurringAuditLogsForRule(any()),
+        );
+      },
+    );
   });
 }

--- a/test/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source_proxy_test.dart
+++ b/test/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source_proxy_test.dart
@@ -1,0 +1,232 @@
+import 'package:expense_tracker/core/services/demo_mode_service.dart';
+import 'package:expense_tracker/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source.dart';
+import 'package:expense_tracker/features/recurring_transactions/data/datasources/recurring_transaction_local_data_source_proxy.dart';
+import 'package:expense_tracker/features/recurring_transactions/data/models/recurring_rule_audit_log_model.dart';
+import 'package:expense_tracker/features/recurring_transactions/data/models/recurring_rule_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockRecurringTransactionLocalDataSource extends Mock
+    implements RecurringTransactionLocalDataSource {}
+
+class MockDemoModeService extends Mock implements DemoModeService {}
+
+class MockRecurringRuleModel extends Mock implements RecurringRuleModel {
+  @override
+  String get description => 'Mock Rule';
+}
+
+class MockRecurringRuleAuditLogModel extends Mock
+    implements RecurringRuleAuditLogModel {}
+
+void main() {
+  late DemoAwareRecurringTransactionDataSource proxy;
+  late MockRecurringTransactionLocalDataSource mockHiveDataSource;
+  late MockDemoModeService mockDemoModeService;
+
+  setUp(() {
+    mockHiveDataSource = MockRecurringTransactionLocalDataSource();
+    mockDemoModeService = MockDemoModeService();
+    proxy = DemoAwareRecurringTransactionDataSource(
+      hiveDataSource: mockHiveDataSource,
+      demoModeService: mockDemoModeService,
+    );
+
+    registerFallbackValue(MockRecurringRuleModel());
+    registerFallbackValue(MockRecurringRuleAuditLogModel());
+  });
+
+  group('addRecurringRule', () {
+    test('should delegate to DemoModeService when demo mode is active', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+      when(() => mockDemoModeService.addDemoRecurringRule(any()))
+          .thenAnswer((_) async {});
+      final rule = MockRecurringRuleModel();
+
+      await proxy.addRecurringRule(rule);
+
+      verify(() => mockDemoModeService.addDemoRecurringRule(rule)).called(1);
+      verifyZeroInteractions(mockHiveDataSource);
+    });
+
+    test('should delegate to HiveDataSource when demo mode is inactive', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+      when(() => mockHiveDataSource.addRecurringRule(any()))
+          .thenAnswer((_) async {});
+      final rule = MockRecurringRuleModel();
+
+      await proxy.addRecurringRule(rule);
+
+      verify(() => mockHiveDataSource.addRecurringRule(rule)).called(1);
+      verifyNever(() => mockDemoModeService.addDemoRecurringRule(any()));
+    });
+  });
+
+  group('getRecurringRules', () {
+    test('should delegate to DemoModeService when demo mode is active', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+      final rules = [MockRecurringRuleModel()];
+      when(() => mockDemoModeService.getDemoRecurringRules())
+          .thenAnswer((_) async => rules);
+
+      final result = await proxy.getRecurringRules();
+
+      expect(result, rules);
+      verify(() => mockDemoModeService.getDemoRecurringRules()).called(1);
+      verifyZeroInteractions(mockHiveDataSource);
+    });
+
+    test('should delegate to HiveDataSource when demo mode is inactive', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+      final rules = [MockRecurringRuleModel()];
+      when(() => mockHiveDataSource.getRecurringRules())
+          .thenAnswer((_) async => rules);
+
+      final result = await proxy.getRecurringRules();
+
+      expect(result, rules);
+      verify(() => mockHiveDataSource.getRecurringRules()).called(1);
+      verifyNever(() => mockDemoModeService.getDemoRecurringRules());
+    });
+  });
+
+  group('getRecurringRuleById', () {
+    test('should delegate to DemoModeService when demo mode is active', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+      final rule = MockRecurringRuleModel();
+      when(() => mockDemoModeService.getDemoRecurringRuleById(any()))
+          .thenAnswer((_) async => rule);
+
+      final result = await proxy.getRecurringRuleById('id');
+
+      expect(result, rule);
+      verify(() => mockDemoModeService.getDemoRecurringRuleById('id')).called(1);
+      verifyZeroInteractions(mockHiveDataSource);
+    });
+
+    test('should throw Exception when demo mode is active and rule not found', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+      when(() => mockDemoModeService.getDemoRecurringRuleById(any()))
+          .thenAnswer((_) async => null);
+
+      expect(() => proxy.getRecurringRuleById('id'), throwsException);
+    });
+
+    test('should delegate to HiveDataSource when demo mode is inactive', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+      final rule = MockRecurringRuleModel();
+      when(() => mockHiveDataSource.getRecurringRuleById(any()))
+          .thenAnswer((_) async => rule);
+
+      final result = await proxy.getRecurringRuleById('id');
+
+      expect(result, rule);
+      verify(() => mockHiveDataSource.getRecurringRuleById('id')).called(1);
+      verifyNever(() => mockDemoModeService.getDemoRecurringRuleById(any()));
+    });
+  });
+
+  group('updateRecurringRule', () {
+    test('should delegate to DemoModeService when demo mode is active', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+      when(() => mockDemoModeService.updateDemoRecurringRule(any()))
+          .thenAnswer((_) async {});
+      final rule = MockRecurringRuleModel();
+
+      await proxy.updateRecurringRule(rule);
+
+      verify(() => mockDemoModeService.updateDemoRecurringRule(rule)).called(1);
+      verifyZeroInteractions(mockHiveDataSource);
+    });
+
+    test('should delegate to HiveDataSource when demo mode is inactive', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+      when(() => mockHiveDataSource.updateRecurringRule(any()))
+          .thenAnswer((_) async {});
+      final rule = MockRecurringRuleModel();
+
+      await proxy.updateRecurringRule(rule);
+
+      verify(() => mockHiveDataSource.updateRecurringRule(rule)).called(1);
+      verifyNever(() => mockDemoModeService.updateDemoRecurringRule(any()));
+    });
+  });
+
+  group('deleteRecurringRule', () {
+    test('should delegate to DemoModeService when demo mode is active', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+      when(() => mockDemoModeService.deleteDemoRecurringRule(any()))
+          .thenAnswer((_) async {});
+
+      await proxy.deleteRecurringRule('id');
+
+      verify(() => mockDemoModeService.deleteDemoRecurringRule('id')).called(1);
+      verifyZeroInteractions(mockHiveDataSource);
+    });
+
+    test('should delegate to HiveDataSource when demo mode is inactive', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+      when(() => mockHiveDataSource.deleteRecurringRule(any()))
+          .thenAnswer((_) async {});
+
+      await proxy.deleteRecurringRule('id');
+
+      verify(() => mockHiveDataSource.deleteRecurringRule('id')).called(1);
+      verifyNever(() => mockDemoModeService.deleteDemoRecurringRule(any()));
+    });
+  });
+
+  group('addAuditLog', () {
+    test('should delegate to DemoModeService when demo mode is active', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+      when(() => mockDemoModeService.addDemoRecurringAuditLog(any()))
+          .thenAnswer((_) async {});
+      final log = MockRecurringRuleAuditLogModel();
+
+      await proxy.addAuditLog(log);
+
+      verify(() => mockDemoModeService.addDemoRecurringAuditLog(log)).called(1);
+      verifyZeroInteractions(mockHiveDataSource);
+    });
+
+    test('should delegate to HiveDataSource when demo mode is inactive', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+      when(() => mockHiveDataSource.addAuditLog(any())).thenAnswer((_) async {});
+      final log = MockRecurringRuleAuditLogModel();
+
+      await proxy.addAuditLog(log);
+
+      verify(() => mockHiveDataSource.addAuditLog(log)).called(1);
+      verifyNever(() => mockDemoModeService.addDemoRecurringAuditLog(any()));
+    });
+  });
+
+  group('getAuditLogsForRule', () {
+    test('should delegate to DemoModeService when demo mode is active', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(true);
+      final logs = [MockRecurringRuleAuditLogModel()];
+      when(() => mockDemoModeService.getDemoRecurringAuditLogsForRule(any()))
+          .thenAnswer((_) async => logs);
+
+      final result = await proxy.getAuditLogsForRule('id');
+
+      expect(result, logs);
+      verify(() => mockDemoModeService.getDemoRecurringAuditLogsForRule('id'))
+          .called(1);
+      verifyZeroInteractions(mockHiveDataSource);
+    });
+
+    test('should delegate to HiveDataSource when demo mode is inactive', () async {
+      when(() => mockDemoModeService.isDemoActive).thenReturn(false);
+      final logs = [MockRecurringRuleAuditLogModel()];
+      when(() => mockHiveDataSource.getAuditLogsForRule(any()))
+          .thenAnswer((_) async => logs);
+
+      final result = await proxy.getAuditLogsForRule('id');
+
+      expect(result, logs);
+      verify(() => mockHiveDataSource.getAuditLogsForRule('id')).called(1);
+      verifyNever(() => mockDemoModeService.getDemoRecurringAuditLogsForRule(any()));
+    });
+  });
+}

--- a/test/ui_coverage_test.dart
+++ b/test/ui_coverage_test.dart
@@ -67,7 +67,9 @@ void main() {
     registerFallbackValue(const LoadGoals());
     registerFallbackValue(const LoadSettings());
     registerFallbackValue(const LoadCategories());
-    registerFallbackValue(const TransactionTypeChanged(TransactionType.expense));
+    registerFallbackValue(
+      const TransactionTypeChanged(TransactionType.expense),
+    );
   });
 
   setUp(() {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+    "cleanUrls": true,
+    "rewrites": [
+        {
+            "source": "/(.*)",
+            "destination": "/index.html"
+        }
+    ]
+}

--- a/web/index.html
+++ b/web/index.html
@@ -29,7 +29,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>expense_tracker</title>
+  <title>Financial OS</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -15,6 +15,7 @@
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
+#include <windows_single_instance/windows_single_instance_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
@@ -35,4 +36,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
+  WindowsSingleInstancePluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowsSingleInstancePlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -12,6 +12,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   permission_handler_windows
   share_plus
   url_launcher_windows
+  windows_single_instance
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
- **Demo Mode**: `SettingsBloc` now emits `DataChangeReason.reset` on entering demo mode, forcing all lists to reload immediately.
- **Create Group**: `CreateGroupPage` now shows a SnackBar if user is not authenticated (instead of silent failure) and uses `AppCountries` for currency list (matching Settings).
- **Recurring Rules**: Added `sampleRecurringRules` to `DemoData`, updated `DemoModeService` to handle recurring rules, created `DemoAwareRecurringTransactionDataSource` proxy, and updated `RecurringTransactionsDependencies` to use it.
- **Refactoring**: Cleaned up `SettingsBloc` to remove unused/invalid usecases and use `SettingsRepository` methods directly. Updated `AppCountries` to include `currencyCode`.

---
*PR created automatically by Jules for task [1386254092846430733](https://jules.google.com/task/1386254092846430733) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Demo mode: recurring transactions with sample rules, in-memory CRUD and audit logs
  - Country list now includes currency codes used in currency dropdowns
  - App rebranded to "Financial OS" (app title and app name)

* **UI/UX**
  - "Login" renamed to "Login / Sign Up"; phone input formatting improved; group creation requires sign-in with SnackBar prompt

* **Tests**
  - Added/updated tests covering demo recurring rules, currency behavior, login formatting, and group creation flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->