### PR TITLE
⚡ Bolt: Optimize UI rebuilds with BlocBuilder buildWhen conditions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
-## 2026-02-06 - [Batch Operations in Clean Architecture]
-**Learning:** Repositories iterating over child entities to perform individual delete/update operations (N+1) are common. Hive supports `deleteAll` for batch removal, which is significantly more efficient than loop-delete.
-**Action:** When implementing `delete` for aggregates (like Goal -> Contributions), always ensure the Datasource exposes a batch delete method to avoid loop-overhead.
+## 2024-05-18 - [Dart/Flutter Performance Baseline]
+**Learning:** This is a Flutter application using Dart and Blocs for state management. While investigating generic lists/ListViews, we need to focus on Dart-specific performance enhancements like `const` constructors where possible, efficient list building with `ListView.builder` over `ListView` for large datasets, avoiding unnecessary rebuilds using `BlocBuilder` with precise `buildWhen`, and lazy-loading components.
+**Action:** Review uses of `ListView` and `SizedBox`/`Padding` to see if they can be optimized to `const`. Look for places where `ListView` is used but could be `ListView.builder`. Check for `Image.network` instead of cached network image.
+
+## 2024-05-18 - [BlocBuilder Optimization]
+**Learning:** There are 38 uses of `BlocBuilder` across the application but ZERO uses of `buildWhen`. This means that ANY state change in these Blocs will trigger a rebuild of the widget subtree, even if the relevant parts of the state haven't changed. This is a massive source of unnecessary re-renders in Flutter apps using Bloc.
+**Action:** I will find 10 instances of `BlocBuilder` that render large lists or complex UI, and add a `buildWhen` condition to them. This ensures the widgets are only rebuilt when the specific properties they depend on actually change.

--- a/lib/features/accounts/presentation/pages/accounts_tab_page.dart
+++ b/lib/features/accounts/presentation/pages/accounts_tab_page.dart
@@ -175,6 +175,7 @@ class _AccountsTabPageState extends State<AccountsTabPage> {
       children: [
         const SectionHeader(title: 'Assets'),
         BlocBuilder<AccountListBloc, AccountListState>(
+          buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is AccountListLoaded && current is AccountListLoaded && previous.items != current.items),
           builder: (context, state) {
             if (state is AccountListLoading && !state.isReloading) {
               return const Center(

--- a/lib/features/accounts/presentation/pages/accounts_tab_page.dart
+++ b/lib/features/accounts/presentation/pages/accounts_tab_page.dart
@@ -175,7 +175,11 @@ class _AccountsTabPageState extends State<AccountsTabPage> {
       children: [
         const SectionHeader(title: 'Assets'),
         BlocBuilder<AccountListBloc, AccountListState>(
-          buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is AccountListLoaded && current is AccountListLoaded && previous.items != current.items),
+          buildWhen: (previous, current) =>
+              previous.runtimeType != current.runtimeType ||
+              (previous is AccountListLoaded &&
+                  current is AccountListLoaded &&
+                  previous.items != current.items),
           builder: (context, state) {
             if (state is AccountListLoading && !state.isReloading) {
               return const Center(

--- a/lib/features/categories/presentation/pages/categories_sub_tab.dart
+++ b/lib/features/categories/presentation/pages/categories_sub_tab.dart
@@ -99,7 +99,12 @@ class CategoriesSubTab extends StatelessWidget {
           ),
           Expanded(
             child: BlocBuilder<CategoryManagementBloc, CategoryManagementState>(
-              buildWhen: (previous, current) => previous.status != current.status || previous.customExpenseCategories != current.customExpenseCategories || previous.customIncomeCategories != current.customIncomeCategories,
+              buildWhen: (previous, current) =>
+                  previous.status != current.status ||
+                  previous.customExpenseCategories !=
+                      current.customExpenseCategories ||
+                  previous.customIncomeCategories !=
+                      current.customIncomeCategories,
               builder: (context, state) {
                 if (state.status == CategoryManagementStatus.initial ||
                     state.status == CategoryManagementStatus.loading) {

--- a/lib/features/categories/presentation/pages/categories_sub_tab.dart
+++ b/lib/features/categories/presentation/pages/categories_sub_tab.dart
@@ -99,6 +99,7 @@ class CategoriesSubTab extends StatelessWidget {
           ),
           Expanded(
             child: BlocBuilder<CategoryManagementBloc, CategoryManagementState>(
+              buildWhen: (previous, current) => previous.status != current.status || previous.customExpenseCategories != current.customExpenseCategories || previous.customIncomeCategories != current.customIncomeCategories,
               builder: (context, state) {
                 if (state.status == CategoryManagementStatus.initial ||
                     state.status == CategoryManagementStatus.loading) {

--- a/lib/features/goals/presentation/pages/goals_sub_tab.dart
+++ b/lib/features/goals/presentation/pages/goals_sub_tab.dart
@@ -18,6 +18,7 @@ class GoalsSubTab extends StatelessWidget {
 
     return Scaffold(
       body: BlocBuilder<GoalListBloc, GoalListState>(
+        buildWhen: (previous, current) => previous.status != current.status || previous.goals != current.goals,
         builder: (context, state) {
           Widget content;
           if (state.status == GoalListStatus.loading && state.goals.isEmpty) {

--- a/lib/features/goals/presentation/pages/goals_sub_tab.dart
+++ b/lib/features/goals/presentation/pages/goals_sub_tab.dart
@@ -18,7 +18,9 @@ class GoalsSubTab extends StatelessWidget {
 
     return Scaffold(
       body: BlocBuilder<GoalListBloc, GoalListState>(
-        buildWhen: (previous, current) => previous.status != current.status || previous.goals != current.goals,
+        buildWhen: (previous, current) =>
+            previous.status != current.status ||
+            previous.goals != current.goals,
         builder: (context, state) {
           Widget content;
           if (state.status == GoalListStatus.loading && state.goals.isEmpty) {

--- a/lib/features/groups/presentation/pages/group_detail_page.dart
+++ b/lib/features/groups/presentation/pages/group_detail_page.dart
@@ -157,6 +157,7 @@ class _GroupDetailPageState extends State<GroupDetailPage>
                     controller: _tabController,
                     children: [
                       BlocBuilder<GroupExpensesBloc, GroupExpensesState>(
+                        buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is GroupExpensesLoaded && current is GroupExpensesLoaded && previous.expenses != current.expenses),
                         builder: (context, state) {
                           if (state is GroupExpensesLoading) {
                             return const Center(

--- a/lib/features/groups/presentation/pages/group_detail_page.dart
+++ b/lib/features/groups/presentation/pages/group_detail_page.dart
@@ -157,7 +157,11 @@ class _GroupDetailPageState extends State<GroupDetailPage>
                     controller: _tabController,
                     children: [
                       BlocBuilder<GroupExpensesBloc, GroupExpensesState>(
-                        buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is GroupExpensesLoaded && current is GroupExpensesLoaded && previous.expenses != current.expenses),
+                        buildWhen: (previous, current) =>
+                            previous.runtimeType != current.runtimeType ||
+                            (previous is GroupExpensesLoaded &&
+                                current is GroupExpensesLoaded &&
+                                previous.expenses != current.expenses),
                         builder: (context, state) {
                           if (state is GroupExpensesLoading) {
                             return const Center(

--- a/lib/features/groups/presentation/pages/group_list_page.dart
+++ b/lib/features/groups/presentation/pages/group_list_page.dart
@@ -77,7 +77,11 @@ class _GroupListPageState extends State<GroupListPage> {
         child: const Icon(Icons.add),
       ),
       body: BlocBuilder<GroupsBloc, GroupsState>(
-        buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is GroupsLoaded && current is GroupsLoaded && previous.groups != current.groups),
+        buildWhen: (previous, current) =>
+            previous.runtimeType != current.runtimeType ||
+            (previous is GroupsLoaded &&
+                current is GroupsLoaded &&
+                previous.groups != current.groups),
         builder: (context, state) {
           if (state is GroupsLoading) {
             return const Center(child: CircularProgressIndicator());

--- a/lib/features/groups/presentation/pages/group_list_page.dart
+++ b/lib/features/groups/presentation/pages/group_list_page.dart
@@ -77,6 +77,7 @@ class _GroupListPageState extends State<GroupListPage> {
         child: const Icon(Icons.add),
       ),
       body: BlocBuilder<GroupsBloc, GroupsState>(
+        buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is GroupsLoaded && current is GroupsLoaded && previous.groups != current.groups),
         builder: (context, state) {
           if (state is GroupsLoading) {
             return const Center(child: CircularProgressIndicator());

--- a/lib/features/groups/presentation/widgets/stitch/group_members_tab.dart
+++ b/lib/features/groups/presentation/widgets/stitch/group_members_tab.dart
@@ -12,7 +12,11 @@ class GroupMembersTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<GroupMembersBloc, GroupMembersState>(
-      buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is GroupMembersLoaded && current is GroupMembersLoaded && previous.members != current.members),
+      buildWhen: (previous, current) =>
+          previous.runtimeType != current.runtimeType ||
+          (previous is GroupMembersLoaded &&
+              current is GroupMembersLoaded &&
+              previous.members != current.members),
       builder: (context, state) {
         if (state is GroupMembersLoading) {
           return const Center(child: CircularProgressIndicator());

--- a/lib/features/groups/presentation/widgets/stitch/group_members_tab.dart
+++ b/lib/features/groups/presentation/widgets/stitch/group_members_tab.dart
@@ -12,6 +12,7 @@ class GroupMembersTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<GroupMembersBloc, GroupMembersState>(
+      buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is GroupMembersLoaded && current is GroupMembersLoaded && previous.members != current.members),
       builder: (context, state) {
         if (state is GroupMembersLoading) {
           return const Center(child: CircularProgressIndicator());

--- a/lib/features/recurring_transactions/presentation/pages/recurring_rule_list_page.dart
+++ b/lib/features/recurring_transactions/presentation/pages/recurring_rule_list_page.dart
@@ -17,6 +17,7 @@ class RecurringRuleListPage extends StatelessWidget {
       body: BlocProvider(
         create: (context) => sl<RecurringListBloc>()..add(LoadRecurringRules()),
         child: BlocBuilder<RecurringListBloc, RecurringListState>(
+          buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is RecurringListLoaded && current is RecurringListLoaded && previous.rules != current.rules),
           builder: (context, state) {
             if (state is RecurringListLoading) {
               return const Center(child: CircularProgressIndicator());

--- a/lib/features/recurring_transactions/presentation/pages/recurring_rule_list_page.dart
+++ b/lib/features/recurring_transactions/presentation/pages/recurring_rule_list_page.dart
@@ -17,7 +17,11 @@ class RecurringRuleListPage extends StatelessWidget {
       body: BlocProvider(
         create: (context) => sl<RecurringListBloc>()..add(LoadRecurringRules()),
         child: BlocBuilder<RecurringListBloc, RecurringListState>(
-          buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is RecurringListLoaded && current is RecurringListLoaded && previous.rules != current.rules),
+          buildWhen: (previous, current) =>
+              previous.runtimeType != current.runtimeType ||
+              (previous is RecurringListLoaded &&
+                  current is RecurringListLoaded &&
+                  previous.rules != current.rules),
           builder: (context, state) {
             if (state is RecurringListLoading) {
               return const Center(child: CircularProgressIndicator());

--- a/lib/features/reports/presentation/pages/budget_performance_page.dart
+++ b/lib/features/reports/presentation/pages/budget_performance_page.dart
@@ -111,6 +111,7 @@ class BudgetPerformancePage extends StatelessWidget {
         );
       },
       body: BlocBuilder<BudgetPerformanceReportBloc, BudgetPerformanceReportState>(
+        buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is BudgetPerformanceReportLoaded && current is BudgetPerformanceReportLoaded && (previous.reportData != current.reportData || previous.showComparison != current.showComparison)),
         builder: (context, state) {
           if (state is BudgetPerformanceReportLoading)
             return const Center(child: CircularProgressIndicator());

--- a/lib/features/reports/presentation/pages/budget_performance_page.dart
+++ b/lib/features/reports/presentation/pages/budget_performance_page.dart
@@ -111,7 +111,12 @@ class BudgetPerformancePage extends StatelessWidget {
         );
       },
       body: BlocBuilder<BudgetPerformanceReportBloc, BudgetPerformanceReportState>(
-        buildWhen: (previous, current) => previous.runtimeType != current.runtimeType || (previous is BudgetPerformanceReportLoaded && current is BudgetPerformanceReportLoaded && (previous.reportData != current.reportData || previous.showComparison != current.showComparison)),
+        buildWhen: (previous, current) =>
+            previous.runtimeType != current.runtimeType ||
+            (previous is BudgetPerformanceReportLoaded &&
+                current is BudgetPerformanceReportLoaded &&
+                (previous.reportData != current.reportData ||
+                    previous.showComparison != current.showComparison)),
         builder: (context, state) {
           if (state is BudgetPerformanceReportLoading)
             return const Center(child: CircularProgressIndicator());

--- a/lib/features/transactions/presentation/pages/transaction_list_page.dart
+++ b/lib/features/transactions/presentation/pages/transaction_list_page.dart
@@ -350,7 +350,12 @@ class _TransactionListPageState extends State<TransactionListPage> {
           const Divider(height: 1, thickness: 1),
           Expanded(
             child: BlocConsumer<TransactionListBloc, TransactionListState>(
-              buildWhen: (previous, current) => previous.status != current.status || previous.transactions != current.transactions || previous.isInBatchEditMode != current.isInBatchEditMode || previous.selectedTransactionIds != current.selectedTransactionIds,
+              buildWhen: (previous, current) =>
+                  previous.status != current.status ||
+                  previous.transactions != current.transactions ||
+                  previous.isInBatchEditMode != current.isInBatchEditMode ||
+                  previous.selectedTransactionIds !=
+                      current.selectedTransactionIds,
               listener: (context, state) {
                 if (state.status == ListStatus.error &&
                     state.errorMessage != null) {
@@ -438,7 +443,10 @@ class _TransactionListPageState extends State<TransactionListPage> {
       ),
       floatingActionButton:
           BlocBuilder<TransactionListBloc, TransactionListState>(
-            buildWhen: (previous, current) => previous.isInBatchEditMode != current.isInBatchEditMode || previous.selectedTransactionIds != current.selectedTransactionIds,
+            buildWhen: (previous, current) =>
+                previous.isInBatchEditMode != current.isInBatchEditMode ||
+                previous.selectedTransactionIds !=
+                    current.selectedTransactionIds,
             builder: (context, state) {
               final bool showFab =
                   state.isInBatchEditMode && !_showCalendarView;

--- a/lib/features/transactions/presentation/pages/transaction_list_page.dart
+++ b/lib/features/transactions/presentation/pages/transaction_list_page.dart
@@ -350,6 +350,7 @@ class _TransactionListPageState extends State<TransactionListPage> {
           const Divider(height: 1, thickness: 1),
           Expanded(
             child: BlocConsumer<TransactionListBloc, TransactionListState>(
+              buildWhen: (previous, current) => previous.status != current.status || previous.transactions != current.transactions || previous.isInBatchEditMode != current.isInBatchEditMode || previous.selectedTransactionIds != current.selectedTransactionIds,
               listener: (context, state) {
                 if (state.status == ListStatus.error &&
                     state.errorMessage != null) {
@@ -437,6 +438,7 @@ class _TransactionListPageState extends State<TransactionListPage> {
       ),
       floatingActionButton:
           BlocBuilder<TransactionListBloc, TransactionListState>(
+            buildWhen: (previous, current) => previous.isInBatchEditMode != current.isInBatchEditMode || previous.selectedTransactionIds != current.selectedTransactionIds,
             builder: (context, state) {
               final bool showFab =
                   state.isInBatchEditMode && !_showCalendarView;


### PR DESCRIPTION
## ⚡ Bolt: BlocBuilder Rebuild Optimizations

### 💡 What
Added `buildWhen` conditions to 10 instances of `BlocBuilder` and `BlocConsumer` widgets across the application (specifically targeting lists and complex screens like Groups, Categories, Goals, Transactions, and Budgets). 

### 🎯 Why
Currently, the application uses over 38 `BlocBuilder` components without a single `buildWhen` condition. This is a common performance anti-pattern in Flutter applications using `flutter_bloc`. Without `buildWhen`, any state emission from the `Bloc` triggers a rebuild of the widget subtree, even if the widget doesn't depend on the changed property.

### 📊 Impact
* **Reduces unnecessary re-renders:** Substantially decreases the number of times heavy list views are rebuilt.
* **Saves CPU cycles:** Makes scrolling and interactions feel smoother, reducing UI jank.

### 🔬 Measurement
Run the application in profile mode and observe the widget rebuild count in the Flutter DevTools Performance view. The count of widget rebuilds during state changes (e.g., when toggling an unrelated setting or when a background sync completes without changing list data) should be significantly lower.

---
*PR created automatically by Jules for task [4100947813321507587](https://jules.google.com/task/4100947813321507587) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary UI rebuilds across accounts, categories, goals, groups, recurring rules, reports, and transactions to improve responsiveness and smoothness.

* **New Features**
  * Transaction list page now accepts initial filters so lists can be pre-filtered on open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->