### PR TITLE
Fix async bugs by securing `firstWhere` and `unawaited` usage

### DIFF
--- a/lib/core/auth/session_cubit.dart
+++ b/lib/core/auth/session_cubit.dart
@@ -29,7 +29,11 @@ class SessionCubit extends Cubit<SessionState> {
         emit(SessionUnauthenticated());
       } else if (authState.event == AuthChangeEvent.signedIn ||
           authState.event == AuthChangeEvent.initialSession) {
-        checkSession();
+        unawaited(
+          checkSession().catchError(
+            (e, s) => log.severe("Silent failure in checkSession: $e\n$s"),
+          ),
+        );
       }
     });
 
@@ -147,6 +151,10 @@ class SessionCubit extends Cubit<SessionState> {
   }
 
   void profileSetupCompleted() {
-    checkSession();
+    unawaited(
+      checkSession().catchError(
+        (e, s) => log.severe("Silent failure in checkSession: $e\n$s"),
+      ),
+    );
   }
 }

--- a/lib/features/accounts/presentation/pages/account_list_page.dart
+++ b/lib/features/accounts/presentation/pages/account_list_page.dart
@@ -1,5 +1,6 @@
 // ... other imports ...
 import 'package:expense_tracker/core/constants/route_names.dart';
+import 'package:expense_tracker/core/utils/logger.dart';
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/ui_kit/theme/app_mode_theme.dart';
 import 'package:expense_tracker/core/utils/app_dialogs.dart';
@@ -174,7 +175,7 @@ class AccountListPage extends StatelessWidget {
                           )
                           .timeout(const Duration(seconds: 3));
                     } catch (e, s) {
-                      debugPrint(
+                      log.severe(
                         "Timeout or error waiting for account list: $e\n$s",
                       );
                     }

--- a/lib/features/accounts/presentation/pages/account_list_page.dart
+++ b/lib/features/accounts/presentation/pages/account_list_page.dart
@@ -167,9 +167,17 @@ class AccountListPage extends StatelessWidget {
                   onRefresh: () async {
                     final bloc = context.read<AccountListBloc>();
                     bloc.add(const LoadAccounts(forceReload: true));
-                    await bloc.stream.firstWhere(
-                      (s) => s is! AccountListLoading || !s.isReloading,
-                    );
+                    try {
+                      await bloc.stream
+                          .firstWhere(
+                            (s) => s is! AccountListLoading || !s.isReloading,
+                          )
+                          .timeout(const Duration(seconds: 3));
+                    } catch (e, s) {
+                      debugPrint(
+                        "Timeout or error waiting for account list: $e\n$s",
+                      );
+                    }
                   },
                   child: ListView.builder(
                     padding:

--- a/lib/features/accounts/presentation/pages/accounts_tab_page.dart
+++ b/lib/features/accounts/presentation/pages/accounts_tab_page.dart
@@ -2,6 +2,7 @@
 // ignore_for_file: deprecated_member_use
 
 import 'package:expense_tracker/core/constants/route_names.dart';
+import 'package:expense_tracker/core/utils/logger.dart';
 import 'package:expense_tracker/ui_kit/theme/app_mode_theme.dart';
 import 'package:expense_tracker/core/utils/currency_formatter.dart';
 import 'package:expense_tracker/core/widgets/section_header.dart';
@@ -92,7 +93,7 @@ class _AccountsTabPageState extends State<AccountsTabPage> {
                 )
                 .timeout(const Duration(seconds: 3));
           } catch (e, s) {
-            debugPrint("Timeout or error waiting for account tab: $e\n$s");
+            log.severe("Timeout or error waiting for account tab: $e\n$s");
           }
         },
         child: ListView(

--- a/lib/features/accounts/presentation/pages/accounts_tab_page.dart
+++ b/lib/features/accounts/presentation/pages/accounts_tab_page.dart
@@ -85,9 +85,15 @@ class _AccountsTabPageState extends State<AccountsTabPage> {
         onRefresh: () async {
           final bloc = context.read<AccountListBloc>();
           bloc.add(const LoadAccounts(forceReload: true));
-          await bloc.stream.firstWhere(
-            (state) => state is! AccountListLoading || !state.isReloading,
-          );
+          try {
+            await bloc.stream
+                .firstWhere(
+                  (state) => state is! AccountListLoading || !state.isReloading,
+                )
+                .timeout(const Duration(seconds: 3));
+          } catch (e, s) {
+            debugPrint("Timeout or error waiting for account tab: $e\n$s");
+          }
         },
         child: ListView(
           padding:

--- a/lib/features/budgets_cats/presentation/pages/budgets_sub_tab.dart
+++ b/lib/features/budgets_cats/presentation/pages/budgets_sub_tab.dart
@@ -124,9 +124,13 @@ class BudgetsSubTab extends StatelessWidget {
               final bloc = context.read<BudgetListBloc>();
               bloc.add(const LoadBudgets(forceReload: true));
               // Wait until the loading state completes
-              await bloc.stream.firstWhere(
-                (s) => s.status != BudgetListStatus.loading,
-              );
+              try {
+                await bloc.stream
+                    .firstWhere((s) => s.status != BudgetListStatus.loading)
+                    .timeout(const Duration(seconds: 3));
+              } catch (e, s) {
+                debugPrint("Timeout or error waiting for budget list: $e\n$s");
+              }
             },
             child: content,
           );

--- a/lib/features/budgets_cats/presentation/pages/budgets_sub_tab.dart
+++ b/lib/features/budgets_cats/presentation/pages/budgets_sub_tab.dart
@@ -1,5 +1,6 @@
 // lib/features/budgets/presentation/pages/budgets_sub_tab.dart
 import 'package:expense_tracker/core/constants/route_names.dart';
+import 'package:expense_tracker/core/utils/logger.dart';
 import 'package:expense_tracker/ui_kit/theme/app_mode_theme.dart';
 import 'package:expense_tracker/features/budgets/presentation/bloc/budget_list/budget_list_bloc.dart';
 import 'package:expense_tracker/features/budgets/presentation/widgets/budget_card.dart';
@@ -129,7 +130,7 @@ class BudgetsSubTab extends StatelessWidget {
                     .firstWhere((s) => s.status != BudgetListStatus.loading)
                     .timeout(const Duration(seconds: 3));
               } catch (e, s) {
-                debugPrint("Timeout or error waiting for budget list: $e\n$s");
+                log.severe("Timeout or error waiting for budget list: $e\n$s");
               }
             },
             child: content,

--- a/lib/features/reports/presentation/widgets/report_filter_controls.dart
+++ b/lib/features/reports/presentation/widgets/report_filter_controls.dart
@@ -22,11 +22,17 @@ class ReportFilterControls extends StatelessWidget {
     if (filterBloc.state.optionsStatus != FilterOptionsStatus.loaded) {
       filterBloc.add(const LoadFilterOptions(forceReload: true));
       // Consider showing a loading indicator briefly or disabling button until loaded
-      await filterBloc.stream.firstWhere(
-        (state) =>
-            state.optionsStatus == FilterOptionsStatus.loaded ||
-            state.optionsStatus == FilterOptionsStatus.error,
-      );
+      try {
+        await filterBloc.stream
+            .firstWhere(
+              (state) =>
+                  state.optionsStatus == FilterOptionsStatus.loaded ||
+                  state.optionsStatus == FilterOptionsStatus.error,
+            )
+            .timeout(const Duration(seconds: 3));
+      } catch (e, s) {
+        debugPrint("Timeout or error waiting for FilterOptionsStatus: $e\n$s");
+      }
       if (!context.mounted ||
           filterBloc.state.optionsStatus != FilterOptionsStatus.loaded) {
         return; // Don't show sheet if loading failed or stream closed early

--- a/lib/features/reports/presentation/widgets/report_filter_controls.dart
+++ b/lib/features/reports/presentation/widgets/report_filter_controls.dart
@@ -1,5 +1,6 @@
 // lib/features/reports/presentation/widgets/report_filter_controls.dart
 import 'package:expense_tracker/core/utils/date_formatter.dart';
+import 'package:expense_tracker/core/utils/logger.dart';
 import 'package:expense_tracker/features/categories/domain/entities/category.dart';
 import 'package:expense_tracker/features/reports/presentation/bloc/report_filter/report_filter_bloc.dart';
 import 'package:expense_tracker/features/transactions/domain/entities/transaction_entity.dart'; // Added
@@ -31,7 +32,7 @@ class ReportFilterControls extends StatelessWidget {
             )
             .timeout(const Duration(seconds: 3));
       } catch (e, s) {
-        debugPrint("Timeout or error waiting for FilterOptionsStatus: $e\n$s");
+        log.severe("Timeout or error waiting for FilterOptionsStatus: $e\n$s");
       }
       if (!context.mounted ||
           filterBloc.state.optionsStatus != FilterOptionsStatus.loaded) {

--- a/lib/features/transactions/presentation/pages/transaction_list_page.dart
+++ b/lib/features/transactions/presentation/pages/transaction_list_page.dart
@@ -1,5 +1,6 @@
 // lib/features/transactions/presentation/pages/transaction_list_page.dart
 import 'package:expense_tracker/core/constants/route_names.dart';
+import 'package:expense_tracker/core/utils/logger.dart';
 import 'package:expense_tracker/core/di/service_locator.dart';
 import 'package:expense_tracker/core/utils/app_dialogs.dart';
 import 'package:expense_tracker/features/accounts/presentation/bloc/account_list/account_list_bloc.dart';


### PR DESCRIPTION
Fix async bugs by securing `firstWhere` and `unawaited` usage

- Wrapped multiple `firstWhere` stream awaiters in presentation layer with `try/catch` and a 3-second `.timeout()` to prevent infinite UI hangs if stream states are missed.
- Applied this fix to `report_filter_controls`, `budgets_sub_tab` (both instances), `goals_sub_tab`, `account_list_page`, `accounts_tab_page`, and `transaction_list_page`.
- Addressed silent failure risk in `SessionCubit` by wrapping the asynchronous `checkSession()` call in `unawaited(...)` and a `.catchError` handler to ensure proper stack trace logging.

---
*PR created automatically by Jules for task [2042893429547308853](https://jules.google.com/task/2042893429547308853) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added 3s timeout and explicit error logging to refresh/loading flows in accounts, budgets, and reports to avoid hanging UI.
  * Stabilized refresh behavior and suppressed propagation of async failures so UI completes gracefully.
  * Apply incoming route-provided transaction filters on initial load and added targeted logging for transaction flows.

* **Chores**
  * Session validation calls now log errors silently instead of propagating exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->