### PR TITLE
Phase 2 Integration Hardening

### DIFF
--- a/docs/PHASE2_INTEGRATION_QA.md
+++ b/docs/PHASE2_INTEGRATION_QA.md
@@ -1,0 +1,82 @@
+# Phase 2 Integration QA Checklist
+
+This document outlines the validation steps for Phase 2A (Groups + Realtime + Outbox) and Phase 2B (Invites + Deep Links + RBAC) integration.
+
+## Integration Test Matrix
+
+### 1. Multi-device Realtime Groups
+- **Scenario**: Device A creates a group online.
+- **Expected**:
+  - Group appears instantly on Device A (Hive updated).
+  - Group appears on Device B without manual refresh (via Realtime).
+  - `updated_at` timestamps are consistent.
+  - No duplicate groups.
+
+### 2. Offline Group Creation + Outbox Flush
+- **Scenario**:
+  - Airplane mode ON.
+  - Create group on Device A.
+  - Verify group appears in UI with "Syncing..." indicator.
+  - Airplane mode OFF.
+- **Expected**:
+  - Outbox item is processed within ~5 seconds.
+  - Group exists on Supabase.
+  - Other devices receive the group via Realtime.
+  - Sync status becomes "Synced".
+  - No duplicates created.
+
+### 3. Deep Link Join (Logged Out)
+- **Scenario**:
+  - User taps `https://spendos.app/join?token=...` or `spendos://join?token=...`.
+  - App opens from cold start (logged out).
+- **Expected**:
+  - Anonymous sign-in occurs automatically.
+  - Overlay "Securing your invite..." appears.
+  - `join_group_via_invite` succeeds.
+  - User lands in the correct Group Dashboard.
+  - Group appears in the groups list immediately.
+
+### 4. Deep Link Join (Logged In)
+- **Scenario**: User taps invite link while already logged in.
+- **Expected**:
+  - App opens/resumes.
+  - Join process succeeds without re-authentication.
+  - User is routed to the new group.
+
+### 5. RBAC Enforcement
+- **Scenario**:
+  - Admin generates a "Viewer" invite.
+  - User B joins using that invite.
+- **Expected**:
+  - User B sees the group as a Viewer.
+  - "Add Expense", "Settlement", and Admin Settings are hidden/disabled for User B.
+  - Realtime updates to role (e.g., Admin promotes Viewer to Member) reflect instantly in UI.
+
+### 6. Member Management
+- **Scenario**: Admin changes a member's role or kicks a member.
+- **Expected**:
+  - **Role Change**: Member's UI updates permissions instantly (Realtime).
+  - **Kick**: Member loses access immediately; group disappears from their list (Realtime/Local cleanup).
+  - Hive cache is updated accordingly.
+
+## Manual QA Script
+
+1.  **Setup**: Two devices (or simulators) logged in with different accounts.
+2.  **Step 1 (Offline Create)**:
+    - Device A: Go offline. Create "Offline Group". Check UI.
+    - Device A: Go online. Wait for sync.
+    - Device B: Verify "Offline Group" appears.
+3.  **Step 2 (Invite & Join)**:
+    - Device A (Admin): Go to Group Settings -> Members -> Invite. Copy Link.
+    - Device B: Logout. Close App.
+    - Device B: Open Deep Link. Verify Anonymous Login + Join.
+4.  **Step 3 (Role Change)**:
+    - Device A: Change Device B's role to "Viewer".
+    - Device B: Verify "Add Expense" button disappears.
+5.  **Step 4 (Kick)**:
+    - Device A: Remove Device B from group.
+    - Device B: Verify group disappears from list.
+
+## Configuration Requirements
+- **Deep Links**: Ensure `android/app/src/main/AndroidManifest.xml` and `ios/Runner/Info.plist` (or Entitlements) are configured for `spendos` scheme and `spendos.app` domain.
+- **Supabase**: Ensure Edge Functions `create-invite` and `join_group_via_invite` are deployed.

--- a/lib/features/deep_link/presentation/bloc/deep_link_bloc.dart
+++ b/lib/features/deep_link/presentation/bloc/deep_link_bloc.dart
@@ -76,7 +76,8 @@ class DeepLinkBloc extends Bloc<DeepLinkEvent, DeepLinkState> {
     }
 
     // 2. Check if it is a join link
-    if (event.uri.path.contains('/join')) {
+    // Support both https://spendos.app/join and spendos://join
+    if (event.uri.path.contains('/join') || event.uri.host == 'join') {
       final token = event.uri.queryParameters['token'];
       if (token != null) {
         await _handleJoin(token, emit);

--- a/lib/features/groups/data/datasources/groups_local_data_source.dart
+++ b/lib/features/groups/data/datasources/groups_local_data_source.dart
@@ -10,6 +10,8 @@ abstract class GroupsLocalDataSource {
   Stream<List<GroupModel>> watchGroups();
   Future<void> saveGroupMembers(List<GroupMemberModel> members);
   List<GroupMemberModel> getGroupMembers(String groupId);
+  Future<void> deleteGroup(String groupId);
+  Future<void> deleteMember(String memberId);
 }
 
 class GroupsLocalDataSourceImpl implements GroupsLocalDataSource {
@@ -53,5 +55,15 @@ class GroupsLocalDataSourceImpl implements GroupsLocalDataSource {
   @override
   List<GroupMemberModel> getGroupMembers(String groupId) {
     return _memberBox.values.where((m) => m.groupId == groupId).toList();
+  }
+
+  @override
+  Future<void> deleteGroup(String groupId) async {
+    await _groupBox.delete(groupId);
+  }
+
+  @override
+  Future<void> deleteMember(String memberId) async {
+    await _memberBox.delete(memberId);
   }
 }

--- a/lib/features/groups/domain/repositories/groups_repository.dart
+++ b/lib/features/groups/domain/repositories/groups_repository.dart
@@ -9,6 +9,10 @@ abstract class GroupsRepository {
   Stream<Either<Failure, List<GroupEntity>>> watchGroups();
   Future<Either<Failure, List<GroupMember>>> getGroupMembers(String groupId);
   Future<Either<Failure, void>> syncGroups();
+
+  /// Fetches groups AND members from server and updates local cache.
+  Future<Either<Failure, void>> refreshGroupsFromServer();
+
   Future<Either<Failure, String>> createInvite(
     String groupId, {
     String role = 'member',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -937,10 +937,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1470,26 +1470,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/test/features/deep_link/presentation/bloc/deep_link_bloc_test.dart
+++ b/test/features/deep_link/presentation/bloc/deep_link_bloc_test.dart
@@ -195,7 +195,7 @@ void main() {
       act: (bloc) async {
         bloc.add(const DeepLinkStarted());
         // Wait for bloc to subscribe
-        await Future.delayed(Duration.zero);
+        await Future.delayed(const Duration(milliseconds: 100));
         uriStreamController.add(
           Uri.parse('https://spendos.app/join?token=stream'),
         );
@@ -226,7 +226,7 @@ void main() {
       act: (bloc) async {
         bloc.add(const DeepLinkStarted());
         // Wait for bloc to subscribe
-        await Future.delayed(Duration.zero);
+        await Future.delayed(const Duration(milliseconds: 100));
         uriStreamController.add(Uri.parse('spendos://join?token=custom'));
       },
       expect: () => [

--- a/test/features/deep_link/presentation/bloc/deep_link_bloc_test.dart
+++ b/test/features/deep_link/presentation/bloc/deep_link_bloc_test.dart
@@ -200,6 +200,7 @@ void main() {
           Uri.parse('https://spendos.app/join?token=stream'),
         );
       },
+      wait: const Duration(milliseconds: 500),
       expect: () => [
         DeepLinkProcessing(),
         const DeepLinkSuccess(groupId: '456', groupName: 'Stream Group'),
@@ -229,6 +230,7 @@ void main() {
         await Future.delayed(const Duration(milliseconds: 100));
         uriStreamController.add(Uri.parse('spendos://join?token=custom'));
       },
+      wait: const Duration(milliseconds: 500),
       expect: () => [
         DeepLinkProcessing(),
         const DeepLinkSuccess(groupId: '789', groupName: 'Custom Group'),

--- a/test/features/groups/data/repositories/groups_repository_impl_test.dart
+++ b/test/features/groups/data/repositories/groups_repository_impl_test.dart
@@ -234,18 +234,14 @@ void main() {
       when(
         () => mockLocalDataSource.saveGroups(any()),
       ).thenAnswer((_) async {});
-      when(
-        () => mockLocalDataSource.getGroups(),
-      ).thenReturn([tGroupModel]);
+      when(() => mockLocalDataSource.getGroups()).thenReturn([tGroupModel]);
       when(
         () => mockRemoteDataSource.getGroupMembers(any()),
       ).thenAnswer((_) async => []);
       when(
         () => mockLocalDataSource.saveGroupMembers(any()),
       ).thenAnswer((_) async {});
-      when(
-        () => mockLocalDataSource.getGroupMembers(any()),
-      ).thenReturn([]);
+      when(() => mockLocalDataSource.getGroupMembers(any())).thenReturn([]);
 
       // Act
       final result = await repository.syncGroups();
@@ -356,28 +352,29 @@ void main() {
   });
 
   group('updateMemberRole', () {
-    test('should call remoteDataSource.updateMemberRole and refresh members', () async {
-      when(
-        () => mockRemoteDataSource.updateMemberRole(any(), any(), any()),
-      ).thenAnswer((_) async {});
-      when(
-        () => mockRemoteDataSource.getGroupMembers(any()),
-      ).thenAnswer((_) async => []);
-      when(
-        () => mockLocalDataSource.saveGroupMembers(any()),
-      ).thenAnswer((_) async {});
-      when(
-        () => mockLocalDataSource.getGroupMembers(any()),
-      ).thenReturn([]);
+    test(
+      'should call remoteDataSource.updateMemberRole and refresh members',
+      () async {
+        when(
+          () => mockRemoteDataSource.updateMemberRole(any(), any(), any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockRemoteDataSource.getGroupMembers(any()),
+        ).thenAnswer((_) async => []);
+        when(
+          () => mockLocalDataSource.saveGroupMembers(any()),
+        ).thenAnswer((_) async {});
+        when(() => mockLocalDataSource.getGroupMembers(any())).thenReturn([]);
 
-      final result = await repository.updateMemberRole('1', 'u1', 'admin');
+        final result = await repository.updateMemberRole('1', 'u1', 'admin');
 
-      expect(result.isRight(), true);
-      verify(
-        () => mockRemoteDataSource.updateMemberRole('1', 'u1', 'admin'),
-      ).called(1);
-      verify(() => mockRemoteDataSource.getGroupMembers('1')).called(1);
-    });
+        expect(result.isRight(), true);
+        verify(
+          () => mockRemoteDataSource.updateMemberRole('1', 'u1', 'admin'),
+        ).called(1);
+        verify(() => mockRemoteDataSource.getGroupMembers('1')).called(1);
+      },
+    );
 
     test('should return ServerFailure on exception', () async {
       when(
@@ -402,9 +399,7 @@ void main() {
       when(
         () => mockLocalDataSource.saveGroupMembers(any()),
       ).thenAnswer((_) async {});
-      when(
-        () => mockLocalDataSource.getGroupMembers(any()),
-      ).thenReturn([]);
+      when(() => mockLocalDataSource.getGroupMembers(any())).thenReturn([]);
 
       final result = await repository.removeMember('1', 'u1');
 


### PR DESCRIPTION
This PR hardens the integration of Phase 2A and Phase 2B features, specifically targeting integration gaps like missing groups after join, stale data, and deep link parsing.

### Fixes
- **Missing Groups**: Added `refreshGroupsFromServer` to `GroupsRepository` which fetches both groups and members, ensuring that when a user joins a group, they get all necessary data.
- **Realtime**: Updated `SyncService` to fetch missing groups when a member is added via Realtime (passive join scenario).
- **Deep Links**: Fixed `DeepLinkBloc` to support `spendos://` scheme and trigger a full refresh after join.
- **Stale Data**: Added cleanup logic in `GroupsRepository` to remove groups/members from Hive that no longer exist on the server.
- **QA**: Added `docs/PHASE2_INTEGRATION_QA.md` with a comprehensive test matrix.

### Verification
- Unit tests added/updated for `DeepLinkBloc` and `GroupsRepositoryImpl`.
- Verified deep link parsing for both `https` and custom scheme.
- Verified stale data cleanup logic.

### Config
- Ensure `android/app/src/main/AndroidManifest.xml` and `ios/Runner/Info.plist` support `spendos` scheme.


---
*PR created automatically by Jules for task [4677358424433230424](https://jules.google.com/task/4677358424433230424) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced deep-link support for join links across multiple URL/URI formats.
  * Added group and member deletion actions.
  * New "refresh groups from server" sync to reconcile remote and local group state.

* **Bug Fixes**
  * Auto-fetch missing groups during sync and remove stale local data.
  * Member lists refresh after role updates and removals.

* **Documentation**
  * Added Phase 2 Integration QA checklist for realtime, offline, invites, deep links, RBAC, and deployment.

* **Tests**
  * Expanded deep-link and group/member sync tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->