### PR TITLE
⚡ Bolt: Cache ListView findChildIndexCallback map in GoalProgressPage to prevent O(N) rebuilds

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Avoid `findChildIndexCallback` precomputation in `build()`]
+**Learning:** Do not precompute a full ID-to-index Map inside `build()` for `ListView.builder`'s `findChildIndexCallback`, as iterating all items on every render negates the O(V) lazy rendering benefit and causes a performance regression.
+**Action:** Instead, convert the widget to a `StatefulWidget` and cache the map in `initState` and `didUpdateWidget`.

--- a/lib/features/reports/presentation/pages/goal_progress_page.dart
+++ b/lib/features/reports/presentation/pages/goal_progress_page.dart
@@ -22,8 +22,26 @@ import 'package:expense_tracker/ui_kit/components/loading/app_loading_indicator.
 import 'package:expense_tracker/core/error/failure.dart';
 import 'package:expense_tracker/ui_bridge/bridge_card.dart';
 
-class GoalProgressPage extends StatelessWidget {
+class GoalProgressPage extends StatefulWidget {
   const GoalProgressPage({super.key});
+
+  @override
+  State<GoalProgressPage> createState() => _GoalProgressPageState();
+}
+
+class _GoalProgressPageState extends State<GoalProgressPage> {
+  Map<String, int> _childIndexMap = {};
+  List<GoalProgressData> _previousProgressData = [];
+
+  void _updateIndexMapIfNeeded(List<GoalProgressData> currentProgressData) {
+    if (_previousProgressData != currentProgressData) {
+      _childIndexMap = {
+        for (var i = 0; i < currentProgressData.length; i++)
+          currentProgressData[i].goal.id: i,
+      };
+      _previousProgressData = currentProgressData;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -100,16 +118,14 @@ class GoalProgressPage extends StatelessWidget {
                 // Problem: ListView.builder creates a standard scroll view which can be janky with many items
                 // Solution: Add findChildIndexCallback for O(1) tracking via precomputed map
                 // Impact: Improves scrolling performance and reduces widget rebuilds
-                final childIndexMap = {
-                  for (var i = 0; i < reportData.progressData.length; i++)
-                    reportData.progressData[i].goal.id: i,
-                };
+
+                _updateIndexMapIfNeeded(reportData.progressData);
 
                 return ListView.builder(
                   itemCount: reportData.progressData.length,
                   findChildIndexCallback: (Key key) {
                     if (key is ValueKey<String>) {
-                      return childIndexMap[key.value];
+                      return _childIndexMap[key.value];
                     }
                     return null;
                   },


### PR DESCRIPTION
💡 What: Converted `GoalProgressPage` to a `StatefulWidget` and cached `_childIndexMap` across `build()` calls.
🎯 Why: `ListView.builder` was previously iterating `reportData.progressData` completely on every frame render or widget rebuild to form `findChildIndexCallback`, negating O(V) benefits and slowing UI interactions like scrolling.
📊 Impact: Prevents O(N) recalculations on identical datasets and speeds up frame-to-frame layout rendering.
🔬 Measurement: Can be verified using Flutter DevTools performance profiler over the Goal Progress tab.

---
*PR created automatically by Jules for task [3178766947413851841](https://jules.google.com/task/3178766947413851841) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved goal progress page rendering performance by implementing intelligent caching of list index lookups, eliminating redundant recalculation and enhancing responsiveness during data updates.

* **Chores**
  * Added internal documentation recording performance optimization learnings and recommended patterns for efficient lazy-loaded list widget implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->