### PR TITLE
⚡ Bolt: Cache ListView findChildIndexCallback map outside build()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2026-03-26 - Precomputing Maps inside build() negates ListView.builder lazy rendering
+**Learning:** For lazy list performance (`ListView.builder`), using `findChildIndexCallback` with a map tracking IDs to indices transforms key lookup from O(V) (where V is the length of visible items) to O(1). However, calculating that ID-to-index map entirely inside the `build()` method executes an O(N) loop on every single render. When N is large, this completely neutralizes the performance benefit of lazy list rendering, causing severe frame drops.
+**Action:** Always precompute state-derived mappings in `initState` and `didUpdateWidget` (inside a `StatefulWidget` or using a bloc state) rather than inside `build()`. Make sure `didUpdateWidget` checks for reference equality of the underlying list.

--- a/lib/features/reports/presentation/pages/goal_progress_page.dart
+++ b/lib/features/reports/presentation/pages/goal_progress_page.dart
@@ -96,41 +96,81 @@ class GoalProgressPage extends StatelessWidget {
                   );
                 }
 
-                // ⚡ Bolt Performance Optimization
-                // Problem: ListView.builder creates a standard scroll view which can be janky with many items
-                // Solution: Add findChildIndexCallback for O(1) tracking via precomputed map
-                // Impact: Improves scrolling performance and reduces widget rebuilds
-                final childIndexMap = {
-                  for (var i = 0; i < reportData.progressData.length; i++)
-                    reportData.progressData[i].goal.id: i,
-                };
-
-                return ListView.builder(
-                  itemCount: reportData.progressData.length,
-                  findChildIndexCallback: (Key key) {
-                    if (key is ValueKey<String>) {
-                      return childIndexMap[key.value];
-                    }
-                    return null;
-                  },
-                  itemBuilder: (context, index) {
-                    final goalData = reportData.progressData[index];
-                    return KeyedSubtree(
-                      key: ValueKey(goalData.goal.id),
-                      child: _buildGoalProgressBridgeCard(
-                        context,
-                        goalData,
-                        settingsState,
-                        isComparisonEnabled,
-                      ),
-                    );
-                  },
+                return _GoalProgressListView(
+                  reportData: reportData,
+                  settingsState: settingsState,
+                  isComparisonEnabled: isComparisonEnabled,
                 );
               }
               return const Center(
                 child: AppText("Select filters to view report."),
               );
             },
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _GoalProgressListView extends StatefulWidget {
+  final GoalProgressReportData reportData;
+  final SettingsState settingsState;
+  final bool isComparisonEnabled;
+
+  const _GoalProgressListView({
+    required this.reportData,
+    required this.settingsState,
+    required this.isComparisonEnabled,
+  });
+
+  @override
+  State<_GoalProgressListView> createState() => _GoalProgressListViewState();
+}
+
+class _GoalProgressListViewState extends State<_GoalProgressListView> {
+  late Map<String, int> _childIndexMap;
+
+  @override
+  void initState() {
+    super.initState();
+    _computeChildIndexMap();
+  }
+
+  @override
+  void didUpdateWidget(covariant _GoalProgressListView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.reportData.progressData != widget.reportData.progressData) {
+      _computeChildIndexMap();
+    }
+  }
+
+  void _computeChildIndexMap() {
+    _childIndexMap = {
+      for (var i = 0; i < widget.reportData.progressData.length; i++)
+        widget.reportData.progressData[i].goal.id: i,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: widget.reportData.progressData.length,
+      findChildIndexCallback: (Key key) {
+        if (key is ValueKey<String>) {
+          return _childIndexMap[key.value];
+        }
+        return null;
+      },
+      itemBuilder: (context, index) {
+        final goalData = widget.reportData.progressData[index];
+        return KeyedSubtree(
+          key: ValueKey(goalData.goal.id),
+          child: _buildGoalProgressBridgeCard(
+            context,
+            goalData,
+            widget.settingsState,
+            widget.isComparisonEnabled,
           ),
         );
       },

--- a/lib/features/transactions/presentation/widgets/transaction_list_view.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_list_view.dart
@@ -20,7 +20,7 @@ import 'package:expense_tracker/ui_bridge/bridge_circular_progress_indicator.dar
 import 'package:expense_tracker/ui_bridge/bridge_text_style.dart';
 import 'package:expense_tracker/ui_kit/theme/app_theme_ext.dart';
 
-class TransactionListView extends StatelessWidget {
+class TransactionListView extends StatefulWidget {
   final TransactionListState state;
   final SettingsState settings;
   final Map<String, String> accountNameMap;
@@ -47,27 +47,57 @@ class TransactionListView extends StatelessWidget {
   });
 
   @override
+  State<TransactionListView> createState() => _TransactionListViewState();
+}
+
+class _TransactionListViewState extends State<TransactionListView> {
+  late Map<String, int> _childIndexMap;
+
+  @override
+  void initState() {
+    super.initState();
+    _computeChildIndexMap();
+  }
+
+  @override
+  void didUpdateWidget(TransactionListView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.state.transactions != widget.state.transactions) {
+      _computeChildIndexMap();
+    }
+  }
+
+  void _computeChildIndexMap() {
+    _childIndexMap = {
+      for (var i = 0; i < widget.state.transactions.length; i++)
+        "${widget.state.transactions[i].id}_dismissible": i,
+    };
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    if (state.status == ListStatus.loading && state.transactions.isEmpty) {
+    if (widget.state.status == ListStatus.loading &&
+        widget.state.transactions.isEmpty) {
       return const Center(child: BridgeCircularProgressIndicator());
     }
-    if (state.status == ListStatus.error && state.transactions.isEmpty) {
+    if (widget.state.status == ListStatus.error &&
+        widget.state.transactions.isEmpty) {
       return Center(
         child: Padding(
           padding: context.space.allXl,
           child: Text(
-            "Error: ${state.errorMessage ?? 'Failed to load transactions'}",
+            "Error: ${widget.state.errorMessage ?? 'Failed to load transactions'}",
             style: BridgeTextStyle(color: theme.colorScheme.error),
             textAlign: TextAlign.center,
           ),
         ),
       );
     }
-    if (state.transactions.isEmpty &&
-        state.status != ListStatus.loading &&
-        state.status != ListStatus.reloading) {
+    if (widget.state.transactions.isEmpty &&
+        widget.state.status != ListStatus.loading &&
+        widget.state.status != ListStatus.reloading) {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(32.0),
@@ -81,7 +111,7 @@ class TransactionListView extends StatelessWidget {
               ),
               const SizedBox(height: 16),
               Text(
-                state.filtersApplied
+                widget.state.filtersApplied
                     ? "No transactions match filters"
                     : "No transactions recorded yet",
                 style: theme.textTheme.headlineSmall?.copyWith(
@@ -90,7 +120,7 @@ class TransactionListView extends StatelessWidget {
               ),
               const SizedBox(height: 8),
               Text(
-                state.filtersApplied
+                widget.state.filtersApplied
                     ? "Try adjusting or clearing the filters."
                     : "Tap the '+' button to add your first expense or income.",
                 style: theme.textTheme.bodyMedium?.copyWith(
@@ -99,7 +129,8 @@ class TransactionListView extends StatelessWidget {
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 24),
-              if (!state
+              if (!widget
+                  .state
                   .filtersApplied) // Show add button only if no filters applied
                 ElevatedButton.icon(
                   key: const ValueKey('button_listView_addFirst'),
@@ -119,56 +150,48 @@ class TransactionListView extends StatelessWidget {
       );
     }
 
-    // ⚡ Bolt Performance Optimization
-    // Problem: ListView.builder creates a standard scroll view which can be janky with many items
-    // Solution: Add findChildIndexCallback for O(1) tracking using a precomputed map
-    // Impact: Improves scrolling performance and reduces widget rebuilds for long transaction lists
-    final childIndexMap = {
-      for (var i = 0; i < state.transactions.length; i++)
-        "${state.transactions[i].id}_dismissible": i,
-    };
-
     return ListView.builder(
       padding: const EdgeInsets.only(
         top: 0,
         bottom: 80,
       ), // Ensure padding for FAB
-      itemCount: state.transactions.length,
+      itemCount: widget.state.transactions.length,
       findChildIndexCallback: (Key key) {
         if (key is ValueKey<String>) {
-          return childIndexMap[key.value];
+          return _childIndexMap[key.value];
         }
         return null;
       },
       itemBuilder: (ctx, index) {
-        final transaction = state.transactions[index];
-        final isSelected = state.selectedTransactionIds.contains(
+        final transaction = widget.state.transactions[index];
+        final isSelected = widget.state.selectedTransactionIds.contains(
           transaction.id,
         );
 
         // --- USE ExpenseCard or IncomeCard based on type ---
         Widget cardItem;
-        final accountName = accountNameMap[transaction.accountId] ?? 'Deleted';
+        final accountName =
+            widget.accountNameMap[transaction.accountId] ?? 'Deleted';
         if (transaction.type == TransactionType.expense) {
           cardItem = ExpenseCard(
             expense: transaction.expense!,
             accountName: accountName,
-            currencySymbol: currencySymbol,
+            currencySymbol: widget.currencySymbol,
             onCardTap: (exp) {
               // Pass original Expense
-              if (state.isInBatchEditMode) {
+              if (widget.state.isInBatchEditMode) {
                 context.read<TransactionListBloc>().add(
                   SelectTransaction(exp.id),
                 );
               } else {
-                navigateToDetailOrEdit(
+                widget.navigateToDetailOrEdit(
                   context,
                   transaction,
                 ); // Pass the TransactionEntity
               }
             },
             onChangeCategoryRequest: (exp) =>
-                handleChangeCategoryRequest(context, transaction),
+                widget.handleChangeCategoryRequest(context, transaction),
             onUserCategorized: (exp, cat) {
               final matchData = TransactionMatchData(
                 description: exp.title,
@@ -189,22 +212,22 @@ class TransactionListView extends StatelessWidget {
           cardItem = IncomeCard(
             income: transaction.income!,
             accountName: accountName,
-            currencySymbol: currencySymbol,
+            currencySymbol: widget.currencySymbol,
             onCardTap: (inc) {
               // Pass original Income
-              if (state.isInBatchEditMode) {
+              if (widget.state.isInBatchEditMode) {
                 context.read<TransactionListBloc>().add(
                   SelectTransaction(inc.id),
                 );
               } else {
-                navigateToDetailOrEdit(
+                widget.navigateToDetailOrEdit(
                   context,
                   transaction,
                 ); // Pass the TransactionEntity
               }
             },
             onChangeCategoryRequest: (inc) =>
-                handleChangeCategoryRequest(context, transaction),
+                widget.handleChangeCategoryRequest(context, transaction),
             onUserCategorized: (inc, cat) {
               final matchData = TransactionMatchData(
                 description: inc.title,
@@ -223,7 +246,7 @@ class TransactionListView extends StatelessWidget {
         }
         // --- END USE ---
 
-        final animatedCard = enableAnimations
+        final animatedCard = widget.enableAnimations
             ? cardItem
                   .animate()
                   .fadeIn(delay: (20 * (index % 10)).ms) // Cap delay
@@ -247,7 +270,7 @@ class TransactionListView extends StatelessWidget {
             ),
           ),
           confirmDismiss: (_) async =>
-              await confirmDeletion(context, transaction),
+              await widget.confirmDeletion(context, transaction),
           onDismissed: (direction) {
             // BLoC event is dispatched by confirmDismiss callback now
             // context.read<TransactionListBloc>().add(DeleteTransaction(transaction));


### PR DESCRIPTION
💡 What: Extracted `ListView.builder` lists in `TransactionListView` and `GoalProgressPage` into `StatefulWidget`s and cached the ID-to-index mapping inside `initState` and `didUpdateWidget`.
🎯 Why: Computing `findChildIndexCallback` maps inside the `build()` method executes an O(N) loop on every frame during lazy rendering, causing severe frame drops and completely negating the O(1) key lookup benefit.
📊 Impact: Eliminates O(N) list iteration on every list render tick. Improves scrolling performance and dramatically reduces CPU spikes when viewing long lists of transactions or goals.
🔬 Measurement: Run a Flutter performance profile on the `TransactionListView` with 1000+ items and observe the frame render times.

---
*PR created automatically by Jules for task [837030533373884881](https://jules.google.com/task/837030533373884881) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized list rendering in goal progress and transaction views for improved performance when working with large datasets. Users will experience smoother scrolling and faster interactions.

* **Documentation**
  * Added guidance on ListView performance optimization best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->