### PR TITLE
test(uikit): add comprehensive widget tests for 20 core ui_kit components

### DIFF
--- a/test/ui_kit/components/feedback/app_banner_test.dart
+++ b/test/ui_kit/components/feedback/app_banner_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/feedback/app_banner.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppBanner', () {
+    testWidgets('renders message and info type by default', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppBanner(message: 'Info message'),
+        ),
+      );
+
+      expect(find.text('Info message'), findsOneWidget);
+      expect(find.byIcon(Icons.info_outline), findsOneWidget);
+    });
+
+    testWidgets('renders success type', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppBanner(message: 'Success!', type: AppBannerType.success),
+        ),
+      );
+
+      expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+    });
+
+    testWidgets('renders warning type', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppBanner(message: 'Warning!', type: AppBannerType.warning),
+        ),
+      );
+
+      expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+    });
+
+    testWidgets('renders error type', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppBanner(message: 'Error!', type: AppBannerType.error),
+        ),
+      );
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    });
+
+    testWidgets('triggers onDismiss callback', (tester) async {
+      bool dismissed = false;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppBanner(
+            message: 'Dismiss me',
+            onDismiss: () => dismissed = true,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.close));
+      expect(dismissed, true);
+    });
+  });
+}

--- a/test/ui_kit/components/feedback/app_bottom_sheet_test.dart
+++ b/test/ui_kit/components/feedback/app_bottom_sheet_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/feedback/app_bottom_sheet.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppBottomSheet', () {
+    testWidgets('renders inline properly', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppBottomSheet(
+            title: 'Sheet Title',
+            child: Text('Sheet Content'),
+          ),
+        ),
+      );
+
+      expect(find.text('Sheet Title'), findsOneWidget);
+      expect(find.text('Sheet Content'), findsOneWidget);
+    });
+
+    testWidgets('shows bottom sheet using static method', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () {
+                  AppBottomSheet.show(
+                    context: context,
+                    title: 'Static Sheet',
+                    child: const Text('Modal Content'),
+                  );
+                },
+                child: const Text('Show Sheet'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Sheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Static Sheet'), findsOneWidget);
+      expect(find.text('Modal Content'), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/feedback/app_dialog_test.dart
+++ b/test/ui_kit/components/feedback/app_dialog_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/feedback/app_dialog.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppDialog', () {
+    testWidgets('renders title and content', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppDialog(
+            title: 'Test Title',
+            content: 'Test Content',
+          ),
+        ),
+      );
+
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.text('Test Content'), findsOneWidget);
+    });
+
+    testWidgets('renders action buttons and triggers callbacks', (tester) async {
+      bool confirmTapped = false;
+      bool cancelTapped = false;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppDialog(
+            title: 'Action Dialog',
+            confirmLabel: 'Confirm',
+            onConfirm: () => confirmTapped = true,
+            cancelLabel: 'Cancel',
+            onCancel: () => cancelTapped = true,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Confirm'));
+      expect(confirmTapped, true);
+
+      await tester.tap(find.text('Cancel'));
+      expect(cancelTapped, true);
+    });
+
+    testWidgets('shows dialog using static method', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () {
+                  AppDialog.show(
+                    context: context,
+                    title: 'Static Show',
+                    content: 'Content text',
+                  );
+                },
+                child: const Text('Show Dialog'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Static Show'), findsOneWidget);
+      expect(find.text('Content text'), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/feedback/app_toast_test.dart
+++ b/test/ui_kit/components/feedback/app_toast_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/feedback/app_toast.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppToast', () {
+    testWidgets('shows info toast', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () {
+                  AppToast.show(context, 'Information Toast');
+                },
+                child: const Text('Show Info Toast'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Info Toast'));
+      await tester.pump(); // Start animation
+      await tester.pump(const Duration(milliseconds: 100)); // allow snackbar to appear
+
+      expect(find.text('Information Toast'), findsOneWidget);
+    });
+
+    testWidgets('shows success toast', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () {
+                  AppToast.show(
+                    context,
+                    'Success Toast',
+                    type: AppToastType.success,
+                  );
+                },
+                child: const Text('Show Success Toast'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Success Toast'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Success Toast'), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    });
+
+    testWidgets('shows error toast', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () {
+                  AppToast.show(
+                    context,
+                    'Error Toast',
+                    type: AppToastType.error,
+                  );
+                },
+                child: const Text('Show Error Toast'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Error Toast'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Error Toast'), findsOneWidget);
+      expect(find.byIcon(Icons.error), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/feedback/app_tooltip_test.dart
+++ b/test/ui_kit/components/feedback/app_tooltip_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/feedback/app_tooltip.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppTooltip', () {
+    testWidgets('renders child and message', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppTooltip(
+            message: 'Tooltip message',
+            child: Text('Hover me'),
+          ),
+        ),
+      );
+
+      expect(find.text('Hover me'), findsOneWidget);
+
+      // Tooltip message is rendered using an Overlay when hovered/long-pressed
+      final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tooltip.message, 'Tooltip message');
+    });
+
+    testWidgets('shows message on long press', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppTooltip(
+            message: 'Tooltip info',
+            child: Icon(Icons.info),
+          ),
+        ),
+      );
+
+      // Find the widget to long press
+      await tester.longPress(find.byIcon(Icons.info));
+      await tester.pumpAndSettle();
+
+      // Ensure the message shows up
+      expect(find.text('Tooltip info'), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/foundations/app_badge_test.dart
+++ b/test/ui_kit/components/foundations/app_badge_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/foundations/app_badge.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppBadge', () {
+    testWidgets('renders with primary type by default', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppBadge(label: 'New'),
+        ),
+      );
+
+      expect(find.text('New'), findsOneWidget);
+    });
+
+    testWidgets('renders all badge types without error', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const Column(
+            children: [
+              AppBadge(label: 'Primary', type: AppBadgeType.primary),
+              AppBadge(label: 'Secondary', type: AppBadgeType.secondary),
+              AppBadge(label: 'Success', type: AppBadgeType.success),
+              AppBadge(label: 'Warn', type: AppBadgeType.warn),
+              AppBadge(label: 'Error', type: AppBadgeType.error),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('Primary'), findsOneWidget);
+      expect(find.text('Secondary'), findsOneWidget);
+      expect(find.text('Success'), findsOneWidget);
+      expect(find.text('Warn'), findsOneWidget);
+      expect(find.text('Error'), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/foundations/app_chip_test.dart
+++ b/test/ui_kit/components/foundations/app_chip_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/foundations/app_chip.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppChip', () {
+    testWidgets('renders label and icon', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppChip(
+            label: 'Filter',
+            icon: Icon(Icons.filter_list),
+          ),
+        ),
+      );
+
+      expect(find.text('Filter'), findsOneWidget);
+      expect(find.byIcon(Icons.filter_list), findsOneWidget);
+    });
+
+    testWidgets('renders selected state', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppChip(
+            label: 'Selected',
+            isSelected: true,
+          ),
+        ),
+      );
+
+      expect(find.text('Selected'), findsOneWidget);
+    });
+
+    testWidgets('triggers onSelected', (tester) async {
+      bool tapped = false;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppChip(
+            label: 'Tap Me',
+            onSelected: () => tapped = true,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Tap Me'));
+      expect(tapped, true);
+    });
+  });
+}

--- a/test/ui_kit/components/foundations/app_divider_test.dart
+++ b/test/ui_kit/components/foundations/app_divider_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/foundations/app_divider.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppDivider', () {
+    testWidgets('renders default divider', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppDivider(),
+        ),
+      );
+
+      expect(find.byType(Divider), findsOneWidget);
+    });
+
+    testWidgets('renders with custom properties', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppDivider(
+            height: 32,
+            thickness: 2,
+            color: Colors.red,
+            indent: 10,
+            endIndent: 20,
+          ),
+        ),
+      );
+
+      final divider = tester.widget<Divider>(find.byType(Divider));
+      expect(divider.height, 32);
+      expect(divider.thickness, 2);
+      expect(divider.color, Colors.red);
+      expect(divider.indent, 10);
+      expect(divider.endIndent, 20);
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_checkbox_test.dart
+++ b/test/ui_kit/components/inputs/app_checkbox_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_checkbox.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          }
+        ),
+      ),
+    );
+  }
+
+  group('AppCheckbox', () {
+    testWidgets('renders checked state', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppCheckbox(
+            value: true,
+            onChanged: (val) {},
+          ),
+        ),
+      );
+
+      final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+      expect(checkbox.value, true);
+    });
+
+    testWidgets('renders unchecked state', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppCheckbox(
+            value: false,
+            onChanged: (val) {},
+          ),
+        ),
+      );
+
+      final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+      expect(checkbox.value, false);
+    });
+
+    testWidgets('triggers onChanged', (tester) async {
+      bool? currentValue = false;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return AppCheckbox(
+                value: currentValue!,
+                onChanged: (val) {
+                  setState(() => currentValue = val);
+                },
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(Checkbox));
+      await tester.pumpAndSettle();
+
+      expect(currentValue, true);
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_date_picker_field_test.dart
+++ b/test/ui_kit/components/inputs/app_date_picker_field_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_date_picker_field.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_text_field.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material( // Added Material
+        child: Builder(
+          builder: (context) {
+            // Need to apply AppKitTheme properly so it doesn't cause null errors on build
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppDatePickerField', () {
+    testWidgets('renders properly with a date', (tester) async {
+      final date = DateTime(2023, 10, 5);
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppDatePickerField(
+            selectedDate: date,
+            onDateSelected: (_) {},
+            label: 'Start Date',
+          ),
+        ),
+      );
+
+      expect(find.text('Start Date'), findsOneWidget);
+      expect(find.byIcon(Icons.calendar_today), findsOneWidget);
+      expect(find.textContaining('Oct 5, 2023'), findsOneWidget);
+    });
+
+    testWidgets('renders properly without a date', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppDatePickerField(
+            selectedDate: null,
+            onDateSelected: (_) {},
+            hint: 'Pick a date',
+          ),
+        ),
+      );
+
+      expect(find.text('Pick a date'), findsOneWidget);
+    });
+
+    testWidgets('opens date picker on tap', (tester) async {
+      DateTime? pickedDate;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppDatePickerField(
+            selectedDate: null,
+            onDateSelected: (date) {
+              pickedDate = date;
+            },
+          ),
+        ),
+      );
+
+      // Use test specific context to trigger selection
+      final BuildContext context = tester.element(find.byType(AppDatePickerField));
+
+      // Tap on the widget that has the onTap property
+      // To reliably tap, we find the AppTextField inside it
+      final appTextField = tester.widget<AppTextField>(find.byType(AppTextField));
+      appTextField.onTap?.call();
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.byType(DatePickerDialog), findsOneWidget);
+
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      expect(pickedDate, isNotNull);
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_dropdown_test.dart
+++ b/test/ui_kit/components/inputs/app_dropdown_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_dropdown.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppDropdown', () {
+    testWidgets('renders properly with label and hint', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppDropdown<String>(
+            label: 'Category',
+            hint: 'Select Category',
+            items: const [
+              DropdownMenuItem(value: 'Food', child: Text('Food')),
+              DropdownMenuItem(value: 'Transport', child: Text('Transport')),
+            ],
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      expect(find.text('Category'), findsOneWidget);
+      expect(find.text('Select Category'), findsOneWidget);
+    });
+
+    testWidgets('displays selected value', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppDropdown<String>(
+            value: 'Food',
+            items: const [
+              DropdownMenuItem(value: 'Food', child: Text('Food')),
+              DropdownMenuItem(value: 'Transport', child: Text('Transport')),
+            ],
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      expect(find.text('Food'), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged when selection changes', (tester) async {
+      String? selectedValue;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return AppDropdown<String>(
+                value: selectedValue,
+                items: const [
+                  DropdownMenuItem(value: 'Food', child: Text('Food')),
+                  DropdownMenuItem(value: 'Transport', child: Text('Transport')),
+                ],
+                onChanged: (val) {
+                  setState(() => selectedValue = val);
+                },
+              );
+            },
+          ),
+        ),
+      );
+
+      // Tap to open dropdown
+      await tester.tap(find.byType(DropdownButton<String>));
+      await tester.pumpAndSettle();
+
+      // Tap item
+      // In dropdowns, the items show twice (one in the button, one in the menu)
+      // So we target the last one which is usually in the overlay menu
+      await tester.tap(find.text('Transport').last);
+      await tester.pumpAndSettle();
+
+      expect(selectedValue, 'Transport');
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_search_field_test.dart
+++ b/test/ui_kit/components/inputs/app_search_field_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_search_field.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          }
+        ),
+      ),
+    );
+  }
+
+  group('AppSearchField', () {
+    testWidgets('renders correctly with default hint', (tester) async {
+      await tester.pumpWidget(buildTestWidget(const AppSearchField()));
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.text('Search...'), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsOneWidget);
+    });
+
+    testWidgets('renders correctly with custom hint', (tester) async {
+      await tester.pumpWidget(buildTestWidget(const AppSearchField(hint: 'Find expense')));
+
+      expect(find.text('Find expense'), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged when text changes', (tester) async {
+      String? changedValue;
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppSearchField(
+            onChanged: (value) => changedValue = value,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'coffee');
+      expect(changedValue, 'coffee');
+    });
+
+    testWidgets('respects controller value', (tester) async {
+      final controller = TextEditingController(text: 'groceries');
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppSearchField(controller: controller),
+        ),
+      );
+
+      expect(find.text('groceries'), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_segmented_control_test.dart
+++ b/test/ui_kit/components/inputs/app_segmented_control_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_segmented_control.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          }
+        ),
+      ),
+    );
+  }
+
+  group('AppSegmentedControl', () {
+    testWidgets('renders segments', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppSegmentedControl<int>(
+            groupValue: 1,
+            children: const {
+              1: Text('Option 1'),
+              2: Text('Option 2'),
+            },
+            onValueChanged: (val) {},
+          ),
+        ),
+      );
+
+      expect(find.byType(CupertinoSlidingSegmentedControl<int>), findsOneWidget);
+      expect(find.text('Option 1'), findsOneWidget);
+      expect(find.text('Option 2'), findsOneWidget);
+    });
+
+    testWidgets('calls onValueChanged on selection', (tester) async {
+      int? selectedValue = 1;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppSegmentedControl<int>(
+            groupValue: selectedValue,
+            children: const {
+              1: Text('One'),
+              2: Text('Two'),
+            },
+            onValueChanged: (val) {
+              selectedValue = val;
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Two'));
+      await tester.pumpAndSettle();
+
+      expect(selectedValue, 2);
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_switch_test.dart
+++ b/test/ui_kit/components/inputs/app_switch_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_switch.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppSwitch', () {
+    testWidgets('renders correct initial state', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppSwitch(
+            value: true,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      final cupertinoSwitch = tester.widget<CupertinoSwitch>(find.byType(CupertinoSwitch));
+      expect(cupertinoSwitch.value, true);
+    });
+
+    testWidgets('calls onChanged when tapped', (tester) async {
+      bool? switchValue = false;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return AppSwitch(
+                value: switchValue!,
+                onChanged: (val) {
+                  setState(() => switchValue = val);
+                },
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(CupertinoSwitch));
+      await tester.pumpAndSettle();
+
+      expect(switchValue, true);
+    });
+  });
+}

--- a/test/ui_kit/components/inputs/app_text_field_test.dart
+++ b/test/ui_kit/components/inputs/app_text_field_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/inputs/app_text_field.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          }
+        ),
+      ),
+    );
+  }
+
+  group('AppTextField', () {
+    testWidgets('renders basic text field', (tester) async {
+      await tester.pumpWidget(buildTestWidget(const AppTextField()));
+
+      expect(find.byType(TextFormField), findsOneWidget);
+    });
+
+    testWidgets('displays label and hint', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppTextField(
+            label: 'Email',
+            hint: 'Enter your email',
+          ),
+        ),
+      );
+
+      expect(find.text('Email'), findsOneWidget);
+      expect(find.text('Enter your email'), findsOneWidget);
+    });
+
+    testWidgets('displays error text', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppTextField(
+            errorText: 'Invalid email format',
+          ),
+        ),
+      );
+
+      expect(find.text('Invalid email format'), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged and onTap', (tester) async {
+      String? changedValue;
+      bool tapped = false;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppTextField(
+            onChanged: (val) => changedValue = val,
+            onTap: () => tapped = true,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'test input');
+      expect(changedValue, 'test input');
+
+      await tester.tap(find.byType(AppTextField));
+      expect(tapped, true);
+    });
+
+    testWidgets('respects obscureText, readOnly, and enabled', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppTextField(
+            obscureText: true,
+            readOnly: true,
+            enabled: false,
+            prefixText: '\$',
+          ),
+        ),
+      );
+
+      final textField = tester.widget<AppTextField>(find.byType(AppTextField));
+      expect(textField.obscureText, true);
+      expect(textField.readOnly, true);
+      expect(textField.enabled, false);
+      expect(find.text('\$'), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/loading/app_empty_state_test.dart
+++ b/test/ui_kit/components/loading/app_empty_state_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/loading/app_empty_state.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppEmptyState', () {
+    testWidgets('renders basic text', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppEmptyState(
+            title: 'No Data',
+          ),
+        ),
+      );
+
+      expect(find.text('No Data'), findsOneWidget);
+    });
+
+    testWidgets('renders with all optional parameters', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppEmptyState(
+            title: 'No Data',
+            subtitle: 'Try adding some.',
+            icon: Icons.hourglass_empty,
+            action: ElevatedButton(
+              onPressed: () {},
+              child: const Text('Add Data'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('No Data'), findsOneWidget);
+      expect(find.text('Try adding some.'), findsOneWidget);
+      expect(find.byIcon(Icons.hourglass_empty), findsOneWidget);
+      expect(find.byType(ElevatedButton), findsOneWidget);
+      expect(find.text('Add Data'), findsOneWidget);
+    });
+
+    testWidgets('renders with custom illustration', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppEmptyState(
+            title: 'Custom Illu',
+            customIllustration: FlutterLogo(),
+          ),
+        ),
+      );
+
+      expect(find.byType(FlutterLogo), findsOneWidget);
+      expect(find.text('Custom Illu'), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/loading/app_loading_indicator_test.dart
+++ b/test/ui_kit/components/loading/app_loading_indicator_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/loading/app_loading_indicator.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppLoadingIndicator', () {
+    testWidgets('renders with default parameters', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppLoadingIndicator(),
+        ),
+      );
+
+      final indicator = tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator));
+      expect(indicator.strokeWidth, 2.5);
+    });
+
+    testWidgets('renders with custom size and color', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppLoadingIndicator(
+            size: 48.0,
+            color: Colors.red,
+          ),
+        ),
+      );
+
+      final sizedBox = tester.widget<SizedBox>(find.byType(SizedBox).last);
+      expect(sizedBox.width, 48.0);
+      expect(sizedBox.height, 48.0);
+
+      final indicator = tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator));
+      expect(indicator.valueColor?.value, Colors.red);
+    });
+  });
+}

--- a/test/ui_kit/components/loading/app_skeleton_test.dart
+++ b/test/ui_kit/components/loading/app_skeleton_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/loading/app_skeleton.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppSkeleton', () {
+    testWidgets('renders rectangle skeleton', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppSkeleton(
+            width: 100,
+            height: 50,
+          ),
+        ),
+      );
+
+      // We pump once instead of pumpAndSettle to avoid infinite animation timeout
+      await tester.pump();
+
+      expect(find.byType(AppSkeleton), findsOneWidget);
+      expect(find.descendant(of: find.byType(AppSkeleton), matching: find.byType(Opacity)), findsOneWidget);
+      expect(find.descendant(of: find.byType(AppSkeleton), matching: find.byType(Container)), findsOneWidget);
+    });
+
+    testWidgets('renders circle skeleton', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppSkeleton(
+            width: 50,
+            height: 50,
+            shape: BoxShape.circle,
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      expect(find.byType(AppSkeleton), findsOneWidget);
+    });
+  });
+}

--- a/test/ui_kit/components/typography/app_link_text_test.dart
+++ b/test/ui_kit/components/typography/app_link_text_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/typography/app_link_text.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppLinkText', () {
+    testWidgets('renders properly with underline', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppLinkText('Click Here'),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.text('Click Here'));
+      expect(textWidget.style?.decoration, TextDecoration.underline);
+    });
+
+    testWidgets('calls onTap when clicked', (tester) async {
+      bool tapped = false;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          AppLinkText(
+            'Click Here',
+            onTap: () => tapped = true,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Click Here'));
+      expect(tapped, true);
+    });
+  });
+}

--- a/test/ui_kit/components/typography/app_text_test.dart
+++ b/test/ui_kit/components/typography/app_text_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:expense_tracker/ui_kit/components/typography/app_text.dart';
+import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_colors.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_typography.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_spacing.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_radii.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_motion.dart';
+import 'package:expense_tracker/ui_kit/tokens/app_shadows.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+      ),
+      home: Material(
+        child: Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [
+                  AppKitTheme(
+                    colors: AppColors(Theme.of(context).colorScheme),
+                    typography: AppTypography(Theme.of(context).textTheme),
+                    spacing: const AppSpacing(),
+                    radii: const AppRadii(),
+                    motion: const AppMotion(),
+                    shadows: const AppShadows(isDark: false),
+                  ),
+                ],
+              ),
+              child: Scaffold(
+                body: child,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  group('AppText', () {
+    testWidgets('renders text correctly', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(const AppText('Hello World')),
+      );
+
+      expect(find.text('Hello World'), findsOneWidget);
+    });
+
+    testWidgets('applies different styles', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const Column(
+            children: [
+              AppText('Display', style: AppTextStyle.display),
+              AppText('Title', style: AppTextStyle.title),
+              AppText('Headline', style: AppTextStyle.headline),
+              AppText('Body', style: AppTextStyle.body),
+              AppText('BodyStrong', style: AppTextStyle.bodyStrong),
+              AppText('Caption', style: AppTextStyle.caption),
+              AppText('Overline', style: AppTextStyle.overline),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('Display'), findsOneWidget);
+      expect(find.text('Caption'), findsOneWidget);
+      // Ensures no errors during build for all styles
+    });
+
+    testWidgets('applies custom color, alignment and overflow', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const AppText(
+            'Custom Text',
+            color: Colors.red,
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.text('Custom Text'));
+      expect(textWidget.style?.color, Colors.red);
+      expect(textWidget.textAlign, TextAlign.center);
+      expect(textWidget.maxLines, 1);
+      expect(textWidget.overflow, TextOverflow.ellipsis);
+    });
+  });
+}


### PR DESCRIPTION
Increased automated test coverage by strictly implementing widget tests across 20 previously untested foundational UI Kit components.

Included tests cover component inputs, typography properties, feedback dialogs/toasts/bottomsheets, loading states, and core foundations like AppBadge and AppChip. All components were verified with standard unit and interaction widget testing against `AppKitTheme`.

---
*PR created automatically by Jules for task [2181229562139928742](https://jules.google.com/task/2181229562139928742) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive widget test suites for UI kit components, validating rendering, styling, user interactions, and callback behavior across feedback, input, loading, and typography elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->