### PR TITLE
Implement Phase 3B Fast UI Expense Wizard

### DIFF
--- a/PHASE_3B_QA.md
+++ b/PHASE_3B_QA.md
@@ -1,0 +1,55 @@
+# Phase 3B QA Checklist
+
+## 1. Personal Expense (Frictionless Path)
+- [ ] Tap "Dashboard FAB" (Main + button).
+- [ ] Verify Numpad screen opens.
+- [ ] Enter Amount (e.g., 15).
+- [ ] Tap Next.
+- [ ] Verify Details screen opens (Description focused).
+- [ ] Enter Description ("Coffee").
+- [ ] Select Category ("Food") from grid.
+- [ ] Verify Context is "Personal Expense" (Default).
+- [ ] Tap SAVE.
+- [ ] Verify Snackbar "Expense added securely." appears.
+- [ ] Verify wizard closes and returns to Dashboard.
+- [ ] (Dev) Verify Outbox contains 'create_expense_transaction' mutation with correct payload.
+
+## 2. Group Expense (Split Logic)
+- [ ] Tap "Dashboard FAB".
+- [ ] Enter Amount (e.g., 100).
+- [ ] Tap Next.
+- [ ] Tap "Personal Expense" pill -> Select a Group (e.g., "Goa Trip").
+- [ ] Tap NEXT (Button changes from SAVE to NEXT).
+- [ ] Verify Split Screen opens.
+- [ ] Verify Default: "Equal Split" selected.
+- [ ] Verify Default: Current User pays 100%.
+- [ ] Toggle "Percentages". Verify inputs appear.
+- [ ] Enter invalid percentages (sum != 100). Verify error message.
+- [ ] Enter valid percentages (50/50). Verify SAVE enabled.
+- [ ] Tap SAVE.
+- [ ] Verify success.
+
+## 3. Receipt Attachment
+- [ ] In Details Screen, tap "Attach Receipt".
+- [ ] Select "Camera" or "Gallery".
+- [ ] Pick an image.
+- [ ] Verify UI shows "Attach Receipt" -> Spinner -> "Receipt Attached".
+- [ ] Verify file is compressed (check logs or file size if possible).
+- [ ] Verify upload to Supabase 'receipts' bucket starts.
+- [ ] Save Expense.
+- [ ] (Dev) Verify payload includes 'p_receipt_url'.
+
+## 4. Offline/Failure Resilience
+- [ ] Disconnect Network.
+- [ ] Attach Receipt (Upload will fail or hang).
+- [ ] Save Expense.
+- [ ] Verify app does NOT block.
+- [ ] Verify Snackbar "Expense added securely.".
+- [ ] (Dev) Verify payload has 'p_receipt_url': null.
+- [ ] (Dev) Verify payload has 'x_local_receipt_path': '...'.
+- [ ] (Dev) Verify SyncEngine (Phase 2A) eventually handles this (out of scope for 3B but good to check).
+
+## 5. UI/UX
+- [ ] Verify "3-second rule" for personal expense.
+- [ ] Verify Numpad is responsive.
+- [ ] Verify Category Grid horizontal scroll.

--- a/lib/core/constants/route_names.dart
+++ b/lib/core/constants/route_names.dart
@@ -40,4 +40,5 @@ abstract class RouteNames {
   static const String paramTransactionId = 'transactionId';
   static const String paramBudgetId = 'budgetId';
   static const String paramGoalId = 'goalId';
+  static const String addExpenseWizard = '/add-expense-wizard';
 }

--- a/lib/core/di/service_configurations/add_expense_dependencies.dart
+++ b/lib/core/di/service_configurations/add_expense_dependencies.dart
@@ -1,0 +1,47 @@
+import 'package:expense_tracker/core/di/service_locator.dart';
+import 'package:expense_tracker/features/add_expense/data/repositories/outbox_add_expense_repository.dart';
+import 'package:expense_tracker/features/add_expense/domain/repositories/add_expense_repository.dart';
+import 'package:expense_tracker/features/add_expense/domain/logic/split_preview_engine.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_bloc.dart';
+import 'package:expense_tracker/core/services/image_compression_service.dart';
+import 'package:expense_tracker/core/auth/session_cubit.dart';
+import 'package:expense_tracker/core/auth/session_state.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:expense_tracker/features/profile/data/models/profile_model.dart';
+
+class AddExpenseDependencies {
+  static void register() {
+    if (!sl.isRegistered<SplitPreviewEngine>()) {
+      sl.registerLazySingleton(() => SplitPreviewEngine());
+    }
+
+    if (!sl.isRegistered<ImageCompressionService>()) {
+      sl.registerLazySingleton(() => ImageCompressionService());
+    }
+
+    if (!sl.isRegistered<AddExpenseRepository>()) {
+      sl.registerLazySingleton<AddExpenseRepository>(
+        () => OutboxAddExpenseRepository(
+          outbox: sl(),
+          uuid: sl(),
+          profileBox: sl(),
+        ),
+      );
+    }
+
+    sl.registerFactory(
+      () => AddExpenseWizardBloc(
+        repository: sl(),
+        groupsRepository: sl(),
+        currentUserId: (sl<SessionCubit>().state is SessionAuthenticated)
+            ? (sl<SessionCubit>().state as SessionAuthenticated).userId
+            : '',
+        splitEngine: sl(),
+        imageCompressionService: sl(),
+        supabase: sl(),
+        uuid: sl(),
+        profileBox: sl(),
+      ),
+    );
+  }
+}

--- a/lib/core/di/service_configurations/add_expense_dependencies.dart
+++ b/lib/core/di/service_configurations/add_expense_dependencies.dart
@@ -24,7 +24,6 @@ class AddExpenseDependencies {
         () => OutboxAddExpenseRepository(
           outbox: sl(),
           uuid: sl(),
-          profileBox: sl(),
         ),
       );
     }
@@ -34,7 +33,7 @@ class AddExpenseDependencies {
         repository: sl(),
         groupsRepository: sl(),
         currentUserId: (sl<SessionCubit>().state is SessionAuthenticated)
-            ? (sl<SessionCubit>().state as SessionAuthenticated).userId
+            ? (sl<SessionCubit>().state as SessionAuthenticated).profile.id
             : '',
         splitEngine: sl(),
         imageCompressionService: sl(),

--- a/lib/core/di/service_configurations/add_expense_dependencies.dart
+++ b/lib/core/di/service_configurations/add_expense_dependencies.dart
@@ -21,10 +21,7 @@ class AddExpenseDependencies {
 
     if (!sl.isRegistered<AddExpenseRepository>()) {
       sl.registerLazySingleton<AddExpenseRepository>(
-        () => OutboxAddExpenseRepository(
-          outbox: sl(),
-          uuid: sl(),
-        ),
+        () => OutboxAddExpenseRepository(outbox: sl(), uuid: sl()),
       );
     }
 

--- a/lib/core/di/service_locator.dart
+++ b/lib/core/di/service_locator.dart
@@ -32,6 +32,7 @@ import 'package:expense_tracker/core/di/service_configurations/auth_dependencies
 import 'package:expense_tracker/core/di/service_configurations/profile_dependencies.dart';
 import 'package:expense_tracker/core/di/service_configurations/groups_dependencies.dart';
 import 'package:expense_tracker/core/di/service_configurations/group_expenses_dependencies.dart';
+import 'package:expense_tracker/core/di/service_configurations/add_expense_dependencies.dart';
 import 'package:expense_tracker/core/di/service_configurations/sync_dependencies.dart';
 import 'package:expense_tracker/core/network/supabase_client_provider.dart';
 import 'package:expense_tracker/core/sync/sync_coordinator.dart';
@@ -204,6 +205,7 @@ Future<void> initLocator({
     SyncDependencies.register();
     GroupsDependencies.register();
     GroupExpensesDependencies.register();
+    AddExpenseDependencies.register();
   }
 
   if (sl.isRegistered<SyncCoordinator>()) {

--- a/lib/core/services/image_compression_service.dart
+++ b/lib/core/services/image_compression_service.dart
@@ -9,7 +9,10 @@ import 'package:path/path.dart' as p;
 class ImageCompressionService {
   Future<XFile?> compressImage(String sourcePath) async {
     final tempDir = await getTemporaryDirectory();
-    final targetPath = p.join(tempDir.path, 'compressed_${DateTime.now().millisecondsSinceEpoch}.jpg');
+    final targetPath = p.join(
+      tempDir.path,
+      'compressed_${DateTime.now().millisecondsSinceEpoch}.jpg',
+    );
 
     // Capture the token to allow platform channel access in the background isolate
     final token = RootIsolateToken.instance;

--- a/lib/core/services/image_compression_service.dart
+++ b/lib/core/services/image_compression_service.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+import 'dart:isolate';
+import 'package:flutter/services.dart'; // For RootIsolateToken
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+
+class ImageCompressionService {
+  Future<XFile?> compressImage(String sourcePath) async {
+    final tempDir = await getTemporaryDirectory();
+    final targetPath = p.join(tempDir.path, 'compressed_${DateTime.now().millisecondsSinceEpoch}.jpg');
+
+    // Capture the token to allow platform channel access in the background isolate
+    final token = RootIsolateToken.instance;
+
+    return await Isolate.run(() async {
+      if (token != null) {
+        BackgroundIsolateBinaryMessenger.ensureInitialized(token);
+      }
+
+      return await FlutterImageCompress.compressAndGetFile(
+        sourcePath,
+        targetPath,
+        quality: 70,
+        minWidth: 1920,
+        minHeight: 1080,
+        format: CompressFormat.jpeg,
+      );
+    });
+  }
+}

--- a/lib/features/add_expense/data/repositories/mock_add_expense_repository.dart
+++ b/lib/features/add_expense/data/repositories/mock_add_expense_repository.dart
@@ -1,0 +1,19 @@
+import 'package:expense_tracker/features/add_expense/domain/repositories/add_expense_repository.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_state.dart';
+import 'package:expense_tracker/core/utils/logger.dart';
+
+class MockAddExpenseRepository implements AddExpenseRepository {
+  @override
+  Future<void> createExpense(AddExpenseWizardState state) async {
+    final payload = state.toApiPayload();
+    log.info('---------------- MOCK CREATE EXPENSE ----------------');
+    log.info('Payload: ');
+    log.info('-----------------------------------------------------');
+    await Future.delayed(const Duration(milliseconds: 500));
+  }
+
+  @override
+  Future<void> saveReceipt(String localPath, String expenseId) async {
+    // No-op for mock
+  }
+}

--- a/lib/features/add_expense/data/repositories/outbox_add_expense_repository.dart
+++ b/lib/features/add_expense/data/repositories/outbox_add_expense_repository.dart
@@ -1,0 +1,37 @@
+import 'package:expense_tracker/features/add_expense/domain/repositories/add_expense_repository.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_state.dart';
+import 'package:expense_tracker/core/sync/outbox_repository.dart';
+import 'package:expense_tracker/core/sync/models/sync_mutation_model.dart';
+import 'package:uuid/uuid.dart';
+
+class OutboxAddExpenseRepository implements AddExpenseRepository {
+  final OutboxRepository outbox;
+  final Uuid uuid;
+
+  OutboxAddExpenseRepository({required this.outbox, required this.uuid});
+
+  @override
+  Future<void> createExpense(AddExpenseWizardState state) async {
+    final payload = state.toApiPayload();
+
+    // If receipt URL is missing but local path exists, include it for SyncEngine handling
+    if (state.receiptCloudUrl == null && state.receiptLocalPath != null) {
+      payload['x_local_receipt_path'] = state.receiptLocalPath;
+    }
+
+    final mutation = SyncMutationModel(
+      id: uuid.v4(),
+      table: 'rpc/create_expense_transaction',
+      operation: OpType.create,
+      payload: payload,
+      createdAt: DateTime.now(),
+    );
+
+    await outbox.add(mutation);
+  }
+
+  @override
+  Future<void> saveReceipt(String localPath, String expenseId) async {
+    // Managed via UI flow or x_local_receipt_path
+  }
+}

--- a/lib/features/add_expense/domain/logic/split_preview_engine.dart
+++ b/lib/features/add_expense/domain/logic/split_preview_engine.dart
@@ -1,0 +1,112 @@
+import 'package:expense_tracker/features/add_expense/domain/models/split_model.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_member.dart';
+
+class SplitPreviewEngine {
+  /// Distributes totalAmount equally among members, handling penny remainders.
+  static List<SplitModel> calculateEqualSplits(
+    double totalAmount,
+    List<GroupMember> members,
+  ) {
+    if (members.isEmpty) return [];
+
+    // Working with cents to avoid floating point issues during division
+    int totalCents = (totalAmount * 100).round();
+    int count = members.length;
+    if (count == 0) return [];
+
+    int baseShareCents = totalCents ~/ count;
+    int remainderCents = totalCents % count;
+
+    List<SplitModel> results = [];
+    for (int i = 0; i < count; i++) {
+      // Distribute remainder cents to the first 'remainderCents' members
+      int currentShareCents = baseShareCents + (i < remainderCents ? 1 : 0);
+      double computed = currentShareCents / 100.0;
+
+      results.add(
+        SplitModel(
+          userId: members[i].userId,
+          shareType: SplitType.EQUAL,
+          shareValue: 1.0, // Represents 1 equal part
+          computedAmount: computed,
+        ),
+      );
+    }
+    return results;
+  }
+
+  /// Recalculates amounts based on percentages.
+  /// Does NOT validate sum=100 here, just computes amounts.
+  static List<SplitModel> calculatePercentSplits(
+    double totalAmount,
+    List<SplitModel> currentSplits,
+  ) {
+    return currentSplits.map((split) {
+      if (split.shareType != SplitType.PERCENT) return split;
+      double computed = (totalAmount * split.shareValue) / 100.0;
+      // Round to 2 decimals
+      computed = (computed * 100).roundToDouble() / 100.0;
+      return split.copyWith(computedAmount: computed);
+    }).toList();
+  }
+
+  /// Recalculates amounts based on shares (weighted average).
+  static List<SplitModel> calculateShareSplits(
+    double totalAmount,
+    List<SplitModel> currentSplits,
+  ) {
+    double totalShares = currentSplits.fold(
+      0,
+      (sum, split) => sum + split.shareValue,
+    );
+
+    if (totalShares == 0) {
+      return currentSplits.map((s) => s.copyWith(computedAmount: 0)).toList();
+    }
+
+    int totalCents = (totalAmount * 100).round();
+
+    // First pass: calculate raw shares
+    List<int> computedCents = [];
+    int distributedCents = 0;
+
+    for (var split in currentSplits) {
+      double ratio = split.shareValue / totalShares;
+      int shareCents = (totalCents * ratio)
+          .floor(); // Floor to ensure we don't over-allocate initially
+      computedCents.add(shareCents);
+      distributedCents += shareCents;
+    }
+
+    // Distribute remainder
+    int remainder = totalCents - distributedCents;
+
+    // Naive distribution of remainder to first items with shares > 0
+    for (int i = 0; i < computedCents.length && remainder > 0; i++) {
+      if (currentSplits[i].shareValue > 0) {
+        computedCents[i]++;
+        remainder--;
+      }
+    }
+
+    // Convert back to models
+    List<SplitModel> results = [];
+    for (int i = 0; i < currentSplits.length; i++) {
+      results.add(
+        currentSplits[i].copyWith(computedAmount: computedCents[i] / 100.0),
+      );
+    }
+
+    return results;
+  }
+
+  static bool validatePercent(List<SplitModel> splits) {
+    double sum = splits.fold(0.0, (prev, e) => prev + e.shareValue);
+    return (sum - 100.0).abs() < 0.01;
+  }
+
+  static bool validateExact(List<SplitModel> splits, double totalAmount) {
+    double sum = splits.fold(0.0, (prev, e) => prev + e.computedAmount);
+    return (sum - totalAmount).abs() < 0.01;
+  }
+}

--- a/lib/features/add_expense/domain/models/add_expense_enums.dart
+++ b/lib/features/add_expense/domain/models/add_expense_enums.dart
@@ -1,0 +1,21 @@
+enum FormStatus { initial, processing, success, error }
+
+enum SplitMode {
+  equal,
+  exact,
+  percent,
+  shares;
+
+  String get displayName {
+    switch (this) {
+      case SplitMode.equal:
+        return 'Equal Split';
+      case SplitMode.exact:
+        return 'Exact Amounts';
+      case SplitMode.percent:
+        return 'Percentages';
+      case SplitMode.shares:
+        return 'Shares';
+    }
+  }
+}

--- a/lib/features/add_expense/domain/models/payer_model.dart
+++ b/lib/features/add_expense/domain/models/payer_model.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+
+class PayerModel extends Equatable {
+  final String userId;
+  final double amountPaid;
+
+  const PayerModel({required this.userId, required this.amountPaid});
+
+  Map<String, dynamic> toJson() => {
+    'user_id': userId,
+    'amount_paid': amountPaid,
+  };
+
+  @override
+  List<Object?> get props => [userId, amountPaid];
+}

--- a/lib/features/add_expense/domain/models/split_model.dart
+++ b/lib/features/add_expense/domain/models/split_model.dart
@@ -1,9 +1,13 @@
 import 'package:equatable/equatable.dart';
 
 enum SplitType {
+  // ignore: constant_identifier_names
   PERCENT,
+  // ignore: constant_identifier_names
   EQUAL,
+  // ignore: constant_identifier_names
   EXACT,
+  // ignore: constant_identifier_names
   SHARE;
 
   String toJson() => name;

--- a/lib/features/add_expense/domain/models/split_model.dart
+++ b/lib/features/add_expense/domain/models/split_model.dart
@@ -1,0 +1,48 @@
+import 'package:equatable/equatable.dart';
+
+enum SplitType {
+  PERCENT,
+  EQUAL,
+  EXACT,
+  SHARE;
+
+  String toJson() => name;
+}
+
+class SplitModel extends Equatable {
+  final String userId;
+  final SplitType shareType;
+  final double shareValue; // The input value (%, amount, share count)
+  final double computedAmount; // The calculated currency amount
+
+  const SplitModel({
+    required this.userId,
+    required this.shareType,
+    required this.shareValue,
+    required this.computedAmount,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'user_id': userId,
+    'share_type': shareType.toJson(),
+    'share_value': shareValue,
+    'computed_amount': computedAmount,
+  };
+
+  SplitModel copyWith({
+    String? userId,
+    SplitType? shareType,
+    double? shareValue,
+    double? computedAmount,
+  }) {
+    return SplitModel(
+      userId: userId ?? this.userId,
+      shareType: shareType ?? this.shareType,
+      shareValue: shareValue ?? this.shareValue,
+      computedAmount: computedAmount ?? this.computedAmount,
+    );
+  }
+
+  @override
+  List<Object?> get props => [userId, shareType, shareValue, computedAmount];
+}

--- a/lib/features/add_expense/domain/repositories/add_expense_repository.dart
+++ b/lib/features/add_expense/domain/repositories/add_expense_repository.dart
@@ -1,0 +1,10 @@
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_state.dart';
+
+abstract class AddExpenseRepository {
+  Future<void> createExpense(AddExpenseWizardState state);
+  Future<void> saveReceipt(
+    String localPath,
+    String expenseId,
+  ); // Or maybe integrated
+  // The state.toApiPayload() handles the JSON construction.
+}

--- a/lib/features/add_expense/presentation/bloc/add_expense_wizard_bloc.dart
+++ b/lib/features/add_expense/presentation/bloc/add_expense_wizard_bloc.dart
@@ -16,7 +16,8 @@ import 'package:uuid/uuid.dart';
 import 'add_expense_wizard_event.dart';
 import 'add_expense_wizard_state.dart';
 
-class AddExpenseWizardBloc extends Bloc<AddExpenseWizardEvent, AddExpenseWizardState> {
+class AddExpenseWizardBloc
+    extends Bloc<AddExpenseWizardEvent, AddExpenseWizardState> {
   final AddExpenseRepository repository;
   final GroupsRepository groupsRepository;
   final String currentUserId;
@@ -35,11 +36,13 @@ class AddExpenseWizardBloc extends Bloc<AddExpenseWizardEvent, AddExpenseWizardS
     required this.supabase,
     required this.profileBox,
     this.uuid = const Uuid(),
-  }) : super(AddExpenseWizardState(
-          expenseDate: DateTime.now(),
-          currentUserId: currentUserId,
-          transactionId: uuid.v4(),
-        )) {
+  }) : super(
+         AddExpenseWizardState(
+           expenseDate: DateTime.now(),
+           currentUserId: currentUserId,
+           transactionId: uuid.v4(),
+         ),
+       ) {
     on<WizardStarted>(_onWizardStarted);
     on<AmountChanged>(_onAmountChanged);
     on<DescriptionChanged>(_onDescriptionChanged);
@@ -55,52 +58,75 @@ class AddExpenseWizardBloc extends Bloc<AddExpenseWizardEvent, AddExpenseWizardS
     on<SubmitExpense>(_onSubmitExpense);
   }
 
-  void _onWizardStarted(WizardStarted event, Emitter<AddExpenseWizardState> emit) {
+  void _onWizardStarted(
+    WizardStarted event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
     String currency = 'INR';
     final profile = profileBox.get(currentUserId);
     if (profile != null) currency = profile.currency;
 
-    emit(state.copyWith(
-      status: FormStatus.initial,
-      transactionId: uuid.v4(),
-      expenseDate: DateTime.now(),
-      currency: currency,
-    ));
+    emit(
+      state.copyWith(
+        status: FormStatus.initial,
+        transactionId: uuid.v4(),
+        expenseDate: DateTime.now(),
+        currency: currency,
+      ),
+    );
   }
 
-  void _onAmountChanged(AmountChanged event, Emitter<AddExpenseWizardState> emit) {
+  void _onAmountChanged(
+    AmountChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
     emit(state.copyWith(amountTotal: event.amount));
     _recalculateSplits(emit);
   }
 
-  void _onDescriptionChanged(DescriptionChanged event, Emitter<AddExpenseWizardState> emit) {
+  void _onDescriptionChanged(
+    DescriptionChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
     emit(state.copyWith(description: event.description));
   }
 
-  void _onCategorySelected(CategorySelected event, Emitter<AddExpenseWizardState> emit) {
-    emit(state.copyWith(
-      selectedCategory: event.category,
-      categoryId: event.category.id,
-    ));
+  void _onCategorySelected(
+    CategorySelected event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        selectedCategory: event.category,
+        categoryId: event.category.id,
+      ),
+    );
   }
 
-  Future<void> _onGroupSelected(GroupSelected event, Emitter<AddExpenseWizardState> emit) async {
+  Future<void> _onGroupSelected(
+    GroupSelected event,
+    Emitter<AddExpenseWizardState> emit,
+  ) async {
     final group = event.group;
     if (group == null) {
-      emit(state.copyWith(
-        groupId: null,
-        selectedGroup: null,
-        groupMembers: [],
-        splitMode: SplitMode.equal,
-      ));
+      emit(
+        state.copyWith(
+          groupId: null,
+          selectedGroup: null,
+          groupMembers: [],
+          splitMode: SplitMode.equal,
+        ),
+      );
       return;
     }
 
-    emit(state.copyWith(
-      selectedGroup: group,
-      groupId: group.id,
-      splitMode: SplitMode.equal,
-    ));
+    emit(
+      state.copyWith(
+        selectedGroup: group,
+        groupId: group.id,
+        splitMode: SplitMode.equal,
+      ),
+    );
 
     final result = await groupsRepository.getGroupMembers(group.id);
     result.fold(
@@ -112,18 +138,20 @@ class AddExpenseWizardBloc extends Bloc<AddExpenseWizardEvent, AddExpenseWizardS
     );
   }
 
-  void _setDefaultSplits(Emitter<AddExpenseWizardState> emit, List<dynamic> members) {
-    final payer = PayerModel(userId: currentUserId, amountPaid: state.amountTotal);
+  void _setDefaultSplits(
+    Emitter<AddExpenseWizardState> emit,
+    List<dynamic> members,
+  ) {
+    final payer = PayerModel(
+      userId: currentUserId,
+      amountPaid: state.amountTotal,
+    );
     final splits = SplitPreviewEngine.calculateEqualSplits(
       state.amountTotal,
       state.groupMembers,
     );
 
-    emit(state.copyWith(
-      payers: [payer],
-      splits: splits,
-      isSplitValid: true,
-    ));
+    emit(state.copyWith(payers: [payer], splits: splits, isSplitValid: true));
   }
 
   void _recalculateSplits(Emitter<AddExpenseWizardState> emit) {
@@ -132,55 +160,81 @@ class AddExpenseWizardBloc extends Bloc<AddExpenseWizardEvent, AddExpenseWizardS
     // Recalculate computed amounts
     List<SplitModel> newSplits = [];
     if (state.splitMode == SplitMode.equal) {
-      newSplits = SplitPreviewEngine.calculateEqualSplits(state.amountTotal, state.groupMembers);
+      newSplits = SplitPreviewEngine.calculateEqualSplits(
+        state.amountTotal,
+        state.groupMembers,
+      );
     } else if (state.splitMode == SplitMode.percent) {
-      newSplits = SplitPreviewEngine.calculatePercentSplits(state.amountTotal, state.splits);
+      newSplits = SplitPreviewEngine.calculatePercentSplits(
+        state.amountTotal,
+        state.splits,
+      );
     } else if (state.splitMode == SplitMode.shares) {
-      newSplits = SplitPreviewEngine.calculateShareSplits(state.amountTotal, state.splits);
+      newSplits = SplitPreviewEngine.calculateShareSplits(
+        state.amountTotal,
+        state.splits,
+      );
     } else {
       // Exact: No auto-calculation on total change
       newSplits = state.splits;
     }
 
     // Also, if single payer is current user, update their amount
-    if (state.payers.length == 1 && state.payers.first.userId == currentUserId) {
-         final updatedPayer = PayerModel(userId: state.payers.first.userId, amountPaid: state.amountTotal);
-         emit(state.copyWith(payers: [updatedPayer]));
+    if (state.payers.length == 1 &&
+        state.payers.first.userId == currentUserId) {
+      final updatedPayer = PayerModel(
+        userId: state.payers.first.userId,
+        amountPaid: state.amountTotal,
+      );
+      emit(state.copyWith(payers: [updatedPayer]));
     }
 
     emit(state.copyWith(splits: newSplits));
     _validateSplits(emit, newSplits);
   }
 
-  void _validateSplits(Emitter<AddExpenseWizardState> emit, List<SplitModel> splits) {
-     bool valid = true;
-     if (state.splitMode == SplitMode.percent) {
-       valid = SplitPreviewEngine.validatePercent(splits);
-     } else if (state.splitMode == SplitMode.exact) {
-       valid = SplitPreviewEngine.validateExact(splits, state.amountTotal);
-     }
-     emit(state.copyWith(isSplitValid: valid));
+  void _validateSplits(
+    Emitter<AddExpenseWizardState> emit,
+    List<SplitModel> splits,
+  ) {
+    bool valid = true;
+    if (state.splitMode == SplitMode.percent) {
+      valid = SplitPreviewEngine.validatePercent(splits);
+    } else if (state.splitMode == SplitMode.exact) {
+      valid = SplitPreviewEngine.validateExact(splits, state.amountTotal);
+    }
+    emit(state.copyWith(isSplitValid: valid));
   }
 
   void _onDateChanged(DateChanged event, Emitter<AddExpenseWizardState> emit) {
     emit(state.copyWith(expenseDate: event.date));
   }
 
-  void _onNotesChanged(NotesChanged event, Emitter<AddExpenseWizardState> emit) {
+  void _onNotesChanged(
+    NotesChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
     emit(state.copyWith(notes: event.notes));
   }
 
-  Future<void> _onReceiptSelected(ReceiptSelected event, Emitter<AddExpenseWizardState> emit) async {
-    emit(state.copyWith(
-      isUploadingReceipt: true,
-      receiptLocalPath: event.localPath,
-    ));
+  Future<void> _onReceiptSelected(
+    ReceiptSelected event,
+    Emitter<AddExpenseWizardState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        isUploadingReceipt: true,
+        receiptLocalPath: event.localPath,
+      ),
+    );
 
     try {
-      final compressedFile = await imageCompressionService.compressImage(event.localPath);
+      final compressedFile = await imageCompressionService.compressImage(
+        event.localPath,
+      );
       if (compressedFile == null) {
-         emit(state.copyWith(isUploadingReceipt: false));
-         return;
+        emit(state.copyWith(isUploadingReceipt: false));
+        return;
       }
 
       final fileExt = compressedFile.path.split('.').last;
@@ -188,46 +242,65 @@ class AddExpenseWizardBloc extends Bloc<AddExpenseWizardEvent, AddExpenseWizardS
       final pathPrefix = state.groupId ?? 'personal';
       final uploadPath = '$pathPrefix/$fileName';
 
-      await supabase.storage.from('receipts').upload(
-        uploadPath,
-        File(compressedFile.path),
-        fileOptions: const FileOptions(upsert: true),
+      await supabase.storage
+          .from('receipts')
+          .upload(
+            uploadPath,
+            File(compressedFile.path),
+            fileOptions: const FileOptions(upsert: true),
+          );
+
+      final publicUrl = supabase.storage
+          .from('receipts')
+          .getPublicUrl(uploadPath);
+
+      emit(
+        state.copyWith(isUploadingReceipt: false, receiptCloudUrl: publicUrl),
       );
-
-      final publicUrl = supabase.storage.from('receipts').getPublicUrl(uploadPath);
-
-      emit(state.copyWith(
-        isUploadingReceipt: false,
-        receiptCloudUrl: publicUrl,
-      ));
     } catch (e) {
       log.severe('Receipt upload failed: $e');
       emit(state.copyWith(isUploadingReceipt: false));
     }
   }
 
-  void _onSplitModeChanged(SplitModeChanged event, Emitter<AddExpenseWizardState> emit) {
+  void _onSplitModeChanged(
+    SplitModeChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
     emit(state.copyWith(splitMode: event.mode));
 
     List<SplitModel> newSplits = [];
     if (event.mode == SplitMode.equal) {
-       newSplits = SplitPreviewEngine.calculateEqualSplits(state.amountTotal, state.groupMembers);
+      newSplits = SplitPreviewEngine.calculateEqualSplits(
+        state.amountTotal,
+        state.groupMembers,
+      );
     } else {
-       // Init with defaults
-       newSplits = state.groupMembers.map((m) {
-         return SplitModel(
-           userId: m.userId,
-           shareType: _getSplitTypeFromMode(event.mode),
-           shareValue: event.mode == SplitMode.shares ? 1.0 : (event.mode == SplitMode.percent ? (100.0/state.groupMembers.length) : 0.0),
-           computedAmount: 0.0,
-         );
-       }).toList();
+      // Init with defaults
+      newSplits = state.groupMembers.map((m) {
+        return SplitModel(
+          userId: m.userId,
+          shareType: _getSplitTypeFromMode(event.mode),
+          shareValue: event.mode == SplitMode.shares
+              ? 1.0
+              : (event.mode == SplitMode.percent
+                    ? (100.0 / state.groupMembers.length)
+                    : 0.0),
+          computedAmount: 0.0,
+        );
+      }).toList();
 
-       if (event.mode == SplitMode.percent) {
-         newSplits = SplitPreviewEngine.calculatePercentSplits(state.amountTotal, newSplits);
-       } else if (event.mode == SplitMode.shares) {
-         newSplits = SplitPreviewEngine.calculateShareSplits(state.amountTotal, newSplits);
-       }
+      if (event.mode == SplitMode.percent) {
+        newSplits = SplitPreviewEngine.calculatePercentSplits(
+          state.amountTotal,
+          newSplits,
+        );
+      } else if (event.mode == SplitMode.shares) {
+        newSplits = SplitPreviewEngine.calculateShareSplits(
+          state.amountTotal,
+          newSplits,
+        );
+      }
     }
 
     emit(state.copyWith(splits: newSplits));
@@ -236,14 +309,21 @@ class AddExpenseWizardBloc extends Bloc<AddExpenseWizardEvent, AddExpenseWizardS
 
   SplitType _getSplitTypeFromMode(SplitMode mode) {
     switch (mode) {
-      case SplitMode.equal: return SplitType.EQUAL;
-      case SplitMode.exact: return SplitType.EXACT;
-      case SplitMode.percent: return SplitType.PERCENT;
-      case SplitMode.shares: return SplitType.SHARE;
+      case SplitMode.equal:
+        return SplitType.EQUAL;
+      case SplitMode.exact:
+        return SplitType.EXACT;
+      case SplitMode.percent:
+        return SplitType.PERCENT;
+      case SplitMode.shares:
+        return SplitType.SHARE;
     }
   }
 
-  void _onSplitValueChanged(SplitValueChanged event, Emitter<AddExpenseWizardState> emit) {
+  void _onSplitValueChanged(
+    SplitValueChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
     final newSplits = state.splits.map((s) {
       if (s.userId == event.userId) {
         return s.copyWith(shareValue: event.value);
@@ -254,40 +334,75 @@ class AddExpenseWizardBloc extends Bloc<AddExpenseWizardEvent, AddExpenseWizardS
     // Recalculate computed amounts
     List<SplitModel> calculatedSplits = newSplits;
     if (state.splitMode == SplitMode.percent) {
-      calculatedSplits = SplitPreviewEngine.calculatePercentSplits(state.amountTotal, newSplits);
+      calculatedSplits = SplitPreviewEngine.calculatePercentSplits(
+        state.amountTotal,
+        newSplits,
+      );
     } else if (state.splitMode == SplitMode.shares) {
-      calculatedSplits = SplitPreviewEngine.calculateShareSplits(state.amountTotal, newSplits);
+      calculatedSplits = SplitPreviewEngine.calculateShareSplits(
+        state.amountTotal,
+        newSplits,
+      );
     } else if (state.splitMode == SplitMode.exact) {
-      calculatedSplits = newSplits.map((s) => s.copyWith(computedAmount: s.shareValue)).toList();
+      calculatedSplits = newSplits
+          .map((s) => s.copyWith(computedAmount: s.shareValue))
+          .toList();
     }
 
     emit(state.copyWith(splits: calculatedSplits));
     _validateSplits(emit, calculatedSplits);
   }
 
-  void _onPayerChanged(PayerChanged event, Emitter<AddExpenseWizardState> emit) {
+  void _onPayerChanged(
+    PayerChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
     List<PayerModel> currentPayers = List.from(state.payers);
     final index = currentPayers.indexWhere((p) => p.userId == event.userId);
     if (index >= 0) {
-      currentPayers[index] = PayerModel(userId: event.userId, amountPaid: event.amount);
+      currentPayers[index] = PayerModel(
+        userId: event.userId,
+        amountPaid: event.amount,
+      );
     } else {
-      currentPayers.add(PayerModel(userId: event.userId, amountPaid: event.amount));
+      currentPayers.add(
+        PayerModel(userId: event.userId, amountPaid: event.amount),
+      );
     }
     emit(state.copyWith(payers: currentPayers));
   }
 
-  void _onSinglePayerSelected(SinglePayerSelected event, Emitter<AddExpenseWizardState> emit) {
-    final payer = PayerModel(userId: event.userId, amountPaid: state.amountTotal);
+  void _onSinglePayerSelected(
+    SinglePayerSelected event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
+    final payer = PayerModel(
+      userId: event.userId,
+      amountPaid: state.amountTotal,
+    );
     emit(state.copyWith(payers: [payer]));
   }
 
-  Future<void> _onSubmitExpense(SubmitExpense event, Emitter<AddExpenseWizardState> emit) async {
+  Future<void> _onSubmitExpense(
+    SubmitExpense event,
+    Emitter<AddExpenseWizardState> emit,
+  ) async {
     if (state.amountTotal <= 0) {
-      emit(state.copyWith(status: FormStatus.error, errorMessage: "Amount must be > 0"));
+      emit(
+        state.copyWith(
+          status: FormStatus.error,
+          errorMessage: "Amount must be > 0",
+        ),
+      );
       return;
     }
     if (!state.isSplitValid && state.groupId != null) {
-      emit(state.copyWith(status: FormStatus.error, errorMessage: "Invalid splits"));
+      emit(
+        state.copyWith(
+          status: FormStatus.error,
+          errorMessage: "Invalid splits",
+        ),
+      );
       return;
     }
 
@@ -297,20 +412,32 @@ class AddExpenseWizardBloc extends Bloc<AddExpenseWizardEvent, AddExpenseWizardS
       AddExpenseWizardState finalState = state;
       // If personal, ensure payers/splits are correct
       if (state.groupId == null) {
-         final payer = PayerModel(userId: currentUserId, amountPaid: state.amountTotal);
-         final split = SplitModel(userId: currentUserId, shareType: SplitType.EQUAL, shareValue: 1.0, computedAmount: state.amountTotal);
-         finalState = state.copyWith(payers: [payer], splits: [split]);
+        final payer = PayerModel(
+          userId: currentUserId,
+          amountPaid: state.amountTotal,
+        );
+        final split = SplitModel(
+          userId: currentUserId,
+          shareType: SplitType.EQUAL,
+          shareValue: 1.0,
+          computedAmount: state.amountTotal,
+        );
+        finalState = state.copyWith(payers: [payer], splits: [split]);
       }
 
       if (state.description.trim().isEmpty && state.selectedCategory != null) {
-         finalState = finalState.copyWith(description: state.selectedCategory!.name);
+        finalState = finalState.copyWith(
+          description: state.selectedCategory!.name,
+        );
       }
 
       await repository.createExpense(finalState);
       emit(finalState.copyWith(status: FormStatus.success));
     } catch (e) {
       log.severe("Submit failed: $e");
-      emit(state.copyWith(status: FormStatus.error, errorMessage: e.toString()));
+      emit(
+        state.copyWith(status: FormStatus.error, errorMessage: e.toString()),
+      );
     }
   }
 }

--- a/lib/features/add_expense/presentation/bloc/add_expense_wizard_bloc.dart
+++ b/lib/features/add_expense/presentation/bloc/add_expense_wizard_bloc.dart
@@ -1,0 +1,434 @@
+import 'dart:io';
+import 'package:bloc/bloc.dart';
+import 'package:expense_tracker/features/add_expense/domain/repositories/add_expense_repository.dart';
+import 'package:expense_tracker/features/add_expense/domain/logic/split_preview_engine.dart';
+import 'package:expense_tracker/features/groups/domain/repositories/groups_repository.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_entity.dart';
+import 'package:expense_tracker/core/services/image_compression_service.dart';
+import 'package:expense_tracker/core/utils/logger.dart';
+import 'package:expense_tracker/features/add_expense/domain/models/add_expense_enums.dart';
+import 'package:expense_tracker/features/add_expense/domain/models/split_model.dart';
+import 'package:expense_tracker/features/add_expense/domain/models/payer_model.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:expense_tracker/features/profile/data/models/profile_model.dart';
+import 'package:uuid/uuid.dart';
+import 'add_expense_wizard_event.dart';
+import 'add_expense_wizard_state.dart';
+
+class AddExpenseWizardBloc
+    extends Bloc<AddExpenseWizardEvent, AddExpenseWizardState> {
+  final AddExpenseRepository repository;
+  final GroupsRepository groupsRepository;
+  final String currentUserId;
+  final SplitPreviewEngine splitEngine;
+  final ImageCompressionService imageCompressionService;
+  final SupabaseClient supabase;
+  final Uuid uuid;
+  final Box<ProfileModel> profileBox;
+
+  AddExpenseWizardBloc({
+    required this.repository,
+    required this.groupsRepository,
+    required this.currentUserId,
+    required this.splitEngine,
+    required this.imageCompressionService,
+    required this.supabase,
+    required this.profileBox,
+    this.uuid = const Uuid(),
+  }) : super(
+         AddExpenseWizardState(
+           expenseDate: DateTime.now(),
+           currency: currency,
+           currentUserId: currentUserId,
+           transactionId: uuid.v4(),
+         ),
+       ) {
+    on<WizardStarted>(_onWizardStarted);
+    on<AmountChanged>(_onAmountChanged);
+    on<DescriptionChanged>(_onDescriptionChanged);
+    on<CategorySelected>(_onCategorySelected);
+    on<GroupSelected>(_onGroupSelected);
+    on<DateChanged>(_onDateChanged);
+    on<NotesChanged>(_onNotesChanged);
+    on<ReceiptSelected>(_onReceiptSelected);
+    on<SplitModeChanged>(_onSplitModeChanged);
+    on<SplitValueChanged>(_onSplitValueChanged);
+    on<PayerChanged>(_onPayerChanged);
+    on<SinglePayerSelected>(_onSinglePayerSelected);
+    on<SubmitExpense>(_onSubmitExpense);
+  }
+
+  void _onWizardStarted(
+    WizardStarted event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
+    String currency = 'INR';
+    final profile = profileBox.get(currentUserId);
+    if (profile != null) currency = profile.currency;
+    emit(
+      state.copyWith(
+        status: FormStatus.initial,
+        transactionId: uuid.v4(),
+        expenseDate: DateTime.now(),
+        currency: currency,
+      ),
+    );
+  }
+
+  void _onAmountChanged(
+    AmountChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
+    emit(state.copyWith(amountTotal: event.amount));
+    _recalculateSplits(emit);
+  }
+
+  void _onDescriptionChanged(
+    DescriptionChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
+    emit(state.copyWith(description: event.description));
+  }
+
+  void _onCategorySelected(
+    CategorySelected event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        selectedCategory: event.category,
+        categoryId: event.category.id,
+      ),
+    );
+  }
+
+  Future<void> _onGroupSelected(
+    GroupSelected event,
+    Emitter<AddExpenseWizardState> emit,
+  ) async {
+    final group = event.group;
+    if (group == null) {
+      emit(
+        state.copyWith(
+          groupId: null,
+          selectedGroup: null,
+          groupMembers: [],
+          splitMode: SplitMode.equal,
+        ),
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        selectedGroup: group,
+        groupId: group.id,
+        splitMode: SplitMode.equal,
+      ),
+    );
+
+    final result = await groupsRepository.getGroupMembers(group.id);
+    result.fold(
+      (failure) => log.warning('Failed to load group members: $failure'),
+      (members) {
+        emit(state.copyWith(groupMembers: members));
+        _setDefaultSplits(emit, members);
+      },
+    );
+  }
+
+  void _setDefaultSplits(
+    Emitter<AddExpenseWizardState> emit,
+    List<dynamic> members,
+  ) {
+    final payer = PayerModel(
+      userId: currentUserId,
+      amountPaid: state.amountTotal,
+    );
+    final splits = SplitPreviewEngine.calculateEqualSplits(
+      state.amountTotal,
+      state.groupMembers,
+    );
+
+    emit(state.copyWith(payers: [payer], splits: splits, isSplitValid: true));
+  }
+
+  void _recalculateSplits(Emitter<AddExpenseWizardState> emit) {
+    // Logic extracted to avoid duplication
+    // If personal (no group), splits are irrelevant (handled at submit)
+    if (state.groupId == null) return;
+
+    // Recalculate computed amounts
+    List<SplitModel> newSplits = [];
+    if (state.splitMode == SplitMode.equal) {
+      newSplits = SplitPreviewEngine.calculateEqualSplits(
+        state.amountTotal,
+        state.groupMembers,
+      );
+    } else if (state.splitMode == SplitMode.percent) {
+      newSplits = SplitPreviewEngine.calculatePercentSplits(
+        state.amountTotal,
+        state.splits,
+      );
+    } else if (state.splitMode == SplitMode.shares) {
+      newSplits = SplitPreviewEngine.calculateShareSplits(
+        state.amountTotal,
+        state.splits,
+      );
+    } else {
+      // Exact: No auto-calculation on total change
+      newSplits = state.splits;
+    }
+
+    // Also, if single payer is current user, update their amount
+    if (state.payers.length == 1 &&
+        state.payers.first.userId == currentUserId) {
+      final updatedPayer = PayerModel(
+        userId: state.payers.first.userId,
+        amountPaid: state.amountTotal,
+      );
+      emit(state.copyWith(payers: [updatedPayer]));
+    }
+
+    emit(state.copyWith(splits: newSplits));
+    _validateSplits(emit, newSplits);
+  }
+
+  void _validateSplits(
+    Emitter<AddExpenseWizardState> emit,
+    List<SplitModel> splits,
+  ) {
+    bool valid = true;
+    if (state.splitMode == SplitMode.percent) {
+      valid = SplitPreviewEngine.validatePercent(splits);
+    } else if (state.splitMode == SplitMode.exact) {
+      valid = SplitPreviewEngine.validateExact(splits, state.amountTotal);
+    }
+    emit(state.copyWith(isSplitValid: valid));
+  }
+
+  void _onDateChanged(DateChanged event, Emitter<AddExpenseWizardState> emit) {
+    emit(state.copyWith(expenseDate: event.date));
+  }
+
+  void _onNotesChanged(
+    NotesChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
+    emit(state.copyWith(notes: event.notes));
+  }
+
+  Future<void> _onReceiptSelected(
+    ReceiptSelected event,
+    Emitter<AddExpenseWizardState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        isUploadingReceipt: true,
+        receiptLocalPath: event.localPath,
+      ),
+    );
+
+    try {
+      final compressedFile = await imageCompressionService.compressImage(
+        event.localPath,
+      );
+      if (compressedFile == null) {
+        emit(state.copyWith(isUploadingReceipt: false));
+        return;
+      }
+
+      final fileExt = compressedFile.path.split('.').last;
+      final fileName = '${state.transactionId}.$fileExt';
+      final pathPrefix = state.groupId ?? 'personal';
+      final uploadPath = '$pathPrefix/$fileName';
+
+      await supabase.storage
+          .from('receipts')
+          .upload(
+            uploadPath,
+            File(compressedFile.path),
+            fileOptions: const FileOptions(upsert: true),
+          );
+
+      final publicUrl = supabase.storage
+          .from('receipts')
+          .getPublicUrl(uploadPath);
+
+      emit(
+        state.copyWith(isUploadingReceipt: false, receiptCloudUrl: publicUrl),
+      );
+    } catch (e) {
+      log.severe('Receipt upload failed: $e');
+      emit(state.copyWith(isUploadingReceipt: false));
+    }
+  }
+
+  void _onSplitModeChanged(
+    SplitModeChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
+    emit(state.copyWith(splitMode: event.mode));
+
+    List<SplitModel> newSplits = [];
+    if (event.mode == SplitMode.equal) {
+      newSplits = SplitPreviewEngine.calculateEqualSplits(
+        state.amountTotal,
+        state.groupMembers,
+      );
+    } else {
+      // Init with defaults
+      newSplits = state.groupMembers.map((m) {
+        return SplitModel(
+          userId: m.userId,
+          shareType: _getSplitTypeFromMode(event.mode),
+          shareValue: event.mode == SplitMode.shares
+              ? 1.0
+              : (event.mode == SplitMode.percent
+                    ? (100.0 / state.groupMembers.length)
+                    : 0.0),
+          computedAmount: 0.0,
+        );
+      }).toList();
+
+      if (event.mode == SplitMode.percent) {
+        newSplits = SplitPreviewEngine.calculatePercentSplits(
+          state.amountTotal,
+          newSplits,
+        );
+      } else if (event.mode == SplitMode.shares) {
+        newSplits = SplitPreviewEngine.calculateShareSplits(
+          state.amountTotal,
+          newSplits,
+        );
+      }
+    }
+
+    emit(state.copyWith(splits: newSplits));
+    _validateSplits(emit, newSplits);
+  }
+
+  SplitType _getSplitTypeFromMode(SplitMode mode) {
+    switch (mode) {
+      case SplitMode.equal:
+        return SplitType.EQUAL;
+      case SplitMode.exact:
+        return SplitType.EXACT;
+      case SplitMode.percent:
+        return SplitType.PERCENT;
+      case SplitMode.shares:
+        return SplitType.SHARE;
+    }
+  }
+
+  void _onSplitValueChanged(
+    SplitValueChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
+    final newSplits = state.splits.map((s) {
+      if (s.userId == event.userId) {
+        return s.copyWith(shareValue: event.value);
+      }
+      return s;
+    }).toList();
+
+    // Recalculate computed amounts
+    List<SplitModel> calculatedSplits = newSplits;
+    if (state.splitMode == SplitMode.percent) {
+      calculatedSplits = SplitPreviewEngine.calculatePercentSplits(
+        state.amountTotal,
+        newSplits,
+      );
+    } else if (state.splitMode == SplitMode.shares) {
+      calculatedSplits = SplitPreviewEngine.calculateShareSplits(
+        state.amountTotal,
+        newSplits,
+      );
+    } else if (state.splitMode == SplitMode.exact) {
+      calculatedSplits = newSplits
+          .map((s) => s.copyWith(computedAmount: s.shareValue))
+          .toList();
+    }
+
+    emit(state.copyWith(splits: calculatedSplits));
+    _validateSplits(emit, calculatedSplits);
+  }
+
+  void _onPayerChanged(
+    PayerChanged event,
+    Emitter<AddExpenseWizardState> emit,
+  ) {
+    List<PayerModel> currentPayers = List.from(state.payers);
+    final index = currentPayers.indexWhere((p) => p.userId == event.userId);
+    if (index >= 0) {
+      currentPayers[index] = PayerModel(
+        userId: event.userId,
+        amountPaid: event.amount,
+      );
+    } else {
+      currentPayers.add(
+        PayerModel(userId: event.userId, amountPaid: event.amount),
+      );
+    }
+    emit(state.copyWith(payers: currentPayers));
+  }
+
+  Future<void> _onSubmitExpense(
+    SubmitExpense event,
+    Emitter<AddExpenseWizardState> emit,
+  ) async {
+    if (state.amountTotal <= 0) {
+      emit(
+        state.copyWith(
+          status: FormStatus.error,
+          errorMessage: "Amount must be > 0",
+        ),
+      );
+      return;
+    }
+    if (!state.isSplitValid && state.groupId != null) {
+      emit(
+        state.copyWith(
+          status: FormStatus.error,
+          errorMessage: "Invalid splits",
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: FormStatus.processing));
+
+    try {
+      AddExpenseWizardState finalState = state;
+      // If personal, ensure payers/splits are correct
+      if (state.groupId == null) {
+        final payer = PayerModel(
+          userId: currentUserId,
+          amountPaid: state.amountTotal,
+        );
+        final split = SplitModel(
+          userId: currentUserId,
+          shareType: SplitType.EQUAL,
+          shareValue: 1.0,
+          computedAmount: state.amountTotal,
+        );
+        finalState = state.copyWith(payers: [payer], splits: [split]);
+      }
+
+      if (state.description.trim().isEmpty && state.selectedCategory != null) {
+        finalState = finalState.copyWith(
+          description: state.selectedCategory!.name,
+        );
+      }
+
+      await repository.createExpense(finalState);
+      emit(finalState.copyWith(status: FormStatus.success));
+    } catch (e) {
+      log.severe("Submit failed: $e");
+      emit(
+        state.copyWith(status: FormStatus.error, errorMessage: e.toString()),
+      );
+    }
+  }
+}

--- a/lib/features/add_expense/presentation/bloc/add_expense_wizard_event.dart
+++ b/lib/features/add_expense/presentation/bloc/add_expense_wizard_event.dart
@@ -1,0 +1,97 @@
+import 'package:equatable/equatable.dart';
+import 'package:expense_tracker/features/add_expense/domain/models/add_expense_enums.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_entity.dart';
+
+sealed class AddExpenseWizardEvent extends Equatable {
+  const AddExpenseWizardEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class WizardStarted extends AddExpenseWizardEvent {
+  const WizardStarted();
+}
+
+class AmountChanged extends AddExpenseWizardEvent {
+  final double amount;
+  const AmountChanged(this.amount);
+  @override
+  List<Object?> get props => [amount];
+}
+
+class DescriptionChanged extends AddExpenseWizardEvent {
+  final String description;
+  const DescriptionChanged(this.description);
+  @override
+  List<Object?> get props => [description];
+}
+
+class CategorySelected extends AddExpenseWizardEvent {
+  final Category category;
+  const CategorySelected(this.category);
+  @override
+  List<Object?> get props => [category];
+}
+
+class GroupSelected extends AddExpenseWizardEvent {
+  final GroupEntity? group;
+  const GroupSelected(this.group);
+  @override
+  List<Object?> get props => [group];
+}
+
+class DateChanged extends AddExpenseWizardEvent {
+  final DateTime date;
+  const DateChanged(this.date);
+  @override
+  List<Object?> get props => [date];
+}
+
+class NotesChanged extends AddExpenseWizardEvent {
+  final String notes;
+  const NotesChanged(this.notes);
+  @override
+  List<Object?> get props => [notes];
+}
+
+class ReceiptSelected extends AddExpenseWizardEvent {
+  final String localPath;
+  const ReceiptSelected(this.localPath);
+  @override
+  List<Object?> get props => [localPath];
+}
+
+class SplitModeChanged extends AddExpenseWizardEvent {
+  final SplitMode mode;
+  const SplitModeChanged(this.mode);
+  @override
+  List<Object?> get props => [mode];
+}
+
+class SplitValueChanged extends AddExpenseWizardEvent {
+  final String userId;
+  final double value;
+  const SplitValueChanged(this.userId, this.value);
+  @override
+  List<Object?> get props => [userId, value];
+}
+
+class SinglePayerSelected extends AddExpenseWizardEvent {
+  final String userId;
+  const SinglePayerSelected(this.userId);
+  @override
+  List<Object?> get props => [userId];
+}
+
+class PayerChanged extends AddExpenseWizardEvent {
+  final String userId;
+  final double amount;
+  const PayerChanged(this.userId, this.amount);
+  @override
+  List<Object?> get props => [userId, amount];
+}
+
+class SubmitExpense extends AddExpenseWizardEvent {
+  const SubmitExpense();
+}

--- a/lib/features/add_expense/presentation/bloc/add_expense_wizard_state.dart
+++ b/lib/features/add_expense/presentation/bloc/add_expense_wizard_state.dart
@@ -1,0 +1,154 @@
+import 'package:equatable/equatable.dart';
+import 'package:expense_tracker/features/add_expense/domain/models/add_expense_enums.dart';
+import 'package:expense_tracker/features/add_expense/domain/models/payer_model.dart';
+import 'package:expense_tracker/features/add_expense/domain/models/split_model.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_entity.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_member.dart';
+
+class AddExpenseWizardState extends Equatable {
+  // Screen 1: Numpad
+  final double amountTotal;
+
+  // Screen 2: Details
+  final String description;
+  final String? categoryId;
+  final Category? selectedCategory;
+  final String? groupId;
+  final GroupEntity? selectedGroup;
+  final List<GroupMember> groupMembers; // For calculating splits/payers
+  final String? receiptLocalPath;
+  final String? receiptCloudUrl;
+  final bool isUploadingReceipt;
+  final DateTime expenseDate;
+  final String notes;
+
+  // Screen 3: Splits
+  final SplitMode splitMode;
+  final List<PayerModel> payers;
+  final List<SplitModel> splits;
+  final bool isSplitValid; // Calculated by engine
+
+  // Meta
+  final FormStatus status;
+  final String? errorMessage;
+  final String? currentUserId; // Needed for default payers/splits
+  final String transactionId;
+  final String currency; // Default INR or User's
+
+  const AddExpenseWizardState({
+    this.amountTotal = 0.0,
+    this.description = '',
+    this.categoryId,
+    this.selectedCategory,
+    this.groupId,
+    this.selectedGroup,
+    this.groupMembers = const [],
+    this.receiptLocalPath,
+    this.receiptCloudUrl,
+    this.isUploadingReceipt = false,
+    required this.expenseDate,
+    this.notes = '',
+    this.splitMode = SplitMode.equal,
+    this.payers = const [],
+    this.splits = const [],
+    this.isSplitValid = true,
+    this.status = FormStatus.initial,
+    this.errorMessage,
+    this.currentUserId,
+    required this.transactionId,
+    this.currency = 'INR',
+  });
+
+  AddExpenseWizardState copyWith({
+    double? amountTotal,
+    String? description,
+    String? categoryId,
+    Category? selectedCategory,
+    String? groupId,
+    GroupEntity? selectedGroup,
+    List<GroupMember>? groupMembers,
+    String? receiptLocalPath,
+    String? receiptCloudUrl,
+    bool? isUploadingReceipt,
+    DateTime? expenseDate,
+    String? notes,
+    SplitMode? splitMode,
+    List<PayerModel>? payers,
+    List<SplitModel>? splits,
+    bool? isSplitValid,
+    FormStatus? status,
+    String? errorMessage,
+    String? currentUserId,
+    String? transactionId,
+    String? currency,
+  }) {
+    return AddExpenseWizardState(
+      amountTotal: amountTotal ?? this.amountTotal,
+      description: description ?? this.description,
+      categoryId: categoryId ?? this.categoryId,
+      selectedCategory: selectedCategory ?? this.selectedCategory,
+      groupId: groupId ?? this.groupId,
+      selectedGroup: selectedGroup ?? this.selectedGroup,
+      groupMembers: groupMembers ?? this.groupMembers,
+      receiptLocalPath: receiptLocalPath ?? this.receiptLocalPath,
+      receiptCloudUrl: receiptCloudUrl ?? this.receiptCloudUrl,
+      isUploadingReceipt: isUploadingReceipt ?? this.isUploadingReceipt,
+      expenseDate: expenseDate ?? this.expenseDate,
+      notes: notes ?? this.notes,
+      splitMode: splitMode ?? this.splitMode,
+      payers: payers ?? this.payers,
+      splits: splits ?? this.splits,
+      isSplitValid: isSplitValid ?? this.isSplitValid,
+      status: status ?? this.status,
+      errorMessage: errorMessage ?? this.errorMessage,
+      currentUserId: currentUserId ?? this.currentUserId,
+      transactionId: transactionId ?? this.transactionId,
+      currency: currency ?? this.currency,
+    );
+  }
+
+  // Helper: To JSON Payload
+  Map<String, dynamic> toApiPayload() {
+    return {
+      'p_group_id': groupId, // Null if personal
+      'p_created_by': currentUserId, // Must be set
+      'p_transaction_id':
+          transactionId, // Optional but good for consistency if allowed
+      'p_amount_total': amountTotal,
+      'p_currency': currency,
+      'p_description': description,
+      'p_category_id': categoryId,
+      'p_expense_date': expenseDate.toIso8601String(),
+      'p_notes': notes,
+      'p_receipt_url': receiptCloudUrl, // New Field
+      'p_payers': payers.map((e) => e.toJson()).toList(),
+      'p_splits': splits.map((e) => e.toJson()).toList(),
+    };
+  }
+
+  @override
+  List<Object?> get props => [
+    amountTotal,
+    description,
+    categoryId,
+    selectedCategory,
+    groupId,
+    selectedGroup,
+    groupMembers,
+    receiptLocalPath,
+    receiptCloudUrl,
+    isUploadingReceipt,
+    expenseDate,
+    notes,
+    splitMode,
+    payers,
+    splits,
+    isSplitValid,
+    status,
+    errorMessage,
+    currentUserId,
+    currency,
+    transactionId,
+  ];
+}

--- a/lib/features/add_expense/presentation/pages/add_expense_wizard_page.dart
+++ b/lib/features/add_expense/presentation/pages/add_expense_wizard_page.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_bloc.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_event.dart';
+import 'package:expense_tracker/features/add_expense/presentation/widgets/numpad_screen.dart';
+import 'package:expense_tracker/features/add_expense/presentation/widgets/details_screen.dart';
+import 'package:expense_tracker/features/add_expense/presentation/widgets/split_screen.dart';
+import 'package:expense_tracker/core/di/service_locator.dart';
+
+class AddExpenseWizardPage extends StatelessWidget {
+  const AddExpenseWizardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) =>
+          sl<AddExpenseWizardBloc>()..add(const WizardStarted()),
+      child: const AddExpenseWizardView(),
+    );
+  }
+}
+
+class AddExpenseWizardView extends StatefulWidget {
+  const AddExpenseWizardView({super.key});
+
+  @override
+  State<AddExpenseWizardView> createState() => _AddExpenseWizardViewState();
+}
+
+class _AddExpenseWizardViewState extends State<AddExpenseWizardView> {
+  final PageController _pageController = PageController();
+
+  void _nextPage() {
+    _pageController.nextPage(
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _prevPage() {
+    _pageController.previousPage(
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: PageView(
+          controller: _pageController,
+          physics: const NeverScrollableScrollPhysics(),
+          children: [
+            NumpadScreen(onNext: _nextPage),
+            DetailsScreen(
+              onNext: (isGroup) {
+                if (isGroup) {
+                  _nextPage();
+                } else {
+                  // DetailsScreen handles Submit for Personal.
+                  // But if we wanted to enforce flow:
+                  // context.read<AddExpenseWizardBloc>().add(SubmitExpense());
+                }
+              },
+              onBack: () {
+                if (_pageController.page == 0) {
+                  Navigator.of(context).pop();
+                } else {
+                  _prevPage();
+                }
+              },
+            ),
+            SplitScreen(onBack: _prevPage),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/add_expense/presentation/widgets/details_screen.dart
+++ b/lib/features/add_expense/presentation/widgets/details_screen.dart
@@ -201,6 +201,7 @@ class _DetailsScreenState extends State<DetailsScreen> {
                           lastDate: DateTime.now().add(const Duration(days: 1)),
                         );
                         if (date != null) {
+                          if (!context.mounted) return;
                           context.read<AddExpenseWizardBloc>().add(
                             DateChanged(date),
                           );
@@ -268,7 +269,8 @@ class _DetailsScreenState extends State<DetailsScreen> {
               title: const Text('Camera'),
               onTap: () async {
                 Navigator.pop(context);
-                if (parentContext.mounted) await _pickReceipt(parentContext, ImageSource.camera);
+                if (parentContext.mounted)
+                  await _pickReceipt(parentContext, ImageSource.camera);
               },
             ),
             ListTile(
@@ -276,7 +278,8 @@ class _DetailsScreenState extends State<DetailsScreen> {
               title: const Text('Gallery'),
               onTap: () async {
                 Navigator.pop(context);
-                if (parentContext.mounted) await _pickReceipt(parentContext, ImageSource.gallery);
+                if (parentContext.mounted)
+                  await _pickReceipt(parentContext, ImageSource.gallery);
               },
             ),
           ],
@@ -289,6 +292,7 @@ class _DetailsScreenState extends State<DetailsScreen> {
     final picker = ImagePicker();
     final picked = await picker.pickImage(source: source);
     if (picked != null) {
+      if (!context.mounted) return;
       context.read<AddExpenseWizardBloc>().add(ReceiptSelected(picked.path));
     }
   }

--- a/lib/features/add_expense/presentation/widgets/details_screen.dart
+++ b/lib/features/add_expense/presentation/widgets/details_screen.dart
@@ -1,0 +1,356 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_bloc.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_event.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_state.dart';
+import 'package:expense_tracker/features/groups/domain/repositories/groups_repository.dart';
+import 'package:expense_tracker/features/categories/domain/repositories/category_repository.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_entity.dart';
+import 'package:expense_tracker/features/categories/domain/entities/category.dart';
+import 'package:expense_tracker/core/di/service_locator.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:intl/intl.dart';
+
+class DetailsScreen extends StatefulWidget {
+  final Function(bool isGroup) onNext;
+  final VoidCallback onBack;
+
+  const DetailsScreen({super.key, required this.onNext, required this.onBack});
+
+  @override
+  State<DetailsScreen> createState() => _DetailsScreenState();
+}
+
+class _DetailsScreenState extends State<DetailsScreen> {
+  final TextEditingController _descController = TextEditingController();
+  final TextEditingController _notesController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    final state = context.read<AddExpenseWizardBloc>().state;
+    _descController.text = state.description;
+    _notesController.text = state.notes;
+  }
+
+  @override
+  void dispose() {
+    _descController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<AddExpenseWizardBloc, AddExpenseWizardState>(
+      listener: (context, state) {
+        // Update controllers if state changes externally (optional)
+      },
+      builder: (context, state) {
+        return Scaffold(
+          appBar: AppBar(
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: widget.onBack,
+            ),
+            title: const Text('Details'),
+            actions: [
+              if (state.groupId == null)
+                TextButton(
+                  onPressed: () {
+                    context.read<AddExpenseWizardBloc>().add(
+                      const SubmitExpense(),
+                    );
+                  },
+                  child: const Text('SAVE'),
+                )
+              else
+                TextButton(
+                  onPressed: () => widget.onNext(true),
+                  child: const Text('NEXT'),
+                ),
+            ],
+          ),
+          body: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              // Context Selector (Pill)
+              Center(
+                child: ActionChip(
+                  avatar: Icon(
+                    state.groupId == null ? Icons.person : Icons.group,
+                  ),
+                  label: Text(state.selectedGroup?.name ?? 'Personal'),
+                  onPressed: () => _showGroupSelector(context),
+                ),
+              ),
+              const SizedBox(height: 16),
+
+              // Description
+              TextField(
+                controller: _descController,
+                autofocus: true,
+                decoration: const InputDecoration(
+                  labelText: 'Description',
+                  hintText: 'What is this for?',
+                ),
+                onChanged: (val) => context.read<AddExpenseWizardBloc>().add(
+                  DescriptionChanged(val),
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              // Categories Grid
+              const Text(
+                'Category',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              SizedBox(
+                height: 100, // Fixed height for scrolling
+                child: FutureBuilder<dynamic>(
+                  future: sl<CategoryRepository>().getAllCategories(),
+                  builder: (context, snapshot) {
+                    if (!snapshot.hasData)
+                      return const Center(child: CircularProgressIndicator());
+                    final result = snapshot.data;
+                    return result.fold(
+                      (failure) => const Text('Error loading categories'),
+                      (List<Category> categories) {
+                        // Sort by usage? Or just take top 8
+                        final topCategories = categories.take(10).toList();
+                        return ListView.separated(
+                          scrollDirection: Axis.horizontal,
+                          itemCount: topCategories.length,
+                          separatorBuilder: (_, __) =>
+                              const SizedBox(width: 12),
+                          itemBuilder: (context, index) {
+                            final cat = topCategories[index];
+                            final isSelected = state.categoryId == cat.id;
+                            return ChoiceChip(
+                              label: Text(cat.name),
+                              selected: isSelected,
+                              onSelected: (selected) {
+                                if (selected) {
+                                  context.read<AddExpenseWizardBloc>().add(
+                                    CategorySelected(cat),
+                                  );
+                                  if (_descController.text.isEmpty) {
+                                    _descController.text = cat.name;
+                                    context.read<AddExpenseWizardBloc>().add(
+                                      DescriptionChanged(cat.name),
+                                    );
+                                  }
+                                }
+                              },
+                            );
+                          },
+                        );
+                      },
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              // Receipt & Date Row
+              Row(
+                children: [
+                  Expanded(
+                    child: InkWell(
+                      onTap: () => _showReceiptOptions(context),
+                      child: Container(
+                        height: 50,
+                        decoration: BoxDecoration(
+                          border: Border.all(color: Colors.grey),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const Icon(Icons.receipt),
+                            const SizedBox(width: 8),
+                            Text(
+                              state.receiptLocalPath != null
+                                  ? 'Receipt Attached'
+                                  : 'Attach Receipt',
+                            ),
+                            if (state.isUploadingReceipt) ...[
+                              const SizedBox(width: 8),
+                              const SizedBox(
+                                width: 12,
+                                height: 12,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: InkWell(
+                      onTap: () async {
+                        final date = await showDatePicker(
+                          context: context,
+                          initialDate: state.expenseDate,
+                          firstDate: DateTime(2000),
+                          lastDate: DateTime.now().add(const Duration(days: 1)),
+                        );
+                        if (date != null) {
+                          context.read<AddExpenseWizardBloc>().add(
+                            DateChanged(date),
+                          );
+                        }
+                      },
+                      child: Container(
+                        height: 50,
+                        decoration: BoxDecoration(
+                          border: Border.all(color: Colors.grey),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const Icon(Icons.calendar_today),
+                            const SizedBox(width: 8),
+                            Text(
+                              DateFormat(
+                                'MMM dd, yyyy',
+                              ).format(state.expenseDate),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+
+              // Notes
+              TextField(
+                controller: _notesController,
+                decoration: const InputDecoration(
+                  labelText: 'Notes (Optional)',
+                  border: OutlineInputBorder(),
+                ),
+                maxLines: 2,
+                onChanged: (val) =>
+                    context.read<AddExpenseWizardBloc>().add(NotesChanged(val)),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _showGroupSelector(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => _GroupSelectorSheet(),
+    );
+  }
+
+  void _showReceiptOptions(BuildContext parentContext) {
+    showModalBottomSheet(
+      context: parentContext,
+      builder: (context) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: const Text('Camera'),
+              onTap: () {
+                Navigator.pop(context);
+                _pickReceipt(parentContext, ImageSource.camera);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: const Text('Gallery'),
+              onTap: () {
+                Navigator.pop(context);
+                _pickReceipt(parentContext, ImageSource.gallery);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickReceipt(BuildContext context, ImageSource source) async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: source);
+    if (picked != null) {
+      context.read<AddExpenseWizardBloc>().add(ReceiptSelected(picked.path));
+    }
+  }
+}
+
+class _GroupSelectorSheet extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      height: 400,
+      child: Column(
+        children: [
+          const Text(
+            'Select Context',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16),
+          ListTile(
+            leading: const Icon(Icons.person),
+            title: const Text('Personal Expense'),
+            onTap: () {
+              context.read<AddExpenseWizardBloc>().add(
+                const GroupSelected(null),
+              );
+              Navigator.pop(context);
+            },
+          ),
+          const Divider(),
+          Expanded(
+            child: FutureBuilder<dynamic>(
+              future: sl<GroupsRepository>().getGroups(),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData)
+                  return const Center(child: CircularProgressIndicator());
+                return snapshot.data.fold(
+                  (failure) => const Text('Error loading groups'),
+                  (List<GroupEntity> groups) {
+                    if (groups.isEmpty) return const Text('No groups found');
+                    return ListView.builder(
+                      itemCount: groups.length,
+                      itemBuilder: (context, index) {
+                        final group = groups[index];
+                        return ListTile(
+                          leading: const Icon(Icons.group),
+                          title: Text(group.name),
+                          onTap: () {
+                            context.read<AddExpenseWizardBloc>().add(
+                              GroupSelected(group),
+                            );
+                            Navigator.pop(context);
+                          },
+                        );
+                      },
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/add_expense/presentation/widgets/details_screen.dart
+++ b/lib/features/add_expense/presentation/widgets/details_screen.dart
@@ -266,17 +266,17 @@ class _DetailsScreenState extends State<DetailsScreen> {
             ListTile(
               leading: const Icon(Icons.camera_alt),
               title: const Text('Camera'),
-              onTap: () {
+              onTap: () async {
                 Navigator.pop(context);
-                _pickReceipt(parentContext, ImageSource.camera);
+                if (parentContext.mounted) await _pickReceipt(parentContext, ImageSource.camera);
               },
             ),
             ListTile(
               leading: const Icon(Icons.photo_library),
               title: const Text('Gallery'),
-              onTap: () {
+              onTap: () async {
                 Navigator.pop(context);
-                _pickReceipt(parentContext, ImageSource.gallery);
+                if (parentContext.mounted) await _pickReceipt(parentContext, ImageSource.gallery);
               },
             ),
           ],
@@ -310,7 +310,7 @@ class _GroupSelectorSheet extends StatelessWidget {
           ListTile(
             leading: const Icon(Icons.person),
             title: const Text('Personal Expense'),
-            onTap: () {
+            onTap: () async {
               context.read<AddExpenseWizardBloc>().add(
                 const GroupSelected(null),
               );
@@ -335,7 +335,7 @@ class _GroupSelectorSheet extends StatelessWidget {
                         return ListTile(
                           leading: const Icon(Icons.group),
                           title: Text(group.name),
-                          onTap: () {
+                          onTap: () async {
                             context.read<AddExpenseWizardBloc>().add(
                               GroupSelected(group),
                             );

--- a/lib/features/add_expense/presentation/widgets/numpad_screen.dart
+++ b/lib/features/add_expense/presentation/widgets/numpad_screen.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_bloc.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_event.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_state.dart';
+import 'package:expense_tracker/core/utils/currency_formatter.dart';
+
+class NumpadScreen extends StatefulWidget {
+  final VoidCallback onNext;
+
+  const NumpadScreen({super.key, required this.onNext});
+
+  @override
+  State<NumpadScreen> createState() => _NumpadScreenState();
+}
+
+class _NumpadScreenState extends State<NumpadScreen> {
+  String _amountStr = '0';
+
+  @override
+  void initState() {
+    super.initState();
+    final stateAmount = context.read<AddExpenseWizardBloc>().state.amountTotal;
+    if (stateAmount > 0) {
+      _amountStr = stateAmount.toStringAsFixed(2);
+      if (_amountStr.endsWith('.00')) {
+        _amountStr = _amountStr.substring(0, _amountStr.length - 3);
+      }
+    }
+  }
+
+  void _handleInput(String input) {
+    setState(() {
+      if (_amountStr == '0' && input != '.') {
+        _amountStr = input;
+      } else {
+        if (input == '.' && _amountStr.contains('.')) return;
+        // Limit decimals to 2
+        if (_amountStr.contains('.')) {
+          final parts = _amountStr.split('.');
+          if (parts.length > 1 && parts[1].length >= 2) return;
+        }
+        _amountStr += input;
+      }
+    });
+    _updateBloc();
+  }
+
+  void _handleBackspace() {
+    setState(() {
+      if (_amountStr.length > 1) {
+        _amountStr = _amountStr.substring(0, _amountStr.length - 1);
+      } else {
+        _amountStr = '0';
+      }
+    });
+    _updateBloc();
+  }
+
+  void _updateBloc() {
+    final amount = double.tryParse(_amountStr) ?? 0.0;
+    context.read<AddExpenseWizardBloc>().add(AmountChanged(amount));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Enter Amount'), centerTitle: true),
+      body: Column(
+        children: [
+          Expanded(
+            child: Center(
+              child: Text(
+                // Simply display what we typed, formatted lightly?
+                // Or stick to _amountStr for raw feedback
+                '$_amountStr',
+                style: theme.textTheme.displayLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ),
+          ),
+          _buildNumpad(context),
+          const SizedBox(height: 20),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: (double.tryParse(_amountStr) ?? 0) > 0
+            ? widget.onNext
+            : null,
+        label: const Text('Next'),
+        icon: const Icon(Icons.arrow_forward),
+      ),
+    );
+  }
+
+  Widget _buildNumpad(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      height: 350,
+      child: Column(
+        children: [
+          _row(context, ['1', '2', '3']),
+          _row(context, ['4', '5', '6']),
+          _row(context, ['7', '8', '9']),
+          _row(context, ['.', '0', '<']),
+        ],
+      ),
+    );
+  }
+
+  Widget _row(BuildContext context, List<String> keys) {
+    return Expanded(
+      child: Row(
+        children: keys.map((k) => Expanded(child: _key(context, k))).toList(),
+      ),
+    );
+  }
+
+  Widget _key(BuildContext context, String key) {
+    if (key == '<') {
+      return InkWell(
+        onTap: _handleBackspace,
+        borderRadius: BorderRadius.circular(50),
+        child: const Center(child: Icon(Icons.backspace_outlined)),
+      );
+    }
+    return InkWell(
+      onTap: () => _handleInput(key),
+      borderRadius: BorderRadius.circular(50),
+      child: Center(
+        child: Text(key, style: Theme.of(context).textTheme.headlineMedium),
+      ),
+    );
+  }
+}

--- a/lib/features/add_expense/presentation/widgets/numpad_screen.dart
+++ b/lib/features/add_expense/presentation/widgets/numpad_screen.dart
@@ -74,7 +74,7 @@ class _NumpadScreenState extends State<NumpadScreen> {
               child: Text(
                 // Simply display what we typed, formatted lightly?
                 // Or stick to _amountStr for raw feedback
-                '$_amountStr',
+                _amountStr,
                 style: theme.textTheme.displayLarge?.copyWith(
                   fontWeight: FontWeight.bold,
                   color: theme.colorScheme.primary,

--- a/lib/features/add_expense/presentation/widgets/split_screen.dart
+++ b/lib/features/add_expense/presentation/widgets/split_screen.dart
@@ -58,7 +58,7 @@ class SplitScreen extends StatelessWidget {
                 child: Column(
                   children: [
                     Text(
-                      'Total: ${CurrencyFormatter.format(state.amountTotal, currency: state.currency)}',
+                      'Total: ${CurrencyFormatter.format(state.amountTotal, state.currency)}',
                       style: Theme.of(context).textTheme.headlineSmall,
                     ),
                     const SizedBox(height: 8),
@@ -291,7 +291,7 @@ class _SplitRowState extends State<_SplitRow> {
           ],
 
           Text(
-            CurrencyFormatter.format(widget.split.computedAmount, currency: widget.currency),
+            CurrencyFormatter.format(widget.split.computedAmount, widget.currency),
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
         ],

--- a/lib/features/add_expense/presentation/widgets/split_screen.dart
+++ b/lib/features/add_expense/presentation/widgets/split_screen.dart
@@ -25,7 +25,7 @@ class SplitScreen extends StatelessWidget {
           );
           Navigator.of(context).pop();
         } else if (state.status == FormStatus.error) {
-           ScaffoldMessenger.of(context).showSnackBar(
+          ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(state.errorMessage ?? 'Error adding expense'),
               backgroundColor: Theme.of(context).colorScheme.error,
@@ -36,15 +36,29 @@ class SplitScreen extends StatelessWidget {
       builder: (context, state) {
         return Scaffold(
           appBar: AppBar(
-            leading: IconButton(onPressed: onBack, icon: const Icon(Icons.arrow_back)),
+            leading: IconButton(
+              onPressed: onBack,
+              icon: const Icon(Icons.arrow_back),
+            ),
             title: const Text('Split Expense'),
             actions: [
               if (state.status == FormStatus.processing)
-                const Center(child: Padding(padding: EdgeInsets.only(right: 16), child: SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))))
+                const Center(
+                  child: Padding(
+                    padding: EdgeInsets.only(right: 16),
+                    child: SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  ),
+                )
               else
                 TextButton(
                   onPressed: state.isSplitValid
-                      ? () => context.read<AddExpenseWizardBloc>().add(const SubmitExpense())
+                      ? () => context.read<AddExpenseWizardBloc>().add(
+                          const SubmitExpense(),
+                        )
                       : null,
                   child: const Text('SAVE'),
                 ),
@@ -77,7 +91,10 @@ class SplitScreen extends StatelessWidget {
                               ),
                             ),
                             const SizedBox(width: 4),
-                            Icon(Icons.arrow_drop_down, color: Theme.of(context).primaryColor),
+                            Icon(
+                              Icons.arrow_drop_down,
+                              color: Theme.of(context).primaryColor,
+                            ),
                           ],
                         ),
                       ),
@@ -99,7 +116,10 @@ class SplitScreen extends StatelessWidget {
                         label: Text(mode.displayName),
                         selected: isSelected,
                         onSelected: (val) {
-                          if (val) context.read<AddExpenseWizardBloc>().add(SplitModeChanged(mode));
+                          if (val)
+                            context.read<AddExpenseWizardBloc>().add(
+                              SplitModeChanged(mode),
+                            );
                         },
                       ),
                     );
@@ -117,7 +137,14 @@ class SplitScreen extends StatelessWidget {
                     final split = state.splits[index];
                     final member = state.groupMembers.firstWhere(
                       (m) => m.userId == split.userId,
-                      orElse: () => GroupMember(id: '', groupId: '', userId: split.userId, role: GroupRole.member, joinedAt: DateTime.now(), updatedAt: DateTime.now()),
+                      orElse: () => GroupMember(
+                        id: '',
+                        groupId: '',
+                        userId: split.userId,
+                        role: GroupRole.member,
+                        joinedAt: DateTime.now(),
+                        updatedAt: DateTime.now(),
+                      ),
                     );
 
                     return _SplitRow(
@@ -126,7 +153,9 @@ class SplitScreen extends StatelessWidget {
                       mode: state.splitMode,
                       currency: state.currency,
                       onValueChanged: (val) {
-                         context.read<AddExpenseWizardBloc>().add(SplitValueChanged(member.userId, val));
+                        context.read<AddExpenseWizardBloc>().add(
+                          SplitValueChanged(member.userId, val),
+                        );
                       },
                     );
                   },
@@ -138,7 +167,9 @@ class SplitScreen extends StatelessWidget {
                   padding: const EdgeInsets.all(8.0),
                   child: Text(
                     _getValidationError(state),
-                    style: TextStyle(color: Theme.of(context).colorScheme.error),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
                   ),
                 ),
             ],
@@ -155,14 +186,23 @@ class SplitScreen extends StatelessWidget {
     if (payerId == state.currentUserId) return 'You';
     final member = state.groupMembers.firstWhere(
       (m) => m.userId == payerId,
-      orElse: () => GroupMember(id: '', groupId: '', userId: payerId, role: GroupRole.member, joinedAt: DateTime.now(), updatedAt: DateTime.now()),
+      orElse: () => GroupMember(
+        id: '',
+        groupId: '',
+        userId: payerId,
+        role: GroupRole.member,
+        joinedAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ),
     );
     return member.userId; // Ideally Name
   }
 
   String _getValidationError(AddExpenseWizardState state) {
-    if (state.splitMode == SplitMode.percent) return "Total percentage must be 100%";
-    if (state.splitMode == SplitMode.exact) return "Total amount must equal expense total";
+    if (state.splitMode == SplitMode.percent)
+      return "Total percentage must be 100%";
+    if (state.splitMode == SplitMode.exact)
+      return "Total amount must equal expense total";
     return "Invalid splits";
   }
 
@@ -175,7 +215,10 @@ class SplitScreen extends StatelessWidget {
           children: [
             const Padding(
               padding: EdgeInsets.all(16.0),
-              child: Text('Who Paid?', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              child: Text(
+                'Who Paid?',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
             ),
             Expanded(
               child: ListView.builder(
@@ -184,10 +227,14 @@ class SplitScreen extends StatelessWidget {
                   final member = state.groupMembers[index];
                   final isYou = member.userId == state.currentUserId;
                   return ListTile(
-                    leading: CircleAvatar(child: Text(member.userId.substring(0, 1).toUpperCase())),
+                    leading: CircleAvatar(
+                      child: Text(member.userId.substring(0, 1).toUpperCase()),
+                    ),
                     title: Text(isYou ? 'You' : member.userId),
                     onTap: () {
-                      context.read<AddExpenseWizardBloc>().add(SinglePayerSelected(member.userId));
+                      context.read<AddExpenseWizardBloc>().add(
+                        SinglePayerSelected(member.userId),
+                      );
                       Navigator.pop(ctx);
                     },
                   );
@@ -233,12 +280,12 @@ class _SplitRowState extends State<_SplitRow> {
   void didUpdateWidget(_SplitRow oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.mode != widget.mode) {
-       _controller.text = _getInitialValue();
+      _controller.text = _getInitialValue();
     } else if (oldWidget.split.shareValue != widget.split.shareValue) {
-       if (double.tryParse(_controller.text) != widget.split.shareValue) {
-          // Update only if text doesn't match value (external update)
-          _controller.text = _getInitialValue();
-       }
+      if (double.tryParse(_controller.text) != widget.split.shareValue) {
+        // Update only if text doesn't match value (external update)
+        _controller.text = _getInitialValue();
+      }
     }
   }
 
@@ -250,10 +297,12 @@ class _SplitRowState extends State<_SplitRow> {
 
   String _getInitialValue() {
     if (widget.mode == SplitMode.percent || widget.mode == SplitMode.shares) {
-       return widget.split.shareValue.toStringAsFixed(widget.mode == SplitMode.shares ? 0 : 1);
+      return widget.split.shareValue.toStringAsFixed(
+        widget.mode == SplitMode.shares ? 0 : 1,
+      );
     }
     if (widget.mode == SplitMode.exact) {
-       return widget.split.shareValue.toStringAsFixed(2);
+      return widget.split.shareValue.toStringAsFixed(2);
     }
     return '';
   }
@@ -266,24 +315,39 @@ class _SplitRowState extends State<_SplitRow> {
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(
         children: [
-          CircleAvatar(child: Text(widget.member.userId.isNotEmpty ? widget.member.userId.substring(0, 1).toUpperCase() : '?')),
+          CircleAvatar(
+            child: Text(
+              widget.member.userId.isNotEmpty
+                  ? widget.member.userId.substring(0, 1).toUpperCase()
+                  : '?',
+            ),
+          ),
           const SizedBox(width: 12),
-          Expanded(child: Text(widget.member.userId, overflow: TextOverflow.ellipsis)),
+          Expanded(
+            child: Text(widget.member.userId, overflow: TextOverflow.ellipsis),
+          ),
 
           if (isEditable) ...[
             SizedBox(
               width: 80,
               child: TextField(
                 controller: _controller,
-                keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
+                ),
                 decoration: InputDecoration(
-                  suffixText: widget.mode == SplitMode.percent ? '%' : (widget.mode == SplitMode.shares ? 'x' : ''),
+                  suffixText: widget.mode == SplitMode.percent
+                      ? '%'
+                      : (widget.mode == SplitMode.shares ? 'x' : ''),
                   isDense: true,
-                  contentPadding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+                  contentPadding: const EdgeInsets.symmetric(
+                    vertical: 8,
+                    horizontal: 4,
+                  ),
                 ),
                 onChanged: (val) {
-                   final d = double.tryParse(val);
-                   if (d != null) widget.onValueChanged(d);
+                  final d = double.tryParse(val);
+                  if (d != null) widget.onValueChanged(d);
                 },
               ),
             ),
@@ -291,7 +355,10 @@ class _SplitRowState extends State<_SplitRow> {
           ],
 
           Text(
-            CurrencyFormatter.format(widget.split.computedAmount, widget.currency),
+            CurrencyFormatter.format(
+              widget.split.computedAmount,
+              widget.currency,
+            ),
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
         ],

--- a/lib/features/add_expense/presentation/widgets/split_screen.dart
+++ b/lib/features/add_expense/presentation/widgets/split_screen.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_bloc.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_event.dart';
+import 'package:expense_tracker/features/add_expense/presentation/bloc/add_expense_wizard_state.dart';
+import 'package:expense_tracker/features/add_expense/domain/models/add_expense_enums.dart';
+import 'package:expense_tracker/features/add_expense/domain/models/split_model.dart';
+import 'package:expense_tracker/core/utils/currency_formatter.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_member.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_role.dart';
+
+class SplitScreen extends StatelessWidget {
+  final VoidCallback onBack;
+
+  const SplitScreen({super.key, required this.onBack});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<AddExpenseWizardBloc, AddExpenseWizardState>(
+      listenWhen: (previous, current) => previous.status != current.status,
+      listener: (context, state) {
+        if (state.status == FormStatus.success) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Expense added securely.')),
+          );
+          Navigator.of(context).pop();
+        } else if (state.status == FormStatus.error) {
+           ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.errorMessage ?? 'Error adding expense'),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        }
+      },
+      builder: (context, state) {
+        return Scaffold(
+          appBar: AppBar(
+            leading: IconButton(onPressed: onBack, icon: const Icon(Icons.arrow_back)),
+            title: const Text('Split Expense'),
+            actions: [
+              if (state.status == FormStatus.processing)
+                const Center(child: Padding(padding: EdgeInsets.only(right: 16), child: SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))))
+              else
+                TextButton(
+                  onPressed: state.isSplitValid
+                      ? () => context.read<AddExpenseWizardBloc>().add(const SubmitExpense())
+                      : null,
+                  child: const Text('SAVE'),
+                ),
+            ],
+          ),
+          body: Column(
+            children: [
+              // Header
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  children: [
+                    Text(
+                      'Total: ${CurrencyFormatter.format(state.amountTotal, currency: state.currency)}',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    const SizedBox(height: 8),
+                    InkWell(
+                      onTap: () => _showPayerSelector(context, state),
+                      child: Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              'Paid by ${_getPayerName(state)}',
+                              style: TextStyle(
+                                color: Theme.of(context).primaryColor,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            Icon(Icons.arrow_drop_down, color: Theme.of(context).primaryColor),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // Mode Selector
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Row(
+                  children: SplitMode.values.map((mode) {
+                    final isSelected = state.splitMode == mode;
+                    return Padding(
+                      padding: const EdgeInsets.only(right: 8),
+                      child: ChoiceChip(
+                        label: Text(mode.displayName),
+                        selected: isSelected,
+                        onSelected: (val) {
+                          if (val) context.read<AddExpenseWizardBloc>().add(SplitModeChanged(mode));
+                        },
+                      ),
+                    );
+                  }).toList(),
+                ),
+              ),
+              const Divider(),
+
+              // Split List
+              Expanded(
+                child: ListView.separated(
+                  itemCount: state.splits.length,
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemBuilder: (context, index) {
+                    final split = state.splits[index];
+                    final member = state.groupMembers.firstWhere(
+                      (m) => m.userId == split.userId,
+                      orElse: () => GroupMember(id: '', groupId: '', userId: split.userId, role: GroupRole.member, joinedAt: DateTime.now(), updatedAt: DateTime.now()),
+                    );
+
+                    return _SplitRow(
+                      member: member,
+                      split: split,
+                      mode: state.splitMode,
+                      currency: state.currency,
+                      onValueChanged: (val) {
+                         context.read<AddExpenseWizardBloc>().add(SplitValueChanged(member.userId, val));
+                      },
+                    );
+                  },
+                ),
+              ),
+
+              if (!state.isSplitValid)
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(
+                    _getValidationError(state),
+                    style: TextStyle(color: Theme.of(context).colorScheme.error),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  String _getPayerName(AddExpenseWizardState state) {
+    if (state.payers.isEmpty) return 'Unknown';
+    if (state.payers.length > 1) return 'Multiple People';
+    final payerId = state.payers.first.userId;
+    if (payerId == state.currentUserId) return 'You';
+    final member = state.groupMembers.firstWhere(
+      (m) => m.userId == payerId,
+      orElse: () => GroupMember(id: '', groupId: '', userId: payerId, role: GroupRole.member, joinedAt: DateTime.now(), updatedAt: DateTime.now()),
+    );
+    return member.userId; // Ideally Name
+  }
+
+  String _getValidationError(AddExpenseWizardState state) {
+    if (state.splitMode == SplitMode.percent) return "Total percentage must be 100%";
+    if (state.splitMode == SplitMode.exact) return "Total amount must equal expense total";
+    return "Invalid splits";
+  }
+
+  void _showPayerSelector(BuildContext context, AddExpenseWizardState state) {
+    showModalBottomSheet(
+      context: context,
+      builder: (_) => SizedBox(
+        height: 300,
+        child: Column(
+          children: [
+            const Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Text('Who Paid?', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            ),
+            Expanded(
+              child: ListView.builder(
+                itemCount: state.groupMembers.length,
+                itemBuilder: (ctx, index) {
+                  final member = state.groupMembers[index];
+                  final isYou = member.userId == state.currentUserId;
+                  return ListTile(
+                    leading: CircleAvatar(child: Text(member.userId.substring(0, 1).toUpperCase())),
+                    title: Text(isYou ? 'You' : member.userId),
+                    onTap: () {
+                      context.read<AddExpenseWizardBloc>().add(SinglePayerSelected(member.userId));
+                      Navigator.pop(ctx);
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SplitRow extends StatefulWidget {
+  final GroupMember member;
+  final SplitModel split;
+  final SplitMode mode;
+  final String currency;
+  final Function(double) onValueChanged;
+
+  const _SplitRow({
+    required this.member,
+    required this.split,
+    required this.mode,
+    required this.currency,
+    required this.onValueChanged,
+  });
+
+  @override
+  State<_SplitRow> createState() => _SplitRowState();
+}
+
+class _SplitRowState extends State<_SplitRow> {
+  late TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: _getInitialValue());
+  }
+
+  @override
+  void didUpdateWidget(_SplitRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.mode != widget.mode) {
+       _controller.text = _getInitialValue();
+    } else if (oldWidget.split.shareValue != widget.split.shareValue) {
+       if (double.tryParse(_controller.text) != widget.split.shareValue) {
+          // Update only if text doesn't match value (external update)
+          _controller.text = _getInitialValue();
+       }
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  String _getInitialValue() {
+    if (widget.mode == SplitMode.percent || widget.mode == SplitMode.shares) {
+       return widget.split.shareValue.toStringAsFixed(widget.mode == SplitMode.shares ? 0 : 1);
+    }
+    if (widget.mode == SplitMode.exact) {
+       return widget.split.shareValue.toStringAsFixed(2);
+    }
+    return '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isEditable = widget.mode != SplitMode.equal;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        children: [
+          CircleAvatar(child: Text(widget.member.userId.isNotEmpty ? widget.member.userId.substring(0, 1).toUpperCase() : '?')),
+          const SizedBox(width: 12),
+          Expanded(child: Text(widget.member.userId, overflow: TextOverflow.ellipsis)),
+
+          if (isEditable) ...[
+            SizedBox(
+              width: 80,
+              child: TextField(
+                controller: _controller,
+                keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                decoration: InputDecoration(
+                  suffixText: widget.mode == SplitMode.percent ? '%' : (widget.mode == SplitMode.shares ? 'x' : ''),
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+                ),
+                onChanged: (val) {
+                   final d = double.tryParse(val);
+                   if (d != null) widget.onValueChanged(d);
+                },
+              ),
+            ),
+            const SizedBox(width: 12),
+          ],
+
+          Text(
+            CurrencyFormatter.format(widget.split.computedAmount, currency: widget.currency),
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main_shell.dart
+++ b/lib/main_shell.dart
@@ -145,7 +145,12 @@ class MainShell extends StatelessWidget {
               onPressed: () {
                 // --- Adjusted FAB navigation based on tab ---
                 switch (currentTabIndex) {
-                  case 0: // Dashboard -> Add Transaction
+                  case 0: // Dashboard -> Add Expense Wizard
+                    log.info(
+                      "[MainShell FAB] Navigating to Add Expense Wizard from Dashboard.",
+                    );
+                    context.push(RouteNames.addExpenseWizard);
+                    break;
                   case 1: // Transactions -> Add Transaction
                     log.info(
                       "[MainShell FAB] Navigating to Add Transaction from tab $currentTabIndex.",

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -53,6 +53,7 @@ import 'package:expense_tracker/features/groups/presentation/pages/group_list_pa
 import 'package:expense_tracker/features/groups/presentation/pages/group_detail_page.dart';
 import 'package:expense_tracker/features/profile/presentation/pages/profile_setup_page.dart';
 import 'package:expense_tracker/features/auth/presentation/pages/lock_screen.dart';
+import 'package:expense_tracker/features/add_expense/presentation/pages/add_expense_wizard_page.dart';
 import 'package:expense_tracker/core/auth/session_state.dart';
 import 'package:expense_tracker/core/auth/session_cubit.dart';
 
@@ -153,6 +154,12 @@ class AppRouter {
         path: RouteNames.initialSetup,
         name: RouteNames.initialSetup,
         builder: (context, state) => const InitialSetupScreen(),
+      ),
+      GoRoute(
+        path: RouteNames.addExpenseWizard,
+        name: RouteNames.addExpenseWizard,
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) => const AddExpenseWizardPage(),
       ),
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) {

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import app_links
 import connectivity_plus
 import file_picker
 import file_selector_macos
+import flutter_image_compress_macos
 import flutter_secure_storage_darwin
 import flutter_timezone
 import local_auth_darwin
@@ -23,6 +24,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1062,7 +1062,7 @@ packages:
     source: hosted
     version: "3.2.1"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -985,10 +985,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1518,26 +1518,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.11"
   timing:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -494,6 +494,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  flutter_image_compress:
+    dependency: "direct main"
+    description:
+      name: flutter_image_compress
+      sha256: "51d23be39efc2185e72e290042a0da41aed70b14ef97db362a6b5368d0523b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  flutter_image_compress_common:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_common
+      sha256: c5c5d50c15e97dd7dc72ff96bd7077b9f791932f2076c5c5b6c43f2c88607bfb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.6"
+  flutter_image_compress_macos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_macos
+      sha256: "20019719b71b743aba0ef874ed29c50747461e5e8438980dfa5c2031898f7337"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  flutter_image_compress_ohos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_ohos
+      sha256: e76b92bbc830ee08f5b05962fc78a532011fcd2041f620b5400a593e96da3f51
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
+  flutter_image_compress_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_platform_interface
+      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  flutter_image_compress_web:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_web
+      sha256: b9b141ac7c686a2ce7bb9a98176321e1182c9074650e47bb140741a44b6f5a96
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -937,10 +985,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1470,26 +1518,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,7 @@ dependencies:
   http: ^1.6.0
   flutter_timezone: ^5.0.1
   image_picker: ^1.2.1
+  flutter_image_compress: ^2.3.0
   country_code_picker: ^3.4.1
   rxdart: ^0.28.0
   windows_single_instance: ^1.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   url_launcher: ^6.3.1
   multi_select_flutter: ^4.1.3
   collection: ^1.18.0
+  path: ^1.9.0
   path_provider: ^2.1.3
   permission_handler: ^11.3.1
   csv: ^6.0.0

--- a/test/features/add_expense/domain/logic/split_preview_engine_test.dart
+++ b/test/features/add_expense/domain/logic/split_preview_engine_test.dart
@@ -1,0 +1,106 @@
+import 'package:expense_tracker/features/add_expense/domain/logic/split_preview_engine.dart';
+import 'package:expense_tracker/features/add_expense/domain/models/split_model.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_member.dart';
+import 'package:expense_tracker/features/groups/domain/entities/group_role.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SplitPreviewEngine', () {
+    test(
+      'calculateEqualSplits distributes remainder correctly (10.00 / 3)',
+      () {
+        final members = [
+          GroupMember(
+            id: '1',
+            groupId: 'g1',
+            userId: 'u1',
+            role: GroupRole.member,
+            joinedAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+          GroupMember(
+            id: '2',
+            groupId: 'g1',
+            userId: 'u2',
+            role: GroupRole.member,
+            joinedAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+          GroupMember(
+            id: '3',
+            groupId: 'g1',
+            userId: 'u3',
+            role: GroupRole.member,
+            joinedAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        ];
+
+        final splits = SplitPreviewEngine.calculateEqualSplits(10.00, members);
+
+        expect(splits.length, 3);
+        // 10.00 -> 1000 cents. 1000 / 3 = 333 remainder 1.
+        // So first gets 3.34, others 3.33.
+        expect(splits[0].computedAmount, 3.34);
+        expect(splits[1].computedAmount, 3.33);
+        expect(splits[2].computedAmount, 3.33);
+
+        final total = splits.fold(0.0, (sum, s) => sum + s.computedAmount);
+        expect(total, 10.00);
+      },
+    );
+
+    test('validatePercent checks sum == 100', () {
+      final validSplits = [
+        SplitModel(
+          userId: 'u1',
+          shareType: SplitType.PERCENT,
+          shareValue: 40,
+          computedAmount: 40,
+        ),
+        SplitModel(
+          userId: 'u2',
+          shareType: SplitType.PERCENT,
+          shareValue: 60,
+          computedAmount: 60,
+        ),
+      ];
+      expect(SplitPreviewEngine.validatePercent(validSplits), true);
+
+      final invalidSplits = [
+        SplitModel(
+          userId: 'u1',
+          shareType: SplitType.PERCENT,
+          shareValue: 40,
+          computedAmount: 40,
+        ),
+        SplitModel(
+          userId: 'u2',
+          shareType: SplitType.PERCENT,
+          shareValue: 50,
+          computedAmount: 50,
+        ),
+      ];
+      expect(SplitPreviewEngine.validatePercent(invalidSplits), false);
+    });
+
+    test('validateExact checks sum == total', () {
+      final splits = [
+        SplitModel(
+          userId: 'u1',
+          shareType: SplitType.EXACT,
+          shareValue: 10,
+          computedAmount: 10,
+        ),
+        SplitModel(
+          userId: 'u2',
+          shareType: SplitType.EXACT,
+          shareValue: 20,
+          computedAmount: 20,
+        ),
+      ];
+      expect(SplitPreviewEngine.validateExact(splits, 30.0), true);
+      expect(SplitPreviewEngine.validateExact(splits, 40.0), false);
+    });
+  });
+}


### PR DESCRIPTION
Implemented Phase 3B: Fast UI Expense Wizard.
- New Route: `/add-expense-wizard`
- Features: Numpad, Details (Context/Category/Receipt), Split (Group only).
- Logic: `AddExpenseWizardBloc`, `SplitPreviewEngine`.
- Storage: `ImageCompressionService`, Supabase Upload.
- Resilience: Optimistic UI, Outbox persistence with fallback for local receipt path.
- Dependencies: `flutter_image_compress` added.

---
*PR created automatically by Jules for task [16978629299919827348](https://jules.google.com/task/16978629299919827348) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step Add Expense Wizard (numpad → details → split) reachable from main FAB; supports personal and group expenses, payer selection, multiple split modes with validation.
  * Receipt capture with background compression and cloud upload.

* **Offline / Resilience**
  * Local receipt tracking and queued syncing so saves aren’t blocked by network or upload failures.

* **Documentation**
  * Phase 3B QA checklist covering flows, receipts, offline scenarios, and UX checks.

* **Tests**
  * Unit tests for split calculations and validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->