### PR TITLE
Execute 10 Bounded Reliability and Performance Bug Fixes

### DIFF
--- a/lib/core/services/upi_service.dart
+++ b/lib/core/services/upi_service.dart
@@ -1,3 +1,4 @@
+import 'package:expense_tracker/core/utils/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -32,13 +33,15 @@ class UpiService {
       if (!launched) {
         if (context.mounted) _handleNoUpiApp(context, upiId);
       }
-    } on PlatformException catch (e) {
+    } on PlatformException catch (e, s) {
+      log.severe('Payment Error: $e\n$s');
       if (context.mounted) {
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(SnackBar(content: Text('Payment Error: ${e.message}')));
       }
-    } catch (e) {
+    } catch (e, s) {
+      log.severe('Unknown Error in launchUpiPayment: $e\n$s');
       if (context.mounted) _handleNoUpiApp(context, upiId);
     }
   }

--- a/lib/core/utils/color_utils.dart
+++ b/lib/core/utils/color_utils.dart
@@ -1,3 +1,4 @@
+import 'package:expense_tracker/core/utils/logger.dart';
 import 'package:flutter/material.dart';
 
 class ColorUtils {
@@ -11,8 +12,8 @@ class ColorUtils {
       if (buffer.length == 8) {
         return Color(int.parse(buffer.toString(), radix: 16));
       }
-    } catch (e) {
-      // Log error if needed
+    } catch (e, s) {
+      log.severe('Error parsing color hex $hexString: $e\n$s');
     }
     return Colors.grey; // Default fallback color
   }

--- a/lib/core/utils/currency_formatter.dart
+++ b/lib/core/utils/currency_formatter.dart
@@ -1,3 +1,4 @@
+import 'package:expense_tracker/core/utils/logger.dart';
 import 'package:intl/intl.dart';
 
 class CurrencyFormatter {
@@ -36,9 +37,9 @@ class CurrencyFormatter {
       }
 
       return currencyFormat.format(amount);
-    } catch (e) {
+    } catch (e, s) {
       // Fallback in case of intl error (e.g., invalid locale)
-      // Consider logging this error
+      log.severe('Error formatting currency: $e\n$s');
       return "$symbolToUse${amount.toStringAsFixed(2)}";
     }
   }

--- a/lib/core/utils/date_formatter.dart
+++ b/lib/core/utils/date_formatter.dart
@@ -1,3 +1,4 @@
+import 'package:expense_tracker/core/utils/logger.dart';
 import 'package:intl/intl.dart';
 
 class DateFormatter {
@@ -19,7 +20,8 @@ class DateFormatter {
     try {
       final format = _getDateTimeFormatter(locale);
       return format.format(dateTime);
-    } catch (e) {
+    } catch (e, s) {
+      log.severe('Error formatting date time: $e\n$s');
       return dateTime.toIso8601String();
     }
   }
@@ -28,7 +30,8 @@ class DateFormatter {
     try {
       final format = _getDateFormatter(locale);
       return format.format(dateTime);
-    } catch (e) {
+    } catch (e, s) {
+      log.severe('Error formatting date: $e\n$s');
       return "${dateTime.year}-${dateTime.month.toString().padLeft(2, '0')}-${dateTime.day.toString().padLeft(2, '0')}";
     }
   }

--- a/lib/features/accounts/presentation/pages/account_list_page.dart
+++ b/lib/features/accounts/presentation/pages/account_list_page.dart
@@ -167,9 +167,15 @@ class AccountListPage extends StatelessWidget {
                   onRefresh: () async {
                     final bloc = context.read<AccountListBloc>();
                     bloc.add(const LoadAccounts(forceReload: true));
-                    await bloc.stream.firstWhere(
-                      (s) => s is! AccountListLoading || !s.isReloading,
-                    );
+                    try {
+                      await bloc.stream
+                          .firstWhere(
+                            (s) => s is! AccountListLoading || !s.isReloading,
+                          )
+                          .timeout(const Duration(seconds: 3));
+                    } catch (_) {
+                      // Ignore timeout or other stream errors to prevent hanging
+                    }
                   },
                   child: ListView.builder(
                     padding:

--- a/lib/features/accounts/presentation/pages/accounts_tab_page.dart
+++ b/lib/features/accounts/presentation/pages/accounts_tab_page.dart
@@ -85,9 +85,15 @@ class _AccountsTabPageState extends State<AccountsTabPage> {
         onRefresh: () async {
           final bloc = context.read<AccountListBloc>();
           bloc.add(const LoadAccounts(forceReload: true));
-          await bloc.stream.firstWhere(
-            (state) => state is! AccountListLoading || !state.isReloading,
-          );
+          try {
+            await bloc.stream
+                .firstWhere(
+                  (state) => state is! AccountListLoading || !state.isReloading,
+                )
+                .timeout(const Duration(seconds: 3));
+          } catch (_) {
+            // Ignore timeout or other stream errors to prevent hanging
+          }
         },
         child: ListView(
           padding:

--- a/lib/features/budgets_cats/presentation/pages/budgets_sub_tab.dart
+++ b/lib/features/budgets_cats/presentation/pages/budgets_sub_tab.dart
@@ -124,9 +124,13 @@ class BudgetsSubTab extends StatelessWidget {
               final bloc = context.read<BudgetListBloc>();
               bloc.add(const LoadBudgets(forceReload: true));
               // Wait until the loading state completes
-              await bloc.stream.firstWhere(
-                (s) => s.status != BudgetListStatus.loading,
-              );
+              try {
+                await bloc.stream
+                    .firstWhere((s) => s.status != BudgetListStatus.loading)
+                    .timeout(const Duration(seconds: 3));
+              } catch (_) {
+                // Prevent infinite hang if state is missed
+              }
             },
             child: content,
           );

--- a/lib/features/categories/presentation/widgets/category_list_section_widget.dart
+++ b/lib/features/categories/presentation/widgets/category_list_section_widget.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
 
-class CategoryListSectionWidget extends StatelessWidget {
+class CategoryListSectionWidget extends StatefulWidget {
   final List<Category> categories;
   final String emptyMessage;
   final Function(Category) onEditCategory;
@@ -22,39 +22,62 @@ class CategoryListSectionWidget extends StatelessWidget {
   });
 
   @override
+  State<CategoryListSectionWidget> createState() =>
+      _CategoryListSectionWidgetState();
+}
+
+class _CategoryListSectionWidgetState extends State<CategoryListSectionWidget> {
+  late List<Category> _sortedCategories;
+
+  @override
+  void initState() {
+    super.initState();
+    _sortCategories();
+  }
+
+  @override
+  void didUpdateWidget(covariant CategoryListSectionWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.categories != oldWidget.categories) {
+      _sortCategories();
+    }
+  }
+
+  void _sortCategories() {
+    _sortedCategories = List.from(widget.categories);
+    if (_sortedCategories.isEmpty) return;
+
+    final lowerCaseNames = {
+      for (var c in _sortedCategories) c.id: c.name.toLowerCase(),
+    };
+
+    _sortedCategories.sort(
+      (a, b) => lowerCaseNames[a.id]!.compareTo(lowerCaseNames[b.id]!),
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    if (categories.isEmpty) {
+    if (_sortedCategories.isEmpty) {
       return Center(
         child: Padding(
           padding: context.space.allXl,
-          child: Text(emptyMessage, style: theme.textTheme.titleMedium),
+          child: Text(widget.emptyMessage, style: theme.textTheme.titleMedium),
         ),
       );
     }
-    // ⚡ Bolt Performance Optimization
-    // Problem: a.name.toLowerCase() inside .sort() allocates O(N log N) strings during widget build
-    // Solution: Cache lowercased names outside the sort function
-    // Impact: Improves UI rendering speed by avoiding tight-loop allocations
-    final lowerCaseNames = {
-      for (var c in categories) c.id: c.name.toLowerCase(),
-    };
-
-    // Sort combined list for consistent display
-    categories.sort(
-      (a, b) => lowerCaseNames[a.id]!.compareTo(lowerCaseNames[b.id]!),
-    );
 
     return ListView.builder(
       padding: const EdgeInsets.only(top: 8.0, bottom: 90.0), // Padding for FAB
-      itemCount: categories.length,
+      itemCount: _sortedCategories.length,
       itemBuilder: (context, index) {
-        final category = categories[index];
+        final category = _sortedCategories[index];
         return CategoryListItemWidget(
               category: category,
-              onEdit: () => onEditCategory(category),
-              onDelete: () => onDeleteCategory(category),
-              onPersonalize: () => onPersonalizeCategory(category),
+              onEdit: () => widget.onEditCategory(category),
+              onDelete: () => widget.onDeleteCategory(category),
+              onPersonalize: () => widget.onPersonalizeCategory(category),
             )
             .animate()
             .fadeIn(delay: (40 * index).ms, duration: 300.ms)

--- a/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -56,9 +56,9 @@ class _DashboardPageState extends State<DashboardPage> {
           )
           .timeout(const Duration(seconds: 10));
       log.info("[DashboardPage] Refresh stream finished or timed out.");
-    } catch (e) {
+    } catch (e, s) {
       log.warning(
-        "[DashboardPage] Error or timeout waiting for refresh stream: $e",
+        "[DashboardPage] Error or timeout waiting for refresh stream: $e\n$s",
       );
     }
   }

--- a/lib/features/reports/presentation/widgets/report_filter_controls.dart
+++ b/lib/features/reports/presentation/widgets/report_filter_controls.dart
@@ -22,11 +22,17 @@ class ReportFilterControls extends StatelessWidget {
     if (filterBloc.state.optionsStatus != FilterOptionsStatus.loaded) {
       filterBloc.add(const LoadFilterOptions(forceReload: true));
       // Consider showing a loading indicator briefly or disabling button until loaded
-      await filterBloc.stream.firstWhere(
-        (state) =>
-            state.optionsStatus == FilterOptionsStatus.loaded ||
-            state.optionsStatus == FilterOptionsStatus.error,
-      );
+      try {
+        await filterBloc.stream
+            .firstWhere(
+              (state) =>
+                  state.optionsStatus == FilterOptionsStatus.loaded ||
+                  state.optionsStatus == FilterOptionsStatus.error,
+            )
+            .timeout(const Duration(seconds: 3));
+      } catch (_) {
+        // Fallback on timeout, prevent modal block
+      }
       if (!context.mounted ||
           filterBloc.state.optionsStatus == FilterOptionsStatus.error) {
         return; // Don't show sheet if loading failed


### PR DESCRIPTION
Executed exactly 10 targeted reliability, debugging, and performance bug fixes.

1. **Fix `firstWhere` Await Hangs in `AccountsTabPage`:** Added a `try/catch` and 3-second `.timeout()` to the `firstWhere` stream listener during `RefreshIndicator.onRefresh` to prevent infinite hangs if the BLoC state completes too quickly.
2. **Fix `firstWhere` Await Hangs in `AccountListPage`:** Applied the same timeout/try-catch wrapper to the inner refresh list handler.
3. **Fix `firstWhere` Await Hangs in `BudgetsSubTab`:** Applied the timeout/try-catch wrapper to the budgets refresh list handler.
4. **Fix `firstWhere` Await Hangs in `ReportFilterControls`:** Added `.timeout()` and a fallback `try/catch` block to prevent a blocked modal UI if the `filterBloc` fails to emit `loaded` or `error` states.
5. **Fix Silent Error Logging in `ColorUtils`:** Replaced the empty `catch (e)` block in `fromHex` with a strict `log.severe` capturing the exception and `StackTrace`, making invalid hex values auditable.
6. **Fix Silent Error Logging in `DateFormatter`:** Addressed the silent exception swallow in `formatDate` and `formatDateTime` by adding `catch (e, s)` and `log.severe` before returning the safe fallback string.
7. **Fix Silent Error Logging in `CurrencyFormatter`:** Addressed the `intl` fallback formatting by adding `catch (e, s)` and logging the `StackTrace` to trace locale formatting crashes.
8. **Fix Silent Error Logging in `UpiService`:** Appended explicit `catch (e, s)` block logging for `launchUpiPayment` deep-link OS yielding exceptions before triggering the UI snackbar fallback.
9. **Fix Missing Exception StackTrace in `DashboardPage` Warning:** Modified `_refreshDashboard` to actively log the stack trace `$s` instead of only capturing the top-level string `e`, allowing proper debug tracking.
10. **Optimize In-Widget List Sorts in `CategoryListSectionWidget`:** Converted the stateless widget to a `StatefulWidget` to precompute the `lowerCaseNames` sorting in `initState` and `didUpdateWidget`, avoiding costly O(N log N) GC string allocations on every `build()` tick.

---
*PR created automatically by Jules for task [4344980466853678951](https://jules.google.com/task/4344980466853678951) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed refresh operations that could hang indefinitely; now complete within 3 seconds.
  * Enhanced error logging and recovery for payment processing and data formatting operations.

* **Performance**
  * Optimized category list sorting to improve rendering efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->