### PR TITLE
feat: Implement Split Brain engine for expense transactions

### DIFF
--- a/lib/core/di/service_configurations/expenses_dependencies.dart
+++ b/lib/core/di/service_configurations/expenses_dependencies.dart
@@ -1,34 +1,32 @@
-// lib/core/di/service_configurations/expenses_dependencies.dart
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/services/demo_mode_service.dart';
 import 'package:expense_tracker/features/expenses/data/datasources/expense_local_data_source.dart';
-import 'package:expense_tracker/features/expenses/data/datasources/expense_local_data_source_proxy.dart'; // Import proxy
-import 'package:expense_tracker/features/expenses/data/models/expense_model.dart';
+import 'package:expense_tracker/features/expenses/data/datasources/expense_local_data_source_proxy.dart';
 import 'package:expense_tracker/features/expenses/data/repositories/expense_repository_impl.dart';
 import 'package:expense_tracker/features/expenses/domain/repositories/expense_repository.dart';
 import 'package:expense_tracker/features/expenses/domain/usecases/add_expense.dart';
 import 'package:expense_tracker/features/expenses/domain/usecases/delete_expense.dart';
 import 'package:expense_tracker/features/expenses/domain/usecases/update_expense.dart';
-import 'package:hive_ce/hive.dart'; // Keep for HiveExpenseLocalDataSource
+import 'package:supabase_flutter/supabase_flutter.dart'; // Import SupabaseClient
 
 class ExpensesDependencies {
   static void register() {
-    // --- MODIFIED: Register Proxy ---
     // Data Source (Proxy that wraps the real one)
     sl.registerLazySingleton<ExpenseLocalDataSource>(
       () => DemoAwareExpenseDataSource(
-        hiveDataSource: sl<HiveExpenseLocalDataSource>(), // Get real DS
+        hiveDataSource: sl<HiveExpenseLocalDataSource>(),
         demoModeService: sl<DemoModeService>(),
       ),
     );
-    // --- END MODIFIED ---
 
     sl.registerLazySingleton<ExpenseRepository>(
       () => ExpenseRepositoryImpl(
         localDataSource: sl(),
         categoryRepository: sl(),
+        supabaseClient: sl<SupabaseClient>(), // Inject SupabaseClient
       ),
     );
+
     // Domain
     sl.registerLazySingleton(() => AddExpenseUseCase(sl()));
     sl.registerLazySingleton(() => UpdateExpenseUseCase(sl()));

--- a/lib/features/expenses/domain/entities/expense.dart
+++ b/lib/features/expenses/domain/entities/expense.dart
@@ -1,51 +1,74 @@
 import 'package:equatable/equatable.dart';
 import 'package:expense_tracker/features/categories/domain/entities/categorization_status.dart';
-import 'package:expense_tracker/features/categories/domain/entities/category.dart'; // Use the new Category entity
-import 'package:flutter/material.dart'; // Import CategorizationStatus
+import 'package:expense_tracker/features/categories/domain/entities/category.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense_payer.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense_split.dart';
+import 'package:flutter/material.dart';
 
 class Expense extends Equatable {
   final String id;
   final String title;
   final double amount;
   final DateTime date;
-  final Category?
-  category; // CHANGED: Now holds the full Category object, nullable initially
+  final Category? category;
   final String accountId;
-  final CategorizationStatus status; // ADDED
-  final double? confidenceScore; // ADDED
-  final String? merchantId; // ADDED
-
+  final CategorizationStatus status;
+  final double? confidenceScore;
+  final String? merchantId;
   final bool isRecurring;
+
+  // New Fields for Split Brain / Group Expenses
+  final String? groupId;
+  final String? createdBy;
+  final String currency;
+  final String? notes;
+  final List<ExpensePayer> payers;
+  final List<ExpenseSplit> splits;
 
   const Expense({
     required this.id,
     required this.title,
     required this.amount,
     required this.date,
-    this.category, // Make category nullable
+    this.category,
     required this.accountId,
-    this.status =
-        CategorizationStatus.uncategorized, // ADDED: Default to uncategorized
-    this.confidenceScore, // ADDED
-    this.merchantId, // ADDED
+    this.status = CategorizationStatus.uncategorized,
+    this.confidenceScore,
+    this.merchantId,
     this.isRecurring = false,
+
+    // Defaults for backward compatibility
+    this.groupId,
+    this.createdBy,
+    this.currency = 'USD', // Default currency
+    this.notes,
+    this.payers = const [],
+    this.splits = const [],
   });
 
-  // Optional: CopyWith method for easier updates
   Expense copyWith({
     String? id,
     String? title,
     double? amount,
     DateTime? date,
-    Category? category, // Allow updating category object
-    ValueGetter<Category?>? categoryOrNull, // Allow setting to null explicitly
+    Category? category,
+    ValueGetter<Category?>? categoryOrNull,
     String? accountId,
     CategorizationStatus? status,
     double? confidenceScore,
-    ValueGetter<double?>? confidenceScoreOrNull, // Allow setting to null
+    ValueGetter<double?>? confidenceScoreOrNull,
     String? merchantId,
-    ValueGetter<String?>? merchantIdOrNull, // Allow setting to null
+    ValueGetter<String?>? merchantIdOrNull,
     bool? isRecurring,
+
+    String? groupId,
+    ValueGetter<String?>? groupIdOrNull,
+    String? createdBy,
+    String? currency,
+    String? notes,
+    ValueGetter<String?>? notesOrNull,
+    List<ExpensePayer>? payers,
+    List<ExpenseSplit>? splits,
   }) {
     return Expense(
       id: id ?? this.id,
@@ -64,6 +87,15 @@ class Expense extends Equatable {
           ? merchantIdOrNull()
           : (merchantId ?? this.merchantId),
       isRecurring: isRecurring ?? this.isRecurring,
+
+      groupId: groupIdOrNull != null
+          ? groupIdOrNull()
+          : (groupId ?? this.groupId),
+      createdBy: createdBy ?? this.createdBy,
+      currency: currency ?? this.currency,
+      notes: notesOrNull != null ? notesOrNull() : (notes ?? this.notes),
+      payers: payers ?? this.payers,
+      splits: splits ?? this.splits,
     );
   }
 
@@ -73,11 +105,17 @@ class Expense extends Equatable {
     title,
     amount,
     date,
-    category, // Updated
+    category,
     accountId,
-    status, // Added
-    confidenceScore, // Added
-    merchantId, // Added
+    status,
+    confidenceScore,
+    merchantId,
     isRecurring,
+    groupId,
+    createdBy,
+    currency,
+    notes,
+    payers,
+    splits,
   ];
 }

--- a/lib/features/expenses/domain/entities/expense_payer.dart
+++ b/lib/features/expenses/domain/entities/expense_payer.dart
@@ -1,0 +1,11 @@
+import 'package:equatable/equatable.dart';
+
+class ExpensePayer extends Equatable {
+  final String userId;
+  final double amountPaid;
+
+  const ExpensePayer({required this.userId, required this.amountPaid});
+
+  @override
+  List<Object?> get props => [userId, amountPaid];
+}

--- a/lib/features/expenses/domain/entities/expense_split.dart
+++ b/lib/features/expenses/domain/entities/expense_split.dart
@@ -1,0 +1,41 @@
+import 'package:equatable/equatable.dart';
+
+enum SplitType {
+  equal,
+  exact,
+  percent,
+  share;
+
+  String get value => name.toUpperCase();
+}
+
+class ExpenseSplit extends Equatable {
+  final String userId;
+  final SplitType shareType;
+  final double shareValue;
+  final double computedAmount;
+
+  const ExpenseSplit({
+    required this.userId,
+    required this.shareType,
+    required this.shareValue,
+    required this.computedAmount,
+  });
+
+  ExpenseSplit copyWith({
+    String? userId,
+    SplitType? shareType,
+    double? shareValue,
+    double? computedAmount,
+  }) {
+    return ExpenseSplit(
+      userId: userId ?? this.userId,
+      shareType: shareType ?? this.shareType,
+      shareValue: shareValue ?? this.shareValue,
+      computedAmount: computedAmount ?? this.computedAmount,
+    );
+  }
+
+  @override
+  List<Object?> get props => [userId, shareType, shareValue, computedAmount];
+}

--- a/lib/features/expenses/domain/repositories/expense_repository.dart
+++ b/lib/features/expenses/domain/repositories/expense_repository.dart
@@ -2,13 +2,11 @@
 import 'package:dartz/dartz.dart';
 import 'package:expense_tracker/core/error/failure.dart';
 import 'package:expense_tracker/features/categories/domain/entities/categorization_status.dart';
-// --- Import Model instead of Entity ---
 import 'package:expense_tracker/features/expenses/data/models/expense_model.dart';
 import 'package:expense_tracker/features/analytics/domain/entities/expense_summary.dart';
 import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
 
 abstract class ExpenseRepository {
-  // --- MODIFIED Return Type ---
   Future<Either<Failure, List<ExpenseModel>>> getExpenses({
     DateTime? startDate,
     DateTime? endDate,
@@ -17,10 +15,7 @@ abstract class ExpenseRepository {
   });
 
   Future<Either<Failure, Expense?>> getExpenseById(String id);
-  // --- END MODIFIED ---
 
-  // Add/Update still take Entity, but might return Model or hydrated Entity?
-  // Let's keep them returning the hydrated Entity for consistency in Add/Edit flow for now.
   Future<Either<Failure, Expense>> addExpense(Expense expense);
   Future<Either<Failure, Expense>> updateExpense(Expense expense);
 
@@ -44,4 +39,7 @@ abstract class ExpenseRepository {
     String oldCategoryId,
     String newCategoryId,
   );
+
+  // New method for Split Brain transaction
+  Future<Either<Failure, Expense>> createExpenseTransaction(Expense expense);
 }

--- a/lib/features/expenses/domain/utils/split_engine.dart
+++ b/lib/features/expenses/domain/utils/split_engine.dart
@@ -1,0 +1,213 @@
+import 'package:expense_tracker/features/expenses/domain/entities/expense_split.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense_payer.dart';
+
+class ValidationException implements Exception {
+  final String message;
+  ValidationException(this.message);
+  @override
+  String toString() => 'ValidationException: $message';
+}
+
+class SplitEngine {
+  /// Validates and calculates splits based on the strategy.
+  /// Returns the reconciled list of splits.
+  static List<ExpenseSplit> calculateSplits({
+    required double totalAmount,
+    required List<ExpenseSplit> splits,
+  }) {
+    // Check for total < 0
+    if (totalAmount < 0)
+      throw ValidationException('Total amount cannot be negative');
+    if (splits.isEmpty) throw ValidationException('Splits cannot be empty');
+
+    // Round total to 2 decimals to ensure we start clean
+    final double total = _round(totalAmount);
+
+    // Check if total is zero
+    if (total == 0.0) {
+      return splits.map((s) => s.copyWith(computedAmount: 0.0)).toList();
+    }
+
+    // Detect strategy from first split
+    final type = splits.first.shareType;
+    if (splits.any((s) => s.shareType != type)) {
+      throw ValidationException('Mixed split types are not supported');
+    }
+
+    List<ExpenseSplit> calculatedSplits = [];
+
+    switch (type) {
+      case SplitType.equal:
+        calculatedSplits = _calculateEqual(total, splits);
+        break;
+      case SplitType.exact:
+        calculatedSplits = _calculateExact(total, splits);
+        break;
+      case SplitType.percent:
+        calculatedSplits = _calculatePercent(total, splits);
+        break;
+      case SplitType.share:
+        calculatedSplits = _calculateShare(total, splits);
+        break;
+    }
+
+    // Final verification (Sanity Check)
+    final sum = calculatedSplits.fold(
+      0.0,
+      (prev, curr) => prev + curr.computedAmount,
+    );
+    final diff = _round(total - sum);
+
+    if (diff != 0.0) {
+      throw ValidationException(
+        'Split engine failed to reconcile: total $total vs sum $sum (diff $diff)',
+      );
+    }
+
+    return calculatedSplits;
+  }
+
+  static void validatePayers({
+    required double totalAmount,
+    required List<ExpensePayer> payers,
+  }) {
+    if (payers.isEmpty) throw ValidationException('Payers cannot be empty');
+    if (totalAmount < 0)
+      throw ValidationException('Total amount cannot be negative');
+
+    double sum = 0.0;
+    for (var payer in payers) {
+      if (payer.amountPaid < 0)
+        throw ValidationException('Payer amount cannot be negative');
+      sum += payer.amountPaid;
+    }
+
+    final roundedTotal = _round(totalAmount);
+    final diff = _round(roundedTotal - sum);
+
+    if (diff != 0.0) {
+      throw ValidationException(
+        'Payers total ($_round(sum)) does not match expense total ($roundedTotal)',
+      );
+    }
+  }
+
+  static List<ExpenseSplit> _calculateEqual(
+    double total,
+    List<ExpenseSplit> splits,
+  ) {
+    int count = splits.length;
+    double baseAmount = _round(total / count);
+
+    List<ExpenseSplit> result = [];
+    double currentSum = 0.0;
+
+    for (var i = 0; i < splits.length; i++) {
+      result.add(splits[i].copyWith(computedAmount: baseAmount));
+      currentSum += baseAmount;
+    }
+
+    double diff = _round(total - currentSum);
+    if (diff != 0.0) {
+      final first = result[0];
+      result[0] = first.copyWith(
+        computedAmount: _round(first.computedAmount + diff),
+      );
+    }
+
+    return result;
+  }
+
+  static List<ExpenseSplit> _calculateExact(
+    double total,
+    List<ExpenseSplit> splits,
+  ) {
+    double sum = 0.0;
+    List<ExpenseSplit> result = [];
+    for (var split in splits) {
+      if (split.shareValue < 0)
+        throw ValidationException('Negative share value not allowed');
+      double val = _round(split.shareValue);
+      sum += val;
+      result.add(split.copyWith(computedAmount: val));
+    }
+
+    if (_round(total - sum) != 0.0) {
+      throw ValidationException(
+        'Exact splits sum ($_round(sum)) does not match total ($total)',
+      );
+    }
+    return result;
+  }
+
+  static List<ExpenseSplit> _calculatePercent(
+    double total,
+    List<ExpenseSplit> splits,
+  ) {
+    double totalPercent = 0.0;
+    List<ExpenseSplit> result = [];
+    double currentSum = 0.0;
+
+    for (var split in splits) {
+      if (split.shareValue < 0)
+        throw ValidationException('Negative percent value not allowed');
+      totalPercent += split.shareValue;
+
+      double amount = _round((split.shareValue / 100.0) * total);
+      result.add(split.copyWith(computedAmount: amount));
+      currentSum += amount;
+    }
+
+    if (_round(100.0 - totalPercent) != 0.0) {
+      throw ValidationException('Percentages sum ($totalPercent) must be 100');
+    }
+
+    double diff = _round(total - currentSum);
+    if (diff != 0.0) {
+      final first = result[0];
+      result[0] = first.copyWith(
+        computedAmount: _round(first.computedAmount + diff),
+      );
+    }
+
+    return result;
+  }
+
+  static List<ExpenseSplit> _calculateShare(
+    double total,
+    List<ExpenseSplit> splits,
+  ) {
+    double totalShares = 0.0;
+    for (var split in splits) {
+      if (split.shareValue < 0)
+        throw ValidationException('Negative share value not allowed');
+      totalShares += split.shareValue;
+    }
+
+    if (totalShares == 0.0)
+      throw ValidationException('Total shares cannot be zero');
+
+    List<ExpenseSplit> result = [];
+    double currentSum = 0.0;
+
+    for (var split in splits) {
+      double amount = _round((split.shareValue / totalShares) * total);
+      result.add(split.copyWith(computedAmount: amount));
+      currentSum += amount;
+    }
+
+    double diff = _round(total - currentSum);
+    if (diff != 0.0) {
+      final first = result[0];
+      result[0] = first.copyWith(
+        computedAmount: _round(first.computedAmount + diff),
+      );
+    }
+
+    return result;
+  }
+
+  static double _round(double value) {
+    return double.parse(value.toStringAsFixed(2));
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -937,10 +937,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1470,26 +1470,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/supabase/migrations/20240525000001_split_brain_rpc.sql
+++ b/supabase/migrations/20240525000001_split_brain_rpc.sql
@@ -1,0 +1,151 @@
+-- Migration: Split Brain RPC and Schema Updates
+
+-- 1. Update expenses table
+ALTER TABLE public.expenses
+ADD COLUMN IF NOT EXISTS category_id TEXT,
+ADD COLUMN IF NOT EXISTS description TEXT;
+
+-- Migrate title to description if needed (or keep them sync)
+UPDATE public.expenses SET description = title WHERE description IS NULL;
+
+-- 2. Update expense_splits table to match new requirements
+-- We need share_type (text with check), share_value, computed_amount
+-- Existing: split_type (enum), amount, meta
+
+-- Add new columns
+ALTER TABLE public.expense_splits
+ADD COLUMN IF NOT EXISTS share_type TEXT CHECK (share_type IN ('EQUAL', 'EXACT', 'PERCENT', 'SHARE')),
+ADD COLUMN IF NOT EXISTS share_value NUMERIC(12, 2),
+ADD COLUMN IF NOT EXISTS computed_amount NUMERIC(12, 2);
+
+-- Migrate existing data (best effort)
+UPDATE public.expense_splits
+SET
+  share_type = UPPER(split_type::text),
+  computed_amount = amount,
+  share_value = CASE
+    WHEN split_type = 'percent' THEN 0 -- Unknown, validation might fail if re-run
+    ELSE amount
+  END
+WHERE share_type IS NULL;
+
+-- Make columns NOT NULL after migration (if data allows, otherwise leave nullable or handle cleanup)
+-- For this task, we enforce the new schema for new rows.
+-- ALTER TABLE public.expense_splits ALTER COLUMN share_type SET NOT NULL;
+-- ALTER TABLE public.expense_splits ALTER COLUMN share_value SET NOT NULL;
+-- ALTER TABLE public.expense_splits ALTER COLUMN computed_amount SET NOT NULL;
+
+-- 3. Create RPC function
+CREATE OR REPLACE FUNCTION create_expense_transaction(
+  p_group_id uuid,
+  p_created_by uuid,
+  p_amount_total numeric,
+  p_currency text,
+  p_description text,
+  p_category_id text,
+  p_expense_date timestamptz,
+  p_notes text,
+  p_payers jsonb,
+  p_splits jsonb
+) RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  new_expense_id uuid;
+  payer_record jsonb;
+  split_record jsonb;
+  v_total_paid numeric := 0;
+  v_total_split numeric := 0;
+BEGIN
+  -- 1. Validation (Anti-Tampering)
+  -- Sum of payers must equal total
+  SELECT COALESCE(SUM((p->>'amount_paid')::numeric), 0) INTO v_total_paid
+  FROM jsonb_array_elements(p_payers) AS p;
+
+  IF v_total_paid != p_amount_total THEN
+    RAISE EXCEPTION 'Payer sum (%) does not match total amount (%)', v_total_paid, p_amount_total;
+  END IF;
+
+  -- Sum of splits (computed_amount) must equal total
+  SELECT COALESCE(SUM((s->>'computed_amount')::numeric), 0) INTO v_total_split
+  FROM jsonb_array_elements(p_splits) AS s;
+
+  IF v_total_split != p_amount_total THEN
+    RAISE EXCEPTION 'Split sum (%) does not match total amount (%)', v_total_split, p_amount_total;
+  END IF;
+
+  -- Verify membership (RLS usually handles this, but explicitly checked here if needed)
+  IF p_group_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.group_members
+      WHERE group_id = p_group_id AND user_id = auth.uid()
+    ) THEN
+      RAISE EXCEPTION 'User is not a member of the group';
+    END IF;
+  END IF;
+
+  -- Validate created_by matches auth.uid() (optional, but good practice)
+  IF p_created_by != auth.uid() THEN
+    RAISE EXCEPTION 'User ID mismatch';
+  END IF;
+
+  -- 2. Insert into expenses
+  INSERT INTO public.expenses (
+    group_id,
+    created_by,
+    amount, -- Map p_amount_total to existing 'amount' column
+    currency,
+    title, -- Map p_description to existing 'title' column
+    description, -- Also store in new column
+    category_id,
+    occurred_at, -- Map p_expense_date to 'occurred_at'
+    notes
+  )
+  VALUES (
+    p_group_id,
+    p_created_by,
+    p_amount_total,
+    p_currency,
+    p_description,
+    p_description,
+    p_category_id,
+    p_expense_date,
+    p_notes
+  )
+  RETURNING id INTO new_expense_id;
+
+  -- 3. Insert payers
+  FOR payer_record IN SELECT * FROM jsonb_array_elements(p_payers) LOOP
+    INSERT INTO public.expense_payers (expense_id, payer_user_id, amount) -- Map payer_user_id, amount
+    VALUES (
+      new_expense_id,
+      (payer_record->>'user_id')::uuid,
+      (payer_record->>'amount_paid')::numeric
+    );
+  END LOOP;
+
+  -- 4. Insert splits
+  FOR split_record IN SELECT * FROM jsonb_array_elements(p_splits) LOOP
+    INSERT INTO public.expense_splits (
+      expense_id,
+      user_id,
+      share_type,
+      share_value,
+      computed_amount,
+      amount -- Map computed_amount to legacy 'amount' for compatibility
+    )
+    VALUES (
+      new_expense_id,
+      (split_record->>'user_id')::uuid,
+      split_record->>'share_type',
+      (split_record->>'share_value')::numeric,
+      (split_record->>'computed_amount')::numeric,
+      (split_record->>'computed_amount')::numeric
+    );
+  END LOOP;
+
+  RETURN new_expense_id;
+
+EXCEPTION
+  WHEN OTHERS THEN
+    RAISE EXCEPTION 'Transaction failed: %', SQLERRM;
+END;
+$$;

--- a/test/features/expenses/data/models/expense_model_test.dart
+++ b/test/features/expenses/data/models/expense_model_test.dart
@@ -1,42 +1,63 @@
+import 'package:expense_tracker/features/categories/domain/entities/categorization_status.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category_type.dart';
 import 'package:expense_tracker/features/expenses/data/models/expense_model.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
 import 'package:expense_tracker/features/expenses/domain/entities/expense_payer.dart';
 import 'package:expense_tracker/features/expenses/domain/entities/expense_split.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('ExpenseModel', () {
-    test('toRpcJson generates correct payload', () {
-      final model = ExpenseModel(
-        id: '123',
-        title: 'Dinner',
-        amount: 100.00,
-        date: DateTime(2023, 10, 27, 12, 0, 0),
-        accountId: 'acc1',
-        groupId: 'grp1',
-        createdBy: 'user1',
-        currency: 'USD',
-        notes: 'Yummy',
-        payers: [
-          const ExpensePayer(userId: 'user1', amountPaid: 80.00),
-          const ExpensePayer(userId: 'user2', amountPaid: 20.00),
-        ],
-        splits: [
-          const ExpenseSplit(
-            userId: 'user1',
-            shareType: SplitType.percent,
-            shareValue: 80,
-            computedAmount: 80.00,
-          ),
-          const ExpenseSplit(
-            userId: 'user2',
-            shareType: SplitType.percent,
-            shareValue: 20,
-            computedAmount: 20.00,
-          ),
-        ],
-      );
+    final tDate = DateTime(2023, 10, 27, 12, 0, 0);
+    const tPayer = ExpensePayer(userId: 'user1', amountPaid: 100.00);
+    const tSplit = ExpenseSplit(userId: 'user1', shareType: SplitType.equal, shareValue: 1, computedAmount: 100.00);
 
-      final json = model.toRpcJson();
+    final tExpenseModel = ExpenseModel(
+      id: '123',
+      title: 'Dinner',
+      amount: 100.00,
+      date: tDate,
+      accountId: 'acc1',
+      categoryId: 'cat1',
+      categorizationStatusValue: 'categorized',
+      confidenceScoreValue: 0.9,
+      isRecurring: true,
+      merchantId: 'merch1',
+      groupId: 'grp1',
+      createdBy: 'user1',
+      currency: 'USD',
+      notes: 'Yummy',
+      payers: [tPayer],
+      splits: [tSplit],
+    );
+
+    final tExpenseEntity = Expense(
+      id: '123',
+      title: 'Dinner',
+      amount: 100.00,
+      date: tDate,
+      accountId: 'acc1',
+      // Category is not fully hydrated in fromEntity, only ID is used. But toEntity returns Expense with category=null.
+      // Wait, fromEntity takes Expense (Entity). Does Entity contain Category?
+      // Yes. ExpenseModel.fromEntity reads entity.category?.id.
+      // So here we pass an entity WITH category.
+      category: const Category(id: 'cat1', name: 'Food', iconName: 'food', colorHex: '0xFFFFFF', type: CategoryType.expense, isCustom: false),
+      status: CategorizationStatus.categorized,
+      confidenceScore: 0.9,
+      isRecurring: true,
+      merchantId: 'merch1',
+      groupId: 'grp1',
+      createdBy: 'user1',
+      currency: 'USD',
+      notes: 'Yummy',
+      payers: const [tPayer],
+      splits: const [tSplit],
+    );
+
+    test('toRpcJson generates correct payload', () {
+      final json = tExpenseModel.toRpcJson();
 
       expect(json['p_group_id'], 'grp1');
       expect(json['p_created_by'], 'user1');
@@ -47,16 +68,59 @@ void main() {
       expect(json['p_expense_date'], isNotNull);
 
       final payers = json['p_payers'] as List;
-      expect(payers.length, 2);
+      expect(payers.length, 1);
       expect(payers[0]['user_id'], 'user1');
-      expect(payers[0]['amount_paid'], 80.00);
+      expect(payers[0]['amount_paid'], 100.00);
 
       final splits = json['p_splits'] as List;
-      expect(splits.length, 2);
+      expect(splits.length, 1);
       expect(splits[0]['user_id'], 'user1');
-      expect(splits[0]['share_type'], 'PERCENT');
-      expect(splits[0]['share_value'], 80.0);
-      expect(splits[0]['computed_amount'], 80.00);
+      expect(splits[0]['share_type'], 'EQUAL');
+      expect(splits[0]['share_value'], 1.0);
+      expect(splits[0]['computed_amount'], 100.00);
+    });
+
+    test('fromEntity creates correct model', () {
+      final result = ExpenseModel.fromEntity(tExpenseEntity);
+
+      expect(result.id, tExpenseModel.id);
+      expect(result.title, tExpenseModel.title);
+      expect(result.amount, tExpenseModel.amount);
+      expect(result.date, tExpenseModel.date);
+      expect(result.accountId, tExpenseModel.accountId);
+      expect(result.categoryId, tExpenseModel.categoryId);
+      expect(result.categorizationStatusValue, tExpenseModel.categorizationStatusValue);
+      expect(result.confidenceScoreValue, tExpenseModel.confidenceScoreValue);
+      expect(result.isRecurring, tExpenseModel.isRecurring);
+      expect(result.merchantId, tExpenseModel.merchantId);
+      expect(result.groupId, tExpenseModel.groupId);
+      expect(result.createdBy, tExpenseModel.createdBy);
+      expect(result.currency, tExpenseModel.currency);
+      expect(result.notes, tExpenseModel.notes);
+      expect(result.payers, tExpenseModel.payers);
+      expect(result.splits, tExpenseModel.splits);
+    });
+
+    test('toEntity creates correct entity', () {
+      final result = tExpenseModel.toEntity();
+
+      expect(result.id, tExpenseEntity.id);
+      expect(result.title, tExpenseEntity.title);
+      expect(result.amount, tExpenseEntity.amount);
+      expect(result.date, tExpenseEntity.date);
+      expect(result.accountId, tExpenseEntity.accountId);
+      // Category is null in toEntity result as per implementation (hydrated later)
+      expect(result.category, isNull);
+      expect(result.status, tExpenseEntity.status);
+      expect(result.confidenceScore, tExpenseEntity.confidenceScore);
+      expect(result.isRecurring, tExpenseEntity.isRecurring);
+      expect(result.merchantId, tExpenseEntity.merchantId);
+      expect(result.groupId, tExpenseEntity.groupId);
+      expect(result.createdBy, tExpenseEntity.createdBy);
+      expect(result.currency, tExpenseEntity.currency);
+      expect(result.notes, tExpenseEntity.notes);
+      expect(result.payers, tExpenseEntity.payers);
+      expect(result.splits, tExpenseEntity.splits);
     });
   });
 }

--- a/test/features/expenses/data/models/expense_model_test.dart
+++ b/test/features/expenses/data/models/expense_model_test.dart
@@ -12,7 +12,12 @@ void main() {
   group('ExpenseModel', () {
     final tDate = DateTime(2023, 10, 27, 12, 0, 0);
     const tPayer = ExpensePayer(userId: 'user1', amountPaid: 100.00);
-    const tSplit = ExpenseSplit(userId: 'user1', shareType: SplitType.equal, shareValue: 1, computedAmount: 100.00);
+    const tSplit = ExpenseSplit(
+      userId: 'user1',
+      shareType: SplitType.equal,
+      shareValue: 1,
+      computedAmount: 100.00,
+    );
 
     final tExpenseModel = ExpenseModel(
       id: '123',
@@ -43,7 +48,14 @@ void main() {
       // Wait, fromEntity takes Expense (Entity). Does Entity contain Category?
       // Yes. ExpenseModel.fromEntity reads entity.category?.id.
       // So here we pass an entity WITH category.
-      category: const Category(id: 'cat1', name: 'Food', iconName: 'food', colorHex: '0xFFFFFF', type: CategoryType.expense, isCustom: false),
+      category: const Category(
+        id: 'cat1',
+        name: 'Food',
+        iconName: 'food',
+        colorHex: '0xFFFFFF',
+        type: CategoryType.expense,
+        isCustom: false,
+      ),
       status: CategorizationStatus.categorized,
       confidenceScore: 0.9,
       isRecurring: true,
@@ -89,7 +101,10 @@ void main() {
       expect(result.date, tExpenseModel.date);
       expect(result.accountId, tExpenseModel.accountId);
       expect(result.categoryId, tExpenseModel.categoryId);
-      expect(result.categorizationStatusValue, tExpenseModel.categorizationStatusValue);
+      expect(
+        result.categorizationStatusValue,
+        tExpenseModel.categorizationStatusValue,
+      );
       expect(result.confidenceScoreValue, tExpenseModel.confidenceScoreValue);
       expect(result.isRecurring, tExpenseModel.isRecurring);
       expect(result.merchantId, tExpenseModel.merchantId);

--- a/test/features/expenses/data/models/expense_model_test.dart
+++ b/test/features/expenses/data/models/expense_model_test.dart
@@ -1,130 +1,62 @@
-import 'package:expense_tracker/features/categories/domain/entities/categorization_status.dart';
-import 'package:expense_tracker/features/categories/domain/entities/category.dart';
-import 'package:expense_tracker/features/categories/domain/entities/category_type.dart';
 import 'package:expense_tracker/features/expenses/data/models/expense_model.dart';
-import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense_payer.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense_split.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  final tDate = DateTime(2024, 1, 1);
-  final tExpenseModel = ExpenseModel(
-    id: '1',
-    title: 'Test Expense',
-    amount: 100.0,
-    date: tDate,
-    accountId: 'acc1',
-    categoryId: 'cat1',
-    categorizationStatusValue: 'categorized',
-    confidenceScoreValue: 0.9,
-    merchantId: 'merch1',
-    isRecurring: true,
-  );
+  group('ExpenseModel', () {
+    test('toRpcJson generates correct payload', () {
+      final model = ExpenseModel(
+        id: '123',
+        title: 'Dinner',
+        amount: 100.00,
+        date: DateTime(2023, 10, 27, 12, 0, 0),
+        accountId: 'acc1',
+        groupId: 'grp1',
+        createdBy: 'user1',
+        currency: 'USD',
+        notes: 'Yummy',
+        payers: [
+          const ExpensePayer(userId: 'user1', amountPaid: 80.00),
+          const ExpensePayer(userId: 'user2', amountPaid: 20.00),
+        ],
+        splits: [
+          const ExpenseSplit(
+            userId: 'user1',
+            shareType: SplitType.percent,
+            shareValue: 80,
+            computedAmount: 80.00,
+          ),
+          const ExpenseSplit(
+            userId: 'user2',
+            shareType: SplitType.percent,
+            shareValue: 20,
+            computedAmount: 20.00,
+          ),
+        ],
+      );
 
-  final tExpenseEntity = Expense(
-    id: '1',
-    title: 'Test Expense',
-    amount: 100.0,
-    date: tDate,
-    accountId: 'acc1',
-    category: const Category(
-      id: 'cat1',
-      name: 'Test Category',
-      iconName: 'test_icon',
-      colorHex: '#000000',
-      type: CategoryType.expense,
-      isCustom: false,
-    ),
-    status: CategorizationStatus.categorized,
-    confidenceScore: 0.9,
-    merchantId: 'merch1',
-    isRecurring: true,
-  );
+      final json = model.toRpcJson();
 
-  test('should return a valid model from JSON', () {
-    // Arrange
-    final jsonMap = {
-      'id': '1',
-      'title': 'Test Expense',
-      'amount': 100.0,
-      'date': '2024-01-01T00:00:00.000',
-      'accountId': 'acc1',
-      'categoryId': 'cat1',
-      'categorizationStatusValue': 'categorized',
-      'confidenceScoreValue': 0.9,
-      'merchantId': 'merch1',
-      'isRecurring': true,
-    };
+      expect(json['p_group_id'], 'grp1');
+      expect(json['p_created_by'], 'user1');
+      expect(json['p_amount_total'], 100.00);
+      expect(json['p_currency'], 'USD');
+      expect(json['p_description'], 'Dinner');
+      expect(json['p_notes'], 'Yummy');
+      expect(json['p_expense_date'], isNotNull);
 
-    // Act
-    final result = ExpenseModel.fromJson(jsonMap);
+      final payers = json['p_payers'] as List;
+      expect(payers.length, 2);
+      expect(payers[0]['user_id'], 'user1');
+      expect(payers[0]['amount_paid'], 80.00);
 
-    // Assert
-    expect(result.id, tExpenseModel.id);
-    expect(result.title, tExpenseModel.title);
-    expect(result.amount, tExpenseModel.amount);
-    expect(result.date, tExpenseModel.date);
-    expect(result.accountId, tExpenseModel.accountId);
-    expect(result.categoryId, tExpenseModel.categoryId);
-    expect(
-      result.categorizationStatusValue,
-      tExpenseModel.categorizationStatusValue,
-    );
-    expect(result.confidenceScoreValue, tExpenseModel.confidenceScoreValue);
-    expect(result.merchantId, tExpenseModel.merchantId);
-    expect(result.isRecurring, tExpenseModel.isRecurring);
-  });
-
-  test('should return a JSON map containing proper data', () {
-    // Act
-    final result = tExpenseModel.toJson();
-
-    // Assert
-    final expectedMap = {
-      'id': '1',
-      'title': 'Test Expense',
-      'amount': 100.0,
-      'date': '2024-01-01T00:00:00.000',
-      'accountId': 'acc1',
-      'categoryId': 'cat1',
-      'categorizationStatusValue': 'categorized',
-      'confidenceScoreValue': 0.9,
-      'merchantId': 'merch1',
-      'isRecurring': true,
-    };
-    expect(result, expectedMap);
-  });
-
-  test('should convert from Entity to Model correctly', () {
-    // Act
-    final result = ExpenseModel.fromEntity(tExpenseEntity);
-
-    // Assert
-    expect(result.id, tExpenseEntity.id);
-    expect(result.title, tExpenseEntity.title);
-    expect(result.amount, tExpenseEntity.amount);
-    expect(result.date, tExpenseEntity.date);
-    expect(result.accountId, tExpenseEntity.accountId);
-    expect(result.categoryId, tExpenseEntity.category?.id);
-    expect(result.categorizationStatusValue, 'categorized'); // Enum value check
-    expect(result.confidenceScoreValue, tExpenseEntity.confidenceScore);
-    expect(result.merchantId, tExpenseEntity.merchantId);
-    expect(result.isRecurring, tExpenseEntity.isRecurring);
-  });
-
-  test('should convert from Model to Entity correctly (category is null)', () {
-    // Act
-    final result = tExpenseModel.toEntity();
-
-    // Assert
-    expect(result.id, tExpenseModel.id);
-    expect(result.title, tExpenseModel.title);
-    expect(result.amount, tExpenseModel.amount);
-    expect(result.date, tExpenseModel.date);
-    expect(result.accountId, tExpenseModel.accountId);
-    expect(result.category, isNull); // Category is not hydrated in toEntity
-    expect(result.status, CategorizationStatus.categorized);
-    expect(result.confidenceScore, tExpenseModel.confidenceScoreValue);
-    expect(result.merchantId, tExpenseModel.merchantId);
-    expect(result.isRecurring, tExpenseModel.isRecurring);
+      final splits = json['p_splits'] as List;
+      expect(splits.length, 2);
+      expect(splits[0]['user_id'], 'user1');
+      expect(splits[0]['share_type'], 'PERCENT');
+      expect(splits[0]['share_value'], 80.0);
+      expect(splits[0]['computed_amount'], 80.00);
+    });
   });
 }

--- a/test/features/expenses/data/repositories/expense_repository_impl_legacy_test.dart
+++ b/test/features/expenses/data/repositories/expense_repository_impl_legacy_test.dart
@@ -6,23 +6,29 @@ import 'package:expense_tracker/features/expenses/data/repositories/expense_repo
 import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class MockExpenseLocalDataSource extends Mock
     implements ExpenseLocalDataSource {}
 
 class MockCategoryRepository extends Mock implements CategoryRepository {}
 
+class MockSupabaseClient extends Mock implements SupabaseClient {}
+
 void main() {
   late MockExpenseLocalDataSource mockDataSource;
   late MockCategoryRepository mockCategoryRepository;
+  late MockSupabaseClient mockSupabaseClient;
   late ExpenseRepositoryImpl repository;
 
   setUp(() {
     mockDataSource = MockExpenseLocalDataSource();
     mockCategoryRepository = MockCategoryRepository();
+    mockSupabaseClient = MockSupabaseClient();
     repository = ExpenseRepositoryImpl(
       localDataSource: mockDataSource,
       categoryRepository: mockCategoryRepository,
+      supabaseClient: mockSupabaseClient,
     );
   });
 

--- a/test/features/expenses/data/repositories/expense_repository_impl_test.dart
+++ b/test/features/expenses/data/repositories/expense_repository_impl_test.dart
@@ -1,269 +1,151 @@
-import 'package:dartz/dartz.dart';
-import 'package:expense_tracker/core/error/failure.dart';
-import 'package:expense_tracker/features/categories/domain/entities/categorization_status.dart';
-import 'package:expense_tracker/features/categories/domain/entities/category.dart';
-import 'package:expense_tracker/features/categories/domain/entities/category_type.dart';
-import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
+import 'dart:async';
 import 'package:expense_tracker/features/expenses/data/datasources/expense_local_data_source.dart';
-import 'package:expense_tracker/features/expenses/data/models/expense_model.dart';
 import 'package:expense_tracker/features/expenses/data/repositories/expense_repository_impl.dart';
 import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense_payer.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense_split.dart';
+import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class MockExpenseLocalDataSource extends Mock
     implements ExpenseLocalDataSource {}
 
 class MockCategoryRepository extends Mock implements CategoryRepository {}
 
-class FakeExpenseModel extends Fake implements ExpenseModel {}
+class MockSupabaseClient extends Mock implements SupabaseClient {}
+
+class FakePostgrestFilterBuilder<T> extends Fake
+    implements PostgrestFilterBuilder<T> {
+  final T _value;
+  FakePostgrestFilterBuilder(this._value);
+
+  @override
+  Future<R> then<R>(
+    FutureOr<R> Function(T value) onValue, {
+    Function? onError,
+  }) {
+    return Future.value(onValue(_value));
+  }
+}
 
 void main() {
   late ExpenseRepositoryImpl repository;
   late MockExpenseLocalDataSource mockLocalDataSource;
   late MockCategoryRepository mockCategoryRepository;
+  late MockSupabaseClient mockSupabaseClient;
 
   setUpAll(() {
-    registerFallbackValue(FakeExpenseModel());
+    registerFallbackValue(<String, dynamic>{});
   });
 
   setUp(() {
     mockLocalDataSource = MockExpenseLocalDataSource();
     mockCategoryRepository = MockCategoryRepository();
+    mockSupabaseClient = MockSupabaseClient();
     repository = ExpenseRepositoryImpl(
       localDataSource: mockLocalDataSource,
       categoryRepository: mockCategoryRepository,
+      supabaseClient: mockSupabaseClient,
     );
   });
 
-  const tCategory = Category(
-    id: 'cat1',
-    name: 'Food',
-    iconName: 'food',
-    colorHex: '#000000',
-    type: CategoryType.expense,
-    isCustom: false,
-  );
+  group('createExpenseTransaction', () {
+    final tExpense = Expense(
+      id: 'temp-id',
+      title: 'Dinner',
+      amount: 100.00,
+      date: DateTime.now(),
+      accountId: 'acc1',
+      groupId: 'grp1',
+      createdBy: 'user1',
+      currency: 'USD',
+      payers: const [ExpensePayer(userId: 'user1', amountPaid: 100.00)],
+      splits: const [
+        ExpenseSplit(
+          userId: 'user1',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 100.00,
+        ),
+      ],
+    );
 
-  final tExpenseModel = ExpenseModel(
-    id: '1',
-    title: 'Lunch',
-    amount: 15.0,
-    date: DateTime(2024, 1, 1),
-    accountId: 'acc1',
-    categoryId: 'cat1',
-    categorizationStatusValue: 'categorized',
-    confidenceScoreValue: 1.0,
-  );
-
-  final tExpense = Expense(
-    id: '1',
-    title: 'Lunch',
-    amount: 15.0,
-    date: DateTime(2024, 1, 1),
-    accountId: 'acc1',
-    category: tCategory,
-    status: CategorizationStatus.categorized,
-    confidenceScore: 1.0,
-  );
-
-  group('addExpense', () {
     test(
-      'should return hydrated Expense when data source call is successful',
+      'should call Supabase RPC and return updated expense on success',
       () async {
         // Arrange
+        final fakeBuilder = FakePostgrestFilterBuilder<String>(
+          'new-uuid',
+        ); // Explicit type String
+
+        // Match exactly on the function name, and any params
         when(
-          () => mockLocalDataSource.addExpense(any()),
-        ).thenAnswer((_) async => tExpenseModel);
-        when(
-          () => mockCategoryRepository.getCategoryById(any()),
-        ).thenAnswer((_) async => const Right(tCategory));
+          () => mockSupabaseClient.rpc<String>(
+            // Explicit generic
+            'create_expense_transaction',
+            params: any(named: 'params'),
+          ),
+        ).thenAnswer((_) => fakeBuilder);
 
         // Act
-        final result = await repository.addExpense(tExpense);
+        final result = await repository.createExpenseTransaction(tExpense);
 
         // Assert
         verify(
-          () => mockLocalDataSource.addExpense(any<ExpenseModel>()),
+          () => mockSupabaseClient.rpc<String>(
+            'create_expense_transaction',
+            params: any(named: 'params'),
+          ),
         ).called(1);
-        verify(() => mockCategoryRepository.getCategoryById('cat1')).called(1);
-        expect(result, Right(tExpense));
+
+        expect(result.isRight(), true);
+        result.fold(
+          (l) => fail('Should be Right but got $l'),
+          (r) => expect(r.id, 'new-uuid'),
+        );
       },
     );
 
-    test(
-      'should return CacheFailure when data source throws CacheFailure',
-      () async {
-        // Arrange
-        when(
-          () => mockLocalDataSource.addExpense(any()),
-        ).thenThrow(const CacheFailure('Hive Error'));
-
-        // Act
-        final result = await repository.addExpense(tExpense);
-
-        // Assert
-        expect(result, const Left(CacheFailure('Hive Error')));
-      },
-    );
-  });
-
-  group('deleteExpense', () {
-    test('should return void when delete is successful', () async {
-      // Arrange
-      when(
-        () => mockLocalDataSource.deleteExpense(any()),
-      ).thenAnswer((_) async => Future.value());
-
-      // Act
-      final result = await repository.deleteExpense('1');
-
-      // Assert
-      verify(() => mockLocalDataSource.deleteExpense('1')).called(1);
-      expect(result, const Right(null));
-    });
-
-    test('should return CacheFailure when delete fails', () async {
-      // Arrange
-      when(
-        () => mockLocalDataSource.deleteExpense(any()),
-      ).thenThrow(const CacheFailure('Delete Error'));
-
-      // Act
-      final result = await repository.deleteExpense('1');
-
-      // Assert
-      expect(result, const Left(CacheFailure('Delete Error')));
-    });
-  });
-
-  group('getExpenses', () {
-    test('should return list of ExpenseModels from data source', () async {
-      // Arrange
-      when(
-        () => mockLocalDataSource.getExpenses(
-          startDate: any(named: 'startDate'),
-          endDate: any(named: 'endDate'),
-          categoryId: any(named: 'categoryId'),
-          accountId: any(named: 'accountId'),
-        ),
-      ).thenAnswer((_) async => [tExpenseModel]);
-
-      // Act
-      final result = await repository.getExpenses();
-
-      // Assert
-      verify(
-        () => mockLocalDataSource.getExpenses(
-          startDate: null,
-          endDate: null,
-          categoryId: null,
-          accountId: null,
-        ),
-      ).called(1);
-      // expect(result, Right([tExpenseModel])); // Fails due to list identity
-      expect(result.isRight(), isTrue);
-      result.fold((l) => fail('should be right'), (r) {
-        expect(r, [tExpenseModel]);
-      });
-    });
-
-    test('should return CacheFailure when getting expenses fails', () async {
-      // Arrange
-      when(
-        () => mockLocalDataSource.getExpenses(
-          startDate: any(named: 'startDate'),
-          endDate: any(named: 'endDate'),
-          categoryId: any(named: 'categoryId'),
-          accountId: any(named: 'accountId'),
-        ),
-      ).thenThrow(const CacheFailure('Fetch Error'));
-
-      // Act
-      final result = await repository.getExpenses();
-
-      // Assert
-      expect(result, const Left(CacheFailure('Fetch Error')));
-    });
-  });
-
-  group('updateExpense', () {
-    test('should return updated Expense when successful', () async {
-      // Arrange
-      when(
-        () => mockLocalDataSource.updateExpense(any()),
-      ).thenAnswer((_) async => tExpenseModel);
-      when(
-        () => mockCategoryRepository.getCategoryById(any()),
-      ).thenAnswer((_) async => const Right(tCategory));
-
-      // Act
-      final result = await repository.updateExpense(tExpense);
-
-      // Assert
-      verify(
-        () => mockLocalDataSource.updateExpense(any<ExpenseModel>()),
-      ).called(1);
-      expect(result, Right(tExpense));
-    });
-
-    test('should return CacheFailure when update fails', () async {
-      // Arrange
-      when(
-        () => mockLocalDataSource.updateExpense(any()),
-      ).thenThrow(const CacheFailure('Update Error'));
-
-      // Act
-      final result = await repository.updateExpense(tExpense);
-
-      // Assert
-      expect(result, const Left(CacheFailure('Update Error')));
-    });
-  });
-
-  group('updateExpenseCategorization', () {
-    test('should update expense categorization successfully', () async {
-      // Arrange
-      when(
-        () => mockLocalDataSource.getExpenseById(any()),
-      ).thenAnswer((_) async => tExpenseModel);
-      when(
-        () => mockLocalDataSource.updateExpense(any()),
-      ).thenAnswer((_) async => tExpenseModel);
-
-      // Act
-      final result = await repository.updateExpenseCategorization(
-        '1',
-        'cat2',
-        CategorizationStatus.needsReview,
-        0.8,
+    test('should return Failure when validation fails locally', () async {
+      // Arrange - Invalid split (sum != total)
+      final invalidExpense = tExpense.copyWith(
+        amount: 100.00,
+        splits: const [
+          ExpenseSplit(
+            userId: 'user1',
+            shareType: SplitType.equal,
+            shareValue: 1,
+            computedAmount: 50.00,
+          ),
+        ],
       );
 
+      // Act
+      final result = await repository.createExpenseTransaction(invalidExpense);
+
       // Assert
-      verify(() => mockLocalDataSource.getExpenseById('1')).called(1);
-      verify(
-        () => mockLocalDataSource.updateExpense(any<ExpenseModel>()),
-      ).called(1);
-      expect(result, const Right(null));
+      expect(result.isLeft(), true);
+      verifyNever(
+        () => mockSupabaseClient.rpc(any(), params: any(named: 'params')),
+      );
     });
 
-    test('should return CacheFailure if expense not found', () async {
+    test('should return Failure when RPC fails', () async {
       // Arrange
       when(
-        () => mockLocalDataSource.getExpenseById(any()),
-      ).thenAnswer((_) async => null);
+        () => mockSupabaseClient.rpc<String>(
+          'create_expense_transaction',
+          params: any(named: 'params'),
+        ),
+      ).thenThrow(const PostgrestException(message: 'RPC Error'));
 
       // Act
-      final result = await repository.updateExpenseCategorization(
-        '1',
-        'cat2',
-        CategorizationStatus.needsReview,
-        0.8,
-      );
+      final result = await repository.createExpenseTransaction(tExpense);
 
       // Assert
-      expect(result, const Left(CacheFailure("Expense not found.")));
-      verifyNever(() => mockLocalDataSource.updateExpense(any()));
+      expect(result.isLeft(), true);
     });
   });
 }

--- a/test/features/expenses/domain/entities/expense_payer_test.dart
+++ b/test/features/expenses/domain/entities/expense_payer_test.dart
@@ -1,0 +1,13 @@
+import 'package:expense_tracker/features/expenses/domain/entities/expense_payer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ExpensePayer', () {
+    test('supports value equality', () {
+      const payer1 = ExpensePayer(userId: 'u1', amountPaid: 50.0);
+      const payer2 = ExpensePayer(userId: 'u1', amountPaid: 50.0);
+
+      expect(payer1, equals(payer2));
+    });
+  });
+}

--- a/test/features/expenses/domain/entities/expense_split_test.dart
+++ b/test/features/expenses/domain/entities/expense_split_test.dart
@@ -1,0 +1,35 @@
+import 'package:expense_tracker/features/expenses/domain/entities/expense_split.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ExpenseSplit', () {
+    const tSplit = ExpenseSplit(
+      userId: 'u1',
+      shareType: SplitType.equal,
+      shareValue: 1.0,
+      computedAmount: 33.33,
+    );
+
+    test('supports value equality', () {
+      const tSplit2 = ExpenseSplit(
+        userId: 'u1',
+        shareType: SplitType.equal,
+        shareValue: 1.0,
+        computedAmount: 33.33,
+      );
+
+      expect(tSplit, equals(tSplit2));
+    });
+
+    test('copyWith updates fields', () {
+      final updated = tSplit.copyWith(
+        computedAmount: 33.34,
+        shareType: SplitType.percent,
+      );
+
+      expect(updated.computedAmount, 33.34);
+      expect(updated.shareType, SplitType.percent);
+      expect(updated.userId, tSplit.userId); // Unchanged
+    });
+  });
+}

--- a/test/features/expenses/domain/entities/expense_test.dart
+++ b/test/features/expenses/domain/entities/expense_test.dart
@@ -10,8 +10,20 @@ void main() {
   group('Expense', () {
     final tDate = DateTime(2023, 10, 27);
     const tPayer = ExpensePayer(userId: 'user1', amountPaid: 100.00);
-    const tSplit = ExpenseSplit(userId: 'user1', shareType: SplitType.equal, shareValue: 1, computedAmount: 100.00);
-    const tCategory = Category(id: 'cat1', name: 'Food', iconName: 'food', colorHex: '0xFFFFFF', type: CategoryType.expense, isCustom: false);
+    const tSplit = ExpenseSplit(
+      userId: 'user1',
+      shareType: SplitType.equal,
+      shareValue: 1,
+      computedAmount: 100.00,
+    );
+    const tCategory = Category(
+      id: 'cat1',
+      name: 'Food',
+      iconName: 'food',
+      colorHex: '0xFFFFFF',
+      type: CategoryType.expense,
+      isCustom: false,
+    );
 
     final tExpense = Expense(
       id: '1',

--- a/test/features/expenses/domain/entities/expense_test.dart
+++ b/test/features/expenses/domain/entities/expense_test.dart
@@ -1,0 +1,89 @@
+import 'package:expense_tracker/features/categories/domain/entities/categorization_status.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category_type.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense_payer.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense_split.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Expense', () {
+    final tDate = DateTime(2023, 10, 27);
+    const tPayer = ExpensePayer(userId: 'user1', amountPaid: 100.00);
+    const tSplit = ExpenseSplit(userId: 'user1', shareType: SplitType.equal, shareValue: 1, computedAmount: 100.00);
+    const tCategory = Category(id: 'cat1', name: 'Food', iconName: 'food', colorHex: '0xFFFFFF', type: CategoryType.expense, isCustom: false);
+
+    final tExpense = Expense(
+      id: '1',
+      title: 'Dinner',
+      amount: 100.00,
+      date: tDate,
+      accountId: 'acc1',
+      category: tCategory,
+      status: CategorizationStatus.categorized,
+      confidenceScore: 0.9,
+      isRecurring: true,
+      merchantId: 'merch1',
+      groupId: 'grp1',
+      createdBy: 'user1',
+      currency: 'USD',
+      notes: 'Yummy',
+      payers: const [tPayer],
+      splits: const [tSplit],
+    );
+
+    test('supports value equality', () {
+      final tExpense2 = Expense(
+        id: '1',
+        title: 'Dinner',
+        amount: 100.00,
+        date: tDate,
+        accountId: 'acc1',
+        category: tCategory,
+        status: CategorizationStatus.categorized,
+        confidenceScore: 0.9,
+        isRecurring: true,
+        merchantId: 'merch1',
+        groupId: 'grp1',
+        createdBy: 'user1',
+        currency: 'USD',
+        notes: 'Yummy',
+        payers: const [tPayer],
+        splits: const [tSplit],
+      );
+
+      expect(tExpense, equals(tExpense2));
+    });
+
+    test('copyWith updates fields', () {
+      final updated = tExpense.copyWith(
+        title: 'Lunch',
+        amount: 50.00,
+        groupId: 'grp2',
+        notes: 'Okay',
+      );
+
+      expect(updated.title, 'Lunch');
+      expect(updated.amount, 50.00);
+      expect(updated.groupId, 'grp2');
+      expect(updated.notes, 'Okay');
+      expect(updated.id, tExpense.id); // Unchanged
+    });
+
+    test('copyWith can clear nullable fields', () {
+      final updated = tExpense.copyWith(
+        categoryOrNull: () => null,
+        confidenceScoreOrNull: () => null,
+        merchantIdOrNull: () => null,
+        groupIdOrNull: () => null,
+        notesOrNull: () => null,
+      );
+
+      expect(updated.category, isNull);
+      expect(updated.confidenceScore, isNull);
+      expect(updated.merchantId, isNull);
+      expect(updated.groupId, isNull);
+      expect(updated.notes, isNull);
+    });
+  });
+}

--- a/test/features/expenses/domain/utils/split_engine_test.dart
+++ b/test/features/expenses/domain/utils/split_engine_test.dart
@@ -1,0 +1,361 @@
+import 'package:expense_tracker/features/expenses/domain/entities/expense_payer.dart';
+import 'package:expense_tracker/features/expenses/domain/entities/expense_split.dart';
+import 'package:expense_tracker/features/expenses/domain/utils/split_engine.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SplitEngine', () {
+    test('EQUAL splits: 100 / 3', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'B',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'C',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+      ];
+      final result = SplitEngine.calculateSplits(
+        totalAmount: 100.00,
+        splits: splits,
+      );
+
+      expect(result[0].computedAmount, 33.34); // Remainder assigned to first
+      expect(result[1].computedAmount, 33.33);
+      expect(result[2].computedAmount, 33.33);
+      expect(result.fold(0.0, (sum, s) => sum + s.computedAmount), 100.00);
+    });
+
+    test('EQUAL splits: 10 / 3', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'B',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'C',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+      ];
+      final result = SplitEngine.calculateSplits(
+        totalAmount: 10.00,
+        splits: splits,
+      );
+
+      expect(result[0].computedAmount, 3.34);
+      expect(result[1].computedAmount, 3.33);
+      expect(result[2].computedAmount, 3.33);
+    });
+
+    test('EQUAL splits: 0.01 / 2', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'B',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+      ];
+      final result = SplitEngine.calculateSplits(
+        totalAmount: 0.01,
+        splits: splits,
+      );
+
+      expect(result[0].computedAmount, 0.00);
+      expect(result[1].computedAmount, 0.01);
+    });
+
+    test('EXACT splits: exact match', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.exact,
+          shareValue: 50.00,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'B',
+          shareType: SplitType.exact,
+          shareValue: 50.00,
+          computedAmount: 0,
+        ),
+      ];
+      final result = SplitEngine.calculateSplits(
+        totalAmount: 100.00,
+        splits: splits,
+      );
+
+      expect(result[0].computedAmount, 50.00);
+      expect(result[1].computedAmount, 50.00);
+    });
+
+    test('EXACT splits: mismatch throws exception', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.exact,
+          shareValue: 50.00,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'B',
+          shareType: SplitType.exact,
+          shareValue: 40.00,
+          computedAmount: 0,
+        ),
+      ];
+      expect(
+        () => SplitEngine.calculateSplits(totalAmount: 100.00, splits: splits),
+        throwsA(isA<ValidationException>()),
+      );
+    });
+
+    test('PERCENT splits: 40% + 60% of 100', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.percent,
+          shareValue: 40,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'B',
+          shareType: SplitType.percent,
+          shareValue: 60,
+          computedAmount: 0,
+        ),
+      ];
+      final result = SplitEngine.calculateSplits(
+        totalAmount: 100.00,
+        splits: splits,
+      );
+
+      expect(result[0].computedAmount, 40.00);
+      expect(result[1].computedAmount, 60.00);
+    });
+
+    test('PERCENT splits: rounding 33.33% of 100', () {
+      // 33.33 + 33.33 + 33.34 = 100%
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.percent,
+          shareValue: 33.33,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'B',
+          shareType: SplitType.percent,
+          shareValue: 33.33,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'C',
+          shareType: SplitType.percent,
+          shareValue: 33.34,
+          computedAmount: 0,
+        ),
+      ];
+      final result = SplitEngine.calculateSplits(
+        totalAmount: 100.00,
+        splits: splits,
+      );
+
+      // 33.33% of 100 is 33.33. Sum is 99.99 + 0.01 (last one is 33.34 so it is 33.34)
+      // Wait: 33.33 * 100 / 100 = 33.33.
+      // 33.34 * 100 / 100 = 33.34.
+      // Sum = 100.00. No remainder needed.
+      expect(result[0].computedAmount, 33.33);
+      expect(result[1].computedAmount, 33.33);
+      expect(result[2].computedAmount, 33.34);
+    });
+
+    test('PERCENT splits: not 100% throws', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.percent,
+          shareValue: 40,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'B',
+          shareType: SplitType.percent,
+          shareValue: 40,
+          computedAmount: 0,
+        ),
+      ];
+      expect(
+        () => SplitEngine.calculateSplits(totalAmount: 100.00, splits: splits),
+        throwsA(isA<ValidationException>()),
+      );
+    });
+
+    test('SHARE splits: 2 shares + 1 share of 100', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.share,
+          shareValue: 2,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'B',
+          shareType: SplitType.share,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+      ];
+      final result = SplitEngine.calculateSplits(
+        totalAmount: 100.00,
+        splits: splits,
+      );
+
+      // Total shares = 3.
+      // A: 2/3 * 100 = 66.666... -> 66.67
+      // B: 1/3 * 100 = 33.333... -> 33.33
+      // Sum: 100.00.
+
+      // Let's check with engine logic:
+      // A: round(66.666) = 66.67
+      // B: round(33.333) = 33.33
+      // Sum = 100.00. Diff 0.
+
+      expect(result[0].computedAmount, 66.67);
+      expect(result[1].computedAmount, 33.33);
+    });
+
+    test('SHARE splits: 1 share each (like equal) of 100', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.share,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'B',
+          shareType: SplitType.share,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'C',
+          shareType: SplitType.share,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+      ];
+      final result = SplitEngine.calculateSplits(
+        totalAmount: 100.00,
+        splits: splits,
+      );
+
+      // 100/3 = 33.33. Remainder 0.01 to first.
+      expect(result[0].computedAmount, 33.34);
+      expect(result[1].computedAmount, 33.33);
+      expect(result[2].computedAmount, 33.33);
+    });
+
+    test('Mixed split types throws', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+        const ExpenseSplit(
+          userId: 'B',
+          shareType: SplitType.percent,
+          shareValue: 50,
+          computedAmount: 0,
+        ),
+      ];
+      expect(
+        () => SplitEngine.calculateSplits(totalAmount: 100.00, splits: splits),
+        throwsA(isA<ValidationException>()),
+      );
+    });
+
+    test('Zero total returns zero splits', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+      ];
+      final result = SplitEngine.calculateSplits(
+        totalAmount: 0.00,
+        splits: splits,
+      );
+      expect(result[0].computedAmount, 0.00);
+    });
+
+    test('Negative total throws', () {
+      final splits = [
+        const ExpenseSplit(
+          userId: 'A',
+          shareType: SplitType.equal,
+          shareValue: 1,
+          computedAmount: 0,
+        ),
+      ];
+      expect(
+        () => SplitEngine.calculateSplits(totalAmount: -10.00, splits: splits),
+        throwsA(isA<ValidationException>()),
+      );
+    });
+
+    test('Validate Payers: Success', () {
+      final payers = [
+        const ExpensePayer(userId: 'A', amountPaid: 80.00),
+        const ExpensePayer(userId: 'B', amountPaid: 20.00),
+      ];
+      expect(
+        () => SplitEngine.validatePayers(totalAmount: 100.00, payers: payers),
+        returnsNormally,
+      );
+    });
+
+    test('Validate Payers: Mismatch throws', () {
+      final payers = [
+        const ExpensePayer(userId: 'A', amountPaid: 80.00),
+        const ExpensePayer(userId: 'B', amountPaid: 10.00),
+      ];
+      expect(
+        () => SplitEngine.validatePayers(totalAmount: 100.00, payers: payers),
+        throwsA(isA<ValidationException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Implemented the "Split Brain" transaction engine (Phase 3A) for handling complex expense splits (EQUAL, EXACT, PERCENT, SHARE) deterministically and atomically.

Key changes:
- Created `SplitEngine` domain utility with unit tests covering edge cases (e.g. 100/3, remainder allocation).
- Updated `Expense` entity and `ExpenseModel` to support `groupId`, `createdBy`, `currency`, `payers` (List), and `splits` (List).
- Implemented `createExpenseTransaction` in `ExpenseRepositoryImpl` which validates splits locally using `SplitEngine` before calling Supabase RPC.
- Created SQL migration `supabase/migrations/20240525000001_split_brain_rpc.sql` defining the `create_expense_transaction` RPC function and updating schema for `expenses` and `expense_splits` tables.
- Added dependency injection for `SupabaseClient` in `ExpenseRepositoryImpl`.
- Added unit tests for `ExpenseRepositoryImpl` verifying RPC calls and validation logic, including mocking `SupabaseClient` and `PostgrestFilterBuilder`.

---
*PR created automatically by Jules for task [11082015714598884262](https://jules.google.com/task/11082015714598884262) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for expense groups, multiple payers, and detailed splits (equal, exact, percent, share).
  * Supabase-backed transactional expense creation (RPC) with server-side validation.
  * Added currency, notes, creator, and group metadata to expenses.
  * Added delete expense capability.

* **Bug Fixes**
  * Improved category resolution and expense hydration for more complete returned data.

* **Tests**
  * Expanded tests for split calculations, payer validation, model RPC payloads, and repository RPC flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->