### PR TITLE
Add comprehensive widget tests for UI Kit components

### DIFF
--- a/test/ui_kit/components/feedback/app_banner_test.dart
+++ b/test/ui_kit/components/feedback/app_banner_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/feedback/app_banner.dart';
+
+void main() {
+  group('AppBanner', () {
+    testWidgets('renders message', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(child: AppBanner(message: 'Test Message')),
+        ),
+      );
+
+      expect(find.text('Test Message'), findsOneWidget);
+    });
+
+    testWidgets('renders different types without crashing', (tester) async {
+      for (final type in AppBannerType.values) {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: AppBanner(message: 'Test Message', type: type),
+            ),
+          ),
+        );
+        expect(find.text('Test Message'), findsOneWidget);
+      }
+    });
+
+    testWidgets('calls onDismiss when close icon is tapped', (tester) async {
+      bool dismissed = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: AppBanner(
+              message: 'Test Message',
+              onDismiss: () => dismissed = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.close));
+      expect(dismissed, true);
+    });
+
+    testWidgets('renders action widget if provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppBanner(
+              message: 'Test Message',
+              action: Text('Custom Action'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Custom Action'), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/feedback/app_bottom_sheet_test.dart
+++ b/test/ui_kit/components/feedback/app_bottom_sheet_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/feedback/app_bottom_sheet.dart';
+
+void main() {
+  group('AppBottomSheet', () {
+    testWidgets('renders child widget', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppBottomSheet(child: Text('BottomSheet Content')),
+          ),
+        ),
+      );
+
+      expect(find.text('BottomSheet Content'), findsOneWidget);
+    });
+
+    testWidgets('renders title when provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppBottomSheet(
+              title: 'My Title',
+              child: Text('BottomSheet Content'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('My Title'), findsOneWidget);
+      expect(find.byType(Divider), findsOneWidget);
+    });
+
+    testWidgets('AppBottomSheet.show presents bottom sheet', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () {
+                AppBottomSheet.show(
+                  context: context,
+                  title: 'Show Title',
+                  child: const Text('Show Content'),
+                );
+              },
+              child: const Text('Open Sheet'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open Sheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Show Title'), findsOneWidget);
+      expect(find.text('Show Content'), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/feedback/app_dialog_test.dart
+++ b/test/ui_kit/components/feedback/app_dialog_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/feedback/app_dialog.dart';
+import 'package:expense_tracker/ui_kit/components/buttons/app_button.dart';
+
+void main() {
+  group('AppDialog', () {
+    testWidgets('renders basic dialog with title and content', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: AppDialog(title: 'Test Title', content: 'Test Content'),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.text('Test Content'), findsOneWidget);
+    });
+
+    testWidgets('renders contentWidget when provided', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: AppDialog(
+              title: 'Test Title',
+              contentWidget: const Text('Custom Widget'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Custom Widget'), findsOneWidget);
+    });
+
+    testWidgets('renders buttons and handles actions', (tester) async {
+      bool confirmTapped = false;
+      bool cancelTapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: AppDialog(
+              title: 'Test Title',
+              confirmLabel: 'Confirm',
+              cancelLabel: 'Cancel',
+              onConfirm: () => confirmTapped = true,
+              onCancel: () => cancelTapped = true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Confirm'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+
+      await tester.tap(find.text('Confirm'));
+      expect(confirmTapped, true);
+
+      await tester.tap(find.text('Cancel'));
+      expect(cancelTapped, true);
+    });
+
+    testWidgets('AppDialog.show presents dialog', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () {
+                AppDialog.show(
+                  context: context,
+                  title: 'Show Title',
+                  content: 'Show Content',
+                  confirmLabel: 'OK',
+                );
+              },
+              child: const Text('Open Dialog'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Show Title'), findsOneWidget);
+      expect(find.text('Show Content'), findsOneWidget);
+      expect(find.text('OK'), findsOneWidget);
+
+      // Tap default OK (onConfirm not provided) and pop might not happen without Navigator.pop
+      // but test is just to show it renders.
+    });
+  });
+}

--- a/test/ui_kit/components/feedback/app_toast_test.dart
+++ b/test/ui_kit/components/feedback/app_toast_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/feedback/app_toast.dart';
+
+void main() {
+  group('AppToast', () {
+    testWidgets('shows snackbar with correct message', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () {
+                  AppToast.show(context, 'Test Toast Message');
+                },
+                child: const Text('Show Toast'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Toast'));
+      await tester.pump();
+
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.text('Test Toast Message'), findsOneWidget);
+    });
+
+    for (final type in AppToastType.values) {
+      testWidgets('supports ${type.name} type', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () {
+                    AppToast.show(context, 'Toast ${type.name}', type: type);
+                  },
+                  child: Text('Show ${type.name}'),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Show ${type.name}'));
+        await tester.pump();
+
+        expect(find.text('Toast ${type.name}'), findsOneWidget);
+      });
+    }
+  });
+}

--- a/test/ui_kit/components/feedback/app_tooltip_test.dart
+++ b/test/ui_kit/components/feedback/app_tooltip_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/feedback/app_tooltip.dart';
+
+void main() {
+  group('AppTooltip', () {
+    testWidgets('renders child and passes message to Tooltip', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppTooltip(
+              message: 'Tooltip message',
+              child: Text('Hover me'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Hover me'), findsOneWidget);
+
+      final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tooltip.message, 'Tooltip message');
+    });
+
+    testWidgets('applies custom decoration and textStyle', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppTooltip(message: 'Test Tooltip', child: Icon(Icons.info)),
+          ),
+        ),
+      );
+
+      final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tooltip.decoration, isA<BoxDecoration>());
+      expect(tooltip.textStyle, isA<TextStyle>());
+    });
+  });
+}

--- a/test/ui_kit/components/foundations/app_badge_test.dart
+++ b/test/ui_kit/components/foundations/app_badge_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/foundations/app_badge.dart';
+
+void main() {
+  group('AppBadge', () {
+    testWidgets('renders basic badge with primary type by default', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppBadge(label: 'New'),
+          ),
+        ),
+      );
+
+      expect(find.text('New'), findsOneWidget);
+    });
+
+    testWidgets('renders all badge types correctly', (tester) async {
+      for (final type in AppBadgeType.values) {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: AppBadge(
+                label: type.name,
+                type: type,
+              ),
+            ),
+          ),
+        );
+        expect(find.text(type.name), findsOneWidget);
+      }
+    });
+  });
+}

--- a/test/ui_kit/components/foundations/app_badge_test.dart
+++ b/test/ui_kit/components/foundations/app_badge_test.dart
@@ -4,12 +4,12 @@ import 'package:expense_tracker/ui_kit/components/foundations/app_badge.dart';
 
 void main() {
   group('AppBadge', () {
-    testWidgets('renders basic badge with primary type by default', (tester) async {
+    testWidgets('renders basic badge with primary type by default', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: Material(
-            child: AppBadge(label: 'New'),
-          ),
+          home: Material(child: AppBadge(label: 'New')),
         ),
       );
 
@@ -21,10 +21,7 @@ void main() {
         await tester.pumpWidget(
           MaterialApp(
             home: Material(
-              child: AppBadge(
-                label: type.name,
-                type: type,
-              ),
+              child: AppBadge(label: type.name, type: type),
             ),
           ),
         );

--- a/test/ui_kit/components/foundations/app_card_test.dart
+++ b/test/ui_kit/components/foundations/app_card_test.dart
@@ -31,9 +31,7 @@ void main() {
 
             if (modeTheme != null) {
               return Theme(
-                data: ThemeData().copyWith(
-                  extensions: [modeTheme],
-                ),
+                data: ThemeData().copyWith(extensions: [modeTheme]),
                 child: Builder(
                   builder: (innerContext) {
                     return AppCard(
@@ -45,7 +43,7 @@ void main() {
                       glass: glass,
                       child: child,
                     );
-                  }
+                  },
                 ),
               );
             }
@@ -68,10 +66,7 @@ void main() {
 
     testWidgets('renders glass effect when requested', (tester) async {
       await tester.pumpWidget(
-        buildTestWidget(
-          glass: true,
-          child: const Text('Glass Content'),
-        ),
+        buildTestWidget(glass: true, child: const Text('Glass Content')),
       );
 
       expect(find.text('Glass Content'), findsOneWidget);

--- a/test/ui_kit/components/foundations/app_card_test.dart
+++ b/test/ui_kit/components/foundations/app_card_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/foundations/app_card.dart';
+import 'package:expense_tracker/ui_kit/theme/app_mode_theme.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+
+void main() {
+  Widget buildTestWidget({
+    required Widget child,
+    VoidCallback? onTap,
+    EdgeInsetsGeometry? padding,
+    EdgeInsetsGeometry? margin,
+    Color? color,
+    double? elevation,
+    bool glass = false,
+    AppModeTheme? modeTheme,
+  }) {
+    return MaterialApp(
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            Widget content = AppCard(
+              onTap: onTap,
+              padding: padding,
+              margin: margin,
+              color: color,
+              elevation: elevation,
+              glass: glass,
+              child: child,
+            );
+
+            if (modeTheme != null) {
+              return Theme(
+                data: ThemeData().copyWith(
+                  extensions: [modeTheme],
+                ),
+                child: Builder(
+                  builder: (innerContext) {
+                    return AppCard(
+                      onTap: onTap,
+                      padding: padding,
+                      margin: margin,
+                      color: color,
+                      elevation: elevation,
+                      glass: glass,
+                      child: child,
+                    );
+                  }
+                ),
+              );
+            }
+            return content;
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppCard', () {
+    testWidgets('renders child in Card by default', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(child: const Text('Card Content')),
+      );
+
+      expect(find.text('Card Content'), findsOneWidget);
+      expect(find.byType(Card), findsOneWidget);
+    });
+
+    testWidgets('renders glass effect when requested', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          glass: true,
+          child: const Text('Glass Content'),
+        ),
+      );
+
+      expect(find.text('Glass Content'), findsOneWidget);
+      expect(find.byType(BackdropFilter), findsOneWidget);
+      expect(find.byType(Card), findsNothing);
+    });
+
+    testWidgets('handles onTap in standard card', (tester) async {
+      bool tapped = false;
+      await tester.pumpWidget(
+        buildTestWidget(
+          onTap: () => tapped = true,
+          child: const Text('Tap Me'),
+        ),
+      );
+
+      await tester.tap(find.text('Tap Me'));
+      expect(tapped, true);
+    });
+
+    testWidgets('handles onTap in glass card', (tester) async {
+      bool tapped = false;
+      await tester.pumpWidget(
+        buildTestWidget(
+          glass: true,
+          onTap: () => tapped = true,
+          child: const Text('Tap Me Glass'),
+        ),
+      );
+
+      await tester.tap(find.text('Tap Me Glass'));
+      expect(tapped, true);
+    });
+  });
+}

--- a/test/ui_kit/components/foundations/app_divider_test.dart
+++ b/test/ui_kit/components/foundations/app_divider_test.dart
@@ -6,11 +6,7 @@ void main() {
   group('AppDivider', () {
     testWidgets('renders basic divider with defaults', (tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: AppDivider(),
-          ),
-        ),
+        const MaterialApp(home: Material(child: AppDivider())),
       );
 
       final dividerFinder = find.byType(Divider);

--- a/test/ui_kit/components/foundations/app_divider_test.dart
+++ b/test/ui_kit/components/foundations/app_divider_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/foundations/app_divider.dart';
+
+void main() {
+  group('AppDivider', () {
+    testWidgets('renders basic divider with defaults', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppDivider(),
+          ),
+        ),
+      );
+
+      final dividerFinder = find.byType(Divider);
+      expect(dividerFinder, findsOneWidget);
+
+      final divider = tester.widget<Divider>(dividerFinder);
+      expect(divider.height, 16.0);
+      expect(divider.thickness, 1.0);
+    });
+
+    testWidgets('applies custom properties', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppDivider(
+              height: 20.0,
+              thickness: 2.0,
+              color: Colors.red,
+              indent: 10.0,
+              endIndent: 10.0,
+            ),
+          ),
+        ),
+      );
+
+      final dividerFinder = find.byType(Divider);
+      expect(dividerFinder, findsOneWidget);
+
+      final divider = tester.widget<Divider>(dividerFinder);
+      expect(divider.height, 20.0);
+      expect(divider.thickness, 2.0);
+      expect(divider.color, Colors.red);
+      expect(divider.indent, 10.0);
+      expect(divider.endIndent, 10.0);
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_checkbox_test.dart
+++ b/test/ui_kit/components/inputs/app_checkbox_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_checkbox.dart';
+
+void main() {
+  Widget buildTestWidget({
+    required bool value,
+    required ValueChanged<bool?>? onChanged,
+  }) {
+    return MaterialApp(
+      home: Material(
+        child: AppCheckbox(value: value, onChanged: onChanged),
+      ),
+    );
+  }
+
+  group('AppCheckbox', () {
+    testWidgets('renders unchecked', (tester) async {
+      await tester.pumpWidget(buildTestWidget(value: false, onChanged: (_) {}));
+
+      final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+      expect(checkbox.value, false);
+    });
+
+    testWidgets('renders checked', (tester) async {
+      await tester.pumpWidget(buildTestWidget(value: true, onChanged: (_) {}));
+
+      final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+      expect(checkbox.value, true);
+    });
+
+    testWidgets('calls onChanged when tapped', (tester) async {
+      bool? changedValue;
+      await tester.pumpWidget(
+        buildTestWidget(value: false, onChanged: (val) => changedValue = val),
+      );
+
+      await tester.tap(find.byType(Checkbox));
+      expect(changedValue, true);
+    });
+
+    testWidgets('renders disabled when onChanged is null', (tester) async {
+      await tester.pumpWidget(buildTestWidget(value: false, onChanged: null));
+
+      final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+      expect(checkbox.onChanged, null);
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_date_picker_field_test.dart
+++ b/test/ui_kit/components/inputs/app_date_picker_field_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_date_picker_field.dart';
+
+void main() {
+  Widget buildTestWidget({
+    DateTime? selectedDate,
+    required ValueChanged<DateTime> onDateSelected,
+    String label = 'Date',
+    String? hint,
+  }) {
+    return MaterialApp(
+      home: Material(
+        child: AppDatePickerField(
+          selectedDate: selectedDate,
+          onDateSelected: onDateSelected,
+          label: label,
+          hint: hint,
+        ),
+      ),
+    );
+  }
+
+  group('AppDatePickerField', () {
+    testWidgets('renders hint when no date provided', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(onDateSelected: (_) {}, hint: 'Select Date'),
+      );
+
+      expect(find.text('Select Date'), findsOneWidget);
+    });
+
+    testWidgets('renders formatted date when provided', (tester) async {
+      final testDate = DateTime(2023, 10, 15);
+      final formattedDate = DateFormat.yMMMd().format(testDate);
+
+      await tester.pumpWidget(
+        buildTestWidget(selectedDate: testDate, onDateSelected: (_) {}),
+      );
+
+      expect(find.text(formattedDate), findsOneWidget);
+    });
+
+    testWidgets('shows DatePicker when tapped', (tester) async {
+      await tester.pumpWidget(buildTestWidget(onDateSelected: (_) {}));
+
+      await tester.tap(find.byIcon(Icons.calendar_today));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DatePickerDialog), findsOneWidget);
+    });
+
+    testWidgets('calls onDateSelected when new date is picked', (tester) async {
+      DateTime? pickedDate;
+      await tester.pumpWidget(
+        buildTestWidget(
+          selectedDate: DateTime(2023, 1, 1),
+          onDateSelected: (date) => pickedDate = date,
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.calendar_today));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('15'));
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      expect(pickedDate, isNotNull);
+      expect(pickedDate!.day, 15);
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_dropdown_test.dart
+++ b/test/ui_kit/components/inputs/app_dropdown_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_dropdown.dart';
+
+void main() {
+  Widget buildTestWidget({
+    String? value,
+    List<DropdownMenuItem<String>>? items,
+    ValueChanged<String?>? onChanged,
+    String? label,
+    String? hint,
+  }) {
+    return MaterialApp(
+      home: Material(
+        child: AppDropdown<String>(
+          value: value,
+          items:
+              items ??
+              [
+                const DropdownMenuItem(value: '1', child: Text('Item 1')),
+                const DropdownMenuItem(value: '2', child: Text('Item 2')),
+              ],
+          onChanged: onChanged,
+          label: label,
+          hint: hint,
+        ),
+      ),
+    );
+  }
+
+  group('AppDropdown', () {
+    testWidgets('renders hint when no value provided', (tester) async {
+      await tester.pumpWidget(buildTestWidget(hint: 'Select an item'));
+
+      expect(find.text('Select an item'), findsOneWidget);
+    });
+
+    testWidgets('renders label when provided', (tester) async {
+      await tester.pumpWidget(buildTestWidget(label: 'My Dropdown'));
+
+      expect(find.text('My Dropdown'), findsOneWidget);
+    });
+
+    testWidgets('displays selected value', (tester) async {
+      await tester.pumpWidget(buildTestWidget(value: '1'));
+
+      expect(find.text('Item 1'), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged when an item is selected', (tester) async {
+      String? selectedValue;
+      await tester.pumpWidget(
+        buildTestWidget(value: '1', onChanged: (val) => selectedValue = val),
+      );
+
+      await tester.tap(find.byType(DropdownButton<String>));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Item 2').last);
+      await tester.pumpAndSettle();
+
+      expect(selectedValue, '2');
+    });
+
+    testWidgets('is disabled when onChanged is null', (tester) async {
+      await tester.pumpWidget(buildTestWidget(onChanged: null));
+
+      final dropdown = tester.widget<DropdownButton<String>>(
+        find.byType(DropdownButton<String>),
+      );
+      expect(dropdown.onChanged, null);
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_search_field_test.dart
+++ b/test/ui_kit/components/inputs/app_search_field_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_search_field.dart';
+
+void main() {
+  Widget buildTestWidget({
+    TextEditingController? controller,
+    ValueChanged<String>? onChanged,
+    String? hint,
+  }) {
+    return MaterialApp(
+      home: Material(
+        child: AppSearchField(
+          controller: controller,
+          onChanged: onChanged,
+          hint: hint,
+        ),
+      ),
+    );
+  }
+
+  group('AppSearchField', () {
+    testWidgets('renders with default hint text', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.text('Search...'), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsOneWidget);
+    });
+
+    testWidgets('renders with custom hint text', (tester) async {
+      await tester.pumpWidget(buildTestWidget(hint: 'Custom hint'));
+
+      expect(find.text('Custom hint'), findsOneWidget);
+    });
+
+    testWidgets('uses provided controller', (tester) async {
+      final controller = TextEditingController(text: 'Initial text');
+      await tester.pumpWidget(buildTestWidget(controller: controller));
+
+      expect(find.text('Initial text'), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged when text changes', (tester) async {
+      String changedText = '';
+      await tester.pumpWidget(
+        buildTestWidget(onChanged: (val) => changedText = val),
+      );
+
+      await tester.enterText(find.byType(TextField), 'new text');
+      expect(changedText, 'new text');
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_segmented_control_test.dart
+++ b/test/ui_kit/components/inputs/app_segmented_control_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_segmented_control.dart';
+
+void main() {
+  Widget buildTestWidget({
+    required Map<String, Widget> children,
+    required String? groupValue,
+    required ValueChanged<String?> onValueChanged,
+  }) {
+    return MaterialApp(
+      home: Material(
+        child: AppSegmentedControl<String>(
+          children: children,
+          groupValue: groupValue,
+          onValueChanged: onValueChanged,
+        ),
+      ),
+    );
+  }
+
+  group('AppSegmentedControl', () {
+    final Map<String, Widget> testChildren = {
+      '1': const Text('Option 1'),
+      '2': const Text('Option 2'),
+    };
+
+    testWidgets('renders all children', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          children: testChildren,
+          groupValue: '1',
+          onValueChanged: (_) {},
+        ),
+      );
+
+      expect(find.text('Option 1'), findsOneWidget);
+      expect(find.text('Option 2'), findsOneWidget);
+      expect(
+        find.byType(CupertinoSlidingSegmentedControl<String>),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('passes correct groupValue', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          children: testChildren,
+          groupValue: '2',
+          onValueChanged: (_) {},
+        ),
+      );
+
+      final control = tester.widget<CupertinoSlidingSegmentedControl<String>>(
+        find.byType(CupertinoSlidingSegmentedControl<String>),
+      );
+      expect(control.groupValue, '2');
+    });
+
+    testWidgets('calls onValueChanged when an option is tapped', (
+      tester,
+    ) async {
+      String? changedValue;
+      await tester.pumpWidget(
+        buildTestWidget(
+          children: testChildren,
+          groupValue: '1',
+          onValueChanged: (val) => changedValue = val,
+        ),
+      );
+
+      await tester.tap(find.text('Option 2'));
+      await tester.pumpAndSettle();
+
+      expect(changedValue, '2');
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_switch_test.dart
+++ b/test/ui_kit/components/inputs/app_switch_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_switch.dart';
+
+void main() {
+  Widget buildTestWidget({
+    required bool value,
+    required ValueChanged<bool>? onChanged,
+  }) {
+    return MaterialApp(
+      home: Material(
+        child: AppSwitch(value: value, onChanged: onChanged),
+      ),
+    );
+  }
+
+  group('AppSwitch', () {
+    testWidgets('renders off', (tester) async {
+      await tester.pumpWidget(buildTestWidget(value: false, onChanged: (_) {}));
+
+      final cupertinoSwitch = tester.widget<CupertinoSwitch>(
+        find.byType(CupertinoSwitch),
+      );
+      expect(cupertinoSwitch.value, false);
+    });
+
+    testWidgets('renders on', (tester) async {
+      await tester.pumpWidget(buildTestWidget(value: true, onChanged: (_) {}));
+
+      final cupertinoSwitch = tester.widget<CupertinoSwitch>(
+        find.byType(CupertinoSwitch),
+      );
+      expect(cupertinoSwitch.value, true);
+    });
+
+    testWidgets('calls onChanged when tapped', (tester) async {
+      bool? changedValue;
+      await tester.pumpWidget(
+        buildTestWidget(value: false, onChanged: (val) => changedValue = val),
+      );
+
+      await tester.tap(find.byType(CupertinoSwitch));
+      expect(changedValue, true);
+    });
+
+    testWidgets('renders disabled when onChanged is null', (tester) async {
+      await tester.pumpWidget(buildTestWidget(value: false, onChanged: null));
+
+      final cupertinoSwitch = tester.widget<CupertinoSwitch>(
+        find.byType(CupertinoSwitch),
+      );
+      expect(cupertinoSwitch.onChanged, null);
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_text_field_test.dart
+++ b/test/ui_kit/components/inputs/app_text_field_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_text_field.dart';
+
+void main() {
+  Widget buildTestWidget({
+    TextEditingController? controller,
+    String? label,
+    String? hint,
+    String? errorText,
+    bool enabled = true,
+    ValueChanged<String>? onChanged,
+  }) {
+    return MaterialApp(
+      home: Material(
+        child: AppTextField(
+          controller: controller,
+          label: label,
+          hint: hint,
+          errorText: errorText,
+          enabled: enabled,
+          onChanged: onChanged,
+        ),
+      ),
+    );
+  }
+
+  group('AppTextField', () {
+    testWidgets('renders hint only when no label provided', (tester) async {
+      await tester.pumpWidget(buildTestWidget(hint: 'Test hint'));
+
+      expect(find.byType(TextFormField), findsOneWidget);
+      expect(find.text('Test hint'), findsOneWidget);
+    });
+
+    testWidgets('renders label when provided', (tester) async {
+      await tester.pumpWidget(buildTestWidget(label: 'Test label'));
+
+      expect(find.text('Test label'), findsOneWidget);
+    });
+
+    testWidgets('renders error text when provided', (tester) async {
+      await tester.pumpWidget(buildTestWidget(errorText: 'Error!'));
+
+      expect(find.text('Error!'), findsOneWidget);
+    });
+
+    testWidgets('handles user input and controller', (tester) async {
+      final controller = TextEditingController();
+      String changedText = '';
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          controller: controller,
+          onChanged: (val) => changedText = val,
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'Hello');
+      expect(changedText, 'Hello');
+      expect(controller.text, 'Hello');
+    });
+
+    testWidgets('respects enabled flag', (tester) async {
+      await tester.pumpWidget(buildTestWidget(enabled: false));
+
+      final textField = tester.widget<TextFormField>(
+        find.byType(TextFormField),
+      );
+      expect(textField.enabled, false);
+    });
+  });
+}

--- a/test/ui_kit/components/loading/app_empty_state_test.dart
+++ b/test/ui_kit/components/loading/app_empty_state_test.dart
@@ -7,9 +7,7 @@ void main() {
     testWidgets('renders title', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: Material(
-            child: AppEmptyState(title: 'No Data'),
-          ),
+          home: Material(child: AppEmptyState(title: 'No Data')),
         ),
       );
 
@@ -36,10 +34,7 @@ void main() {
       await tester.pumpWidget(
         const MaterialApp(
           home: Material(
-            child: AppEmptyState(
-              title: 'No Data',
-              icon: Icons.error,
-            ),
+            child: AppEmptyState(title: 'No Data', icon: Icons.error),
           ),
         ),
       );

--- a/test/ui_kit/components/loading/app_empty_state_test.dart
+++ b/test/ui_kit/components/loading/app_empty_state_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/loading/app_empty_state.dart';
+
+void main() {
+  group('AppEmptyState', () {
+    testWidgets('renders title', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppEmptyState(title: 'No Data'),
+          ),
+        ),
+      );
+
+      expect(find.text('No Data'), findsOneWidget);
+    });
+
+    testWidgets('renders subtitle when provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppEmptyState(
+              title: 'No Data',
+              subtitle: 'Please check back later.',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('No Data'), findsOneWidget);
+      expect(find.text('Please check back later.'), findsOneWidget);
+    });
+
+    testWidgets('renders icon when provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppEmptyState(
+              title: 'No Data',
+              icon: Icons.error,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.error), findsOneWidget);
+    });
+
+    testWidgets('renders custom illustration instead of icon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppEmptyState(
+              title: 'No Data',
+              icon: Icons.error,
+              customIllustration: Text('Custom Image'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Custom Image'), findsOneWidget);
+      expect(find.byIcon(Icons.error), findsNothing);
+    });
+
+    testWidgets('renders action widget when provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppEmptyState(
+              title: 'No Data',
+              action: ElevatedButton(onPressed: null, child: Text('Retry')),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Retry'), findsOneWidget);
+      expect(find.byType(ElevatedButton), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/loading/app_loading_indicator_test.dart
+++ b/test/ui_kit/components/loading/app_loading_indicator_test.dart
@@ -4,22 +4,19 @@ import 'package:expense_tracker/ui_kit/components/loading/app_loading_indicator.
 
 void main() {
   group('AppLoadingIndicator', () {
-    testWidgets('renders CircularProgressIndicator with default size', (tester) async {
+    testWidgets('renders CircularProgressIndicator with default size', (
+      tester,
+    ) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: AppLoadingIndicator(),
-          ),
-        ),
+        const MaterialApp(home: Material(child: AppLoadingIndicator())),
       );
 
       final indicatorFinder = find.byType(CircularProgressIndicator);
       expect(indicatorFinder, findsOneWidget);
 
-      final sizedBoxFinder = find.ancestor(
-        of: indicatorFinder,
-        matching: find.byType(SizedBox),
-      ).first;
+      final sizedBoxFinder = find
+          .ancestor(of: indicatorFinder, matching: find.byType(SizedBox))
+          .first;
 
       final sizedBox = tester.widget<SizedBox>(sizedBoxFinder);
       expect(sizedBox.width, 24.0);
@@ -30,10 +27,7 @@ void main() {
       await tester.pumpWidget(
         const MaterialApp(
           home: Material(
-            child: AppLoadingIndicator(
-              size: 48.0,
-              color: Colors.red,
-            ),
+            child: AppLoadingIndicator(size: 48.0, color: Colors.red),
           ),
         ),
       );
@@ -41,13 +35,14 @@ void main() {
       final indicatorFinder = find.byType(CircularProgressIndicator);
       expect(indicatorFinder, findsOneWidget);
 
-      final indicator = tester.widget<CircularProgressIndicator>(indicatorFinder);
+      final indicator = tester.widget<CircularProgressIndicator>(
+        indicatorFinder,
+      );
       expect(indicator.valueColor?.value, Colors.red);
 
-      final sizedBoxFinder = find.ancestor(
-        of: indicatorFinder,
-        matching: find.byType(SizedBox),
-      ).first;
+      final sizedBoxFinder = find
+          .ancestor(of: indicatorFinder, matching: find.byType(SizedBox))
+          .first;
 
       final sizedBox = tester.widget<SizedBox>(sizedBoxFinder);
       expect(sizedBox.width, 48.0);

--- a/test/ui_kit/components/loading/app_loading_indicator_test.dart
+++ b/test/ui_kit/components/loading/app_loading_indicator_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/loading/app_loading_indicator.dart';
+
+void main() {
+  group('AppLoadingIndicator', () {
+    testWidgets('renders CircularProgressIndicator with default size', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppLoadingIndicator(),
+          ),
+        ),
+      );
+
+      final indicatorFinder = find.byType(CircularProgressIndicator);
+      expect(indicatorFinder, findsOneWidget);
+
+      final sizedBoxFinder = find.ancestor(
+        of: indicatorFinder,
+        matching: find.byType(SizedBox),
+      ).first;
+
+      final sizedBox = tester.widget<SizedBox>(sizedBoxFinder);
+      expect(sizedBox.width, 24.0);
+      expect(sizedBox.height, 24.0);
+    });
+
+    testWidgets('renders with custom size and color', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppLoadingIndicator(
+              size: 48.0,
+              color: Colors.red,
+            ),
+          ),
+        ),
+      );
+
+      final indicatorFinder = find.byType(CircularProgressIndicator);
+      expect(indicatorFinder, findsOneWidget);
+
+      final indicator = tester.widget<CircularProgressIndicator>(indicatorFinder);
+      expect(indicator.valueColor?.value, Colors.red);
+
+      final sizedBoxFinder = find.ancestor(
+        of: indicatorFinder,
+        matching: find.byType(SizedBox),
+      ).first;
+
+      final sizedBox = tester.widget<SizedBox>(sizedBoxFinder);
+      expect(sizedBox.width, 48.0);
+      expect(sizedBox.height, 48.0);
+    });
+  });
+}

--- a/test/ui_kit/components/loading/app_skeleton_test.dart
+++ b/test/ui_kit/components/loading/app_skeleton_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/loading/app_skeleton.dart';
+
+void main() {
+  group('AppSkeleton', () {
+    testWidgets('renders basic skeleton', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(child: AppSkeleton(width: 100, height: 20)),
+        ),
+      );
+
+      final containerFinder = find.byType(Container);
+      expect(containerFinder, findsOneWidget);
+
+      final container = tester.widget<Container>(containerFinder);
+      expect(container.constraints?.minWidth, 100);
+      expect(container.constraints?.minHeight, 20);
+    });
+
+    testWidgets('renders circle shape', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppSkeleton(width: 50, height: 50, shape: BoxShape.circle),
+          ),
+        ),
+      );
+
+      final containerFinder = find.byType(Container);
+      expect(containerFinder, findsOneWidget);
+
+      final container = tester.widget<Container>(containerFinder);
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.shape, BoxShape.circle);
+      expect(decoration.borderRadius, isNull);
+    });
+
+    testWidgets('animates opacity', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(child: AppSkeleton(width: 100, height: 20)),
+        ),
+      );
+
+      final opacityFinder = find.byType(Opacity);
+      expect(opacityFinder, findsOneWidget);
+
+      final initialOpacity = tester.widget<Opacity>(opacityFinder).opacity;
+
+      // Advance time to allow animation to progress
+      await tester.pump(const Duration(milliseconds: 750));
+
+      final midOpacity = tester.widget<Opacity>(opacityFinder).opacity;
+      expect(initialOpacity, isNot(equals(midOpacity)));
+    });
+  });
+}

--- a/test/ui_kit/components/typography/app_link_text_test.dart
+++ b/test/ui_kit/components/typography/app_link_text_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/typography/app_link_text.dart';
+
+void main() {
+  group('AppLinkText', () {
+    testWidgets('renders text and applies default style', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Material(child: AppLinkText('Click Me'))),
+      );
+
+      expect(find.text('Click Me'), findsOneWidget);
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.style?.decoration, TextDecoration.underline);
+    });
+
+    testWidgets('calls onTap when tapped', (tester) async {
+      bool tapped = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: AppLinkText('Click Me', onTap: () => tapped = true),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Click Me'));
+      expect(tapped, true);
+    });
+
+    testWidgets('respects provided style', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppLinkText('Click Me', style: TextStyle(fontSize: 24)),
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.style?.fontSize, 24);
+      expect(textWidget.style?.decoration, TextDecoration.underline);
+    });
+  });
+}

--- a/test/ui_kit/components/typography/app_text_test.dart
+++ b/test/ui_kit/components/typography/app_text_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/typography/app_text.dart';
+
+void main() {
+  group('AppText', () {
+    testWidgets('renders basic text', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Material(child: AppText('Hello World'))),
+      );
+
+      expect(find.text('Hello World'), findsOneWidget);
+    });
+
+    testWidgets('applies different styles correctly', (tester) async {
+      for (final style in AppTextStyle.values) {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(child: AppText('Styled Text', style: style)),
+          ),
+        );
+
+        expect(find.text('Styled Text'), findsOneWidget);
+        // It's tricky to assert specific TextStyle from tokens accurately without a BuildContext,
+        // but ensuring it doesn't crash covers the switch statement.
+      }
+    });
+
+    testWidgets('applies custom properties', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: AppText(
+              'Custom Text',
+              color: Colors.red,
+              textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.style?.color, Colors.red);
+      expect(textWidget.textAlign, TextAlign.center);
+      expect(textWidget.maxLines, 2);
+      expect(textWidget.overflow, TextOverflow.ellipsis);
+    });
+  });
+}

--- a/test/ui_kit/theme/app_theme_ext_test.dart
+++ b/test/ui_kit/theme/app_theme_ext_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  group('AppKitTheme', () {
+    final defaultTheme = AppKitTheme(
+      colors: AppColors(ColorScheme.light()),
+      typography: AppTypography(TextTheme()),
+      spacing: const AppSpacing(),
+      radii: const AppRadii(),
+      motion: const AppMotion(),
+      shadows: AppShadows(isDark: false),
+    );
+
+    test('copyWith updates properties', () {
+      final newColors = AppColors(ColorScheme.dark());
+      final updatedTheme = defaultTheme.copyWith(colors: newColors);
+
+      expect(updatedTheme.colors, newColors);
+      expect(updatedTheme.typography, defaultTheme.typography);
+    });
+
+    test('lerp works correctly', () {
+      final newTheme = AppKitTheme(
+        colors: AppColors(ColorScheme.dark()),
+        typography: AppTypography(TextTheme()),
+        spacing: const AppSpacing(),
+        radii: const AppRadii(),
+        motion: const AppMotion(),
+        shadows: AppShadows(isDark: true),
+      );
+
+      final lerpedHalf = defaultTheme.lerp(newTheme, 0.4);
+      expect(lerpedHalf.colors, defaultTheme.colors);
+
+      final lerpedFull = defaultTheme.lerp(newTheme, 0.6);
+      expect(lerpedFull.colors, newTheme.colors);
+
+      final lerpedOther = defaultTheme.lerp(null, 0.5);
+      expect(lerpedOther, defaultTheme);
+    });
+  });
+
+  group('AppKitThemeContextExtension', () {
+    testWidgets('kit returns provided extension', (tester) async {
+      final theme = AppKitTheme(
+        colors: AppColors(ColorScheme.light()),
+        typography: AppTypography(TextTheme()),
+        spacing: const AppSpacing(),
+        radii: const AppRadii(),
+        motion: const AppMotion(),
+        shadows: AppShadows(isDark: false),
+      );
+
+      AppKitTheme? contextTheme;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData().copyWith(extensions: [theme]),
+          home: Builder(
+            builder: (context) {
+              contextTheme = context.kit;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(contextTheme, theme);
+    });
+
+    testWidgets('kit returns fallback when extension is missing', (
+      tester,
+    ) async {
+      AppKitTheme? contextTheme;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(),
+          home: Builder(
+            builder: (context) {
+              contextTheme = context.kit;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(contextTheme, isNotNull);
+      expect(contextTheme!.spacing, isA<AppSpacing>());
+    });
+  });
+}


### PR DESCRIPTION
Added comprehensive unit/widget test coverage for exactly 21 previously untested UI Kit component files in `lib/ui_kit/`, driving up the overall testing percentage meaningfully by focusing on UI boundary paths, null conditions, user interactions, and visual states.

---
*PR created automatically by Jules for task [12981604424275327089](https://jules.google.com/task/12981604424275327089) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive widget tests for UI kit: feedback (banners, bottom sheets, dialogs, toasts, tooltips), foundations (badge, card, divider), inputs (checkbox, date picker, dropdown, search, segmented control, switch, text field), loading (empty state, indicator, skeleton), typography (link, text) and theme utilities. Tests cover rendering, user interactions, callbacks, variant coverage, formatting, and animation/visual behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->