### PR TITLE
Fix unawaited Stream subscriptions and background async tasks error handling

### DIFF
--- a/lib/features/accounts/presentation/pages/account_list_page.dart
+++ b/lib/features/accounts/presentation/pages/account_list_page.dart
@@ -167,9 +167,13 @@ class AccountListPage extends StatelessWidget {
                   onRefresh: () async {
                     final bloc = context.read<AccountListBloc>();
                     bloc.add(const LoadAccounts(forceReload: true));
-                    await bloc.stream.firstWhere(
-                      (s) => s is! AccountListLoading || !s.isReloading,
-                    );
+                    try {
+                      await bloc.stream
+                          .firstWhere(
+                            (s) => s is! AccountListLoading || !s.isReloading,
+                          )
+                          .timeout(const Duration(seconds: 3));
+                    } catch (_) {}
                   },
                   child: ListView.builder(
                     padding:

--- a/lib/features/accounts/presentation/pages/accounts_tab_page.dart
+++ b/lib/features/accounts/presentation/pages/accounts_tab_page.dart
@@ -85,9 +85,13 @@ class _AccountsTabPageState extends State<AccountsTabPage> {
         onRefresh: () async {
           final bloc = context.read<AccountListBloc>();
           bloc.add(const LoadAccounts(forceReload: true));
-          await bloc.stream.firstWhere(
-            (state) => state is! AccountListLoading || !state.isReloading,
-          );
+          try {
+            await bloc.stream
+                .firstWhere(
+                  (state) => state is! AccountListLoading || !state.isReloading,
+                )
+                .timeout(const Duration(seconds: 3));
+          } catch (_) {}
         },
         child: ListView(
           padding:

--- a/lib/features/budgets_cats/presentation/pages/budgets_sub_tab.dart
+++ b/lib/features/budgets_cats/presentation/pages/budgets_sub_tab.dart
@@ -124,9 +124,11 @@ class BudgetsSubTab extends StatelessWidget {
               final bloc = context.read<BudgetListBloc>();
               bloc.add(const LoadBudgets(forceReload: true));
               // Wait until the loading state completes
-              await bloc.stream.firstWhere(
-                (s) => s.status != BudgetListStatus.loading,
-              );
+              try {
+                await bloc.stream
+                    .firstWhere((s) => s.status != BudgetListStatus.loading)
+                    .timeout(const Duration(seconds: 3));
+              } catch (_) {}
             },
             child: content,
           );

--- a/lib/features/groups/presentation/bloc/group_balances/group_balances_bloc.dart
+++ b/lib/features/groups/presentation/bloc/group_balances/group_balances_bloc.dart
@@ -185,15 +185,17 @@ class GroupBalancesBloc extends Bloc<GroupBalancesEvent, GroupBalancesState> {
       emit(GroupBalancesLoaded(newBalances));
 
       if (_currentGroupId != null) {
-        Future.delayed(const Duration(milliseconds: 500))
-            .then((_) {
-              if (!isClosed) {
-                add(RefreshBalances(_currentGroupId!));
-              }
-            })
-            .catchError((e, s) {
-              _log.severe('Error dispatching optimistic refresh: $e\n$s');
-            });
+        unawaited(
+          Future.delayed(const Duration(milliseconds: 500))
+              .then((_) {
+                if (!isClosed) {
+                  add(RefreshBalances(_currentGroupId!));
+                }
+              })
+              .catchError((e, s) {
+                _log.severe('Error dispatching optimistic refresh: $e\n$s');
+              }),
+        );
       }
     }
   }

--- a/lib/features/groups/presentation/bloc/group_balances/group_balances_bloc.dart
+++ b/lib/features/groups/presentation/bloc/group_balances/group_balances_bloc.dart
@@ -20,6 +20,8 @@ class GroupBalancesBloc extends Bloc<GroupBalancesEvent, GroupBalancesState> {
   final _log = Logger('GroupBalancesBloc');
   String? _currentGroupId;
 
+  set currentGroupIdForTest(String id) => _currentGroupId = id;
+
   GroupBalancesBloc({
     required this.supabase,
     required this.authSessionService,

--- a/lib/features/reports/presentation/widgets/report_filter_controls.dart
+++ b/lib/features/reports/presentation/widgets/report_filter_controls.dart
@@ -22,11 +22,15 @@ class ReportFilterControls extends StatelessWidget {
     if (filterBloc.state.optionsStatus != FilterOptionsStatus.loaded) {
       filterBloc.add(const LoadFilterOptions(forceReload: true));
       // Consider showing a loading indicator briefly or disabling button until loaded
-      await filterBloc.stream.firstWhere(
-        (state) =>
-            state.optionsStatus == FilterOptionsStatus.loaded ||
-            state.optionsStatus == FilterOptionsStatus.error,
-      );
+      try {
+        await filterBloc.stream
+            .firstWhere(
+              (state) =>
+                  state.optionsStatus == FilterOptionsStatus.loaded ||
+                  state.optionsStatus == FilterOptionsStatus.error,
+            )
+            .timeout(const Duration(seconds: 3));
+      } catch (_) {}
       if (!context.mounted ||
           filterBloc.state.optionsStatus != FilterOptionsStatus.loaded) {
         return; // Don't show sheet if loading failed or stream closed early

--- a/lib/features/transactions/presentation/bloc/transaction_list_bloc.dart
+++ b/lib/features/transactions/presentation/bloc/transaction_list_bloc.dart
@@ -614,20 +614,24 @@ class TransactionListBloc
       transactionData: event.matchData,
       selectedCategory: event.selectedCategory,
     );
-    _saveUserHistoryUseCase(historyParams)
-        .then((result) {
-          result.fold(
-            (failure) => log.warning(
-              "[TransactionListBloc] Failed to save user history: ${failure.message}",
-            ),
-            (_) => log.info(
-              "[TransactionListBloc] User history saved successfully for rule based on txn ${event.transactionId}",
-            ),
-          );
-        })
-        .catchError((e, s) {
-          log.severe("[TransactionListBloc] Error saving user history: $e\n$s");
-        });
+    unawaited(
+      _saveUserHistoryUseCase(historyParams)
+          .then((result) {
+            result.fold(
+              (failure) => log.warning(
+                "[TransactionListBloc] Failed to save user history: ${failure.message}",
+              ),
+              (_) => log.info(
+                "[TransactionListBloc] User history saved successfully for rule based on txn ${event.transactionId}",
+              ),
+            );
+          })
+          .catchError((e, s) {
+            log.severe(
+              "[TransactionListBloc] Error saving user history: $e\n$s",
+            );
+          }),
+    );
 
     // Update Transaction Categorization State
     log.info(

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -218,7 +218,9 @@ class AppRouter {
                   final Map<String, dynamic> queryParams =
                       state.uri.queryParameters;
                   final Map<String, dynamic>? extra =
-                      state.extra as Map<String, dynamic>?;
+                      state.extra is Map<String, dynamic>
+                      ? state.extra as Map<String, dynamic>
+                      : null;
                   Map<String, dynamic>? filtersFromExtra =
                       extra?['filters'] as Map<String, dynamic>?;
 
@@ -240,7 +242,9 @@ class AppRouter {
                       if (state.extra is String) {
                         merchantIdFromExtra = state.extra as String;
                       } else if (state.extra is Map) {
-                        final map = state.extra as Map;
+                        final map = state.extra is Map
+                            ? state.extra as Map
+                            : {};
                         if (map.containsKey('merchantId') &&
                             map['merchantId'] is String) {
                           merchantIdFromExtra = map['merchantId'] as String;
@@ -327,7 +331,9 @@ class AppRouter {
                         parentNavigatorKey: _rootNavigatorKey,
                         builder: (context, state) {
                           final Map<String, dynamic>? extra =
-                              state.extra as Map<String, dynamic>?;
+                              state.extra is Map<String, dynamic>
+                              ? state.extra as Map<String, dynamic>
+                              : null;
                           final CategoryType? initialType =
                               extra?['initialType'] as CategoryType?;
                           return AddEditCategoryScreen(
@@ -639,12 +645,10 @@ class AppRouter {
   ) {
     final categoryId = state.pathParameters[RouteNames.paramId];
     Category? category = state.extra is Category
-        ? (state.extra is Category ? state.extra as Category : null)
+        ? state.extra as Category
         : null;
     final Map<String, dynamic>? extraMap = state.extra is Map<String, dynamic>
-        ? (state.extra is Map<String, dynamic>
-              ? state.extra as Map<String, dynamic>
-              : null)
+        ? state.extra as Map<String, dynamic>
         : null;
     final CategoryType? initialType = extraMap?['initialType'] as CategoryType?;
 

--- a/test/features/accounts/presentation/pages/account_list_page_test.dart
+++ b/test/features/accounts/presentation/pages/account_list_page_test.dart
@@ -96,6 +96,30 @@ void main() {
       expect(router.routerDelegate.currentConfiguration.uri.toString(), '/add');
     });
 
+    testWidgets('handles refresh correctly', (tester) async {
+      whenListen(
+        mockBloc,
+        Stream.fromIterable([
+          const AccountListLoading(),
+          const AccountListLoaded(accounts: []),
+        ]),
+        initialState: const AccountListLoaded(accounts: []),
+      );
+      await pumpWidgetWithProviders(
+        tester: tester,
+        widget: const AccountListPage(),
+        accountListBloc: mockBloc,
+      );
+
+      expect(find.byType(RefreshIndicator), findsOneWidget);
+
+      await tester.fling(find.byType(ListView), const Offset(0.0, 300.0), 1000.0);
+      await tester.pump();
+
+      verify(() => mockBloc.add(const LoadAccounts(forceReload: true))).called(1);
+      await tester.pumpAndSettle();
+    });
+
     testWidgets('shows error state and retries', (tester) async {
       whenListen(
         mockBloc,

--- a/test/features/accounts/presentation/pages/accounts_tab_page_test.dart
+++ b/test/features/accounts/presentation/pages/accounts_tab_page_test.dart
@@ -50,4 +50,26 @@ void main() {
     // Might have "Accounts" header
     // expect(find.text('Accounts'), findsOneWidget);
   });
+
+  testWidgets('AccountsTabPage handles refresh correctly', (tester) async {
+    whenListen(
+      mockAccountListBloc,
+      Stream.fromIterable([
+        const AccountListLoading(),
+        const AccountListLoaded(accounts: []),
+      ]),
+      initialState: const AccountListLoaded(accounts: []),
+    );
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+
+    await tester.fling(find.byType(ListView), const Offset(0.0, 300.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // Wait for refresh indicator to settle
+
+    verify(() => mockAccountListBloc.add(const LoadAccounts(forceReload: true))).called(1);
+    await tester.pumpAndSettle();
+  });
 }

--- a/test/features/groups/presentation/bloc/group_balances/group_balances_bloc_test.dart
+++ b/test/features/groups/presentation/bloc/group_balances/group_balances_bloc_test.dart
@@ -141,19 +141,25 @@ void main() {
           ],
         ),
       ),
-      act: (bloc) => bloc.add(
-        const ApplyOptimisticSettlement(
-          amount: 50.0,
-          fromUserId: 'user1',
-          toUserId: 'user2',
-        ),
-      ),
+      act: (bloc) {
+        bloc.currentGroupIdForTest = 'test-group';
+        bloc.add(
+          const ApplyOptimisticSettlement(
+            amount: 50.0,
+            fromUserId: 'user1',
+            toUserId: 'user2',
+          ),
+        );
+      },
+      wait: const Duration(milliseconds: 600),
       expect: () => [
         isA<GroupBalancesLoaded>().having(
           (s) => s.balances.myNetBalance,
           'myNetBalance',
           -50.0,
         ), // -100 + 50
+        isA<GroupBalancesLoaded>(), // The optimistic state
+        isA<GroupBalancesLoaded>(), // The refreshed state
       ],
     );
   });

--- a/test/features/reports/presentation/widgets/report_filter_controls_test.dart
+++ b/test/features/reports/presentation/widgets/report_filter_controls_test.dart
@@ -39,4 +39,26 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(ReportFilterControls), findsOneWidget);
   });
+
+  testWidgets('calls showFilterSheet and waits when stream is not loaded', (tester) async {
+    whenListen(
+      mockBloc,
+      Stream.fromIterable([
+        ReportFilterState.initial().copyWith(optionsStatus: FilterOptionsStatus.loading),
+        ReportFilterState.initial().copyWith(optionsStatus: FilterOptionsStatus.loaded),
+      ]),
+      initialState: ReportFilterState.initial().copyWith(optionsStatus: FilterOptionsStatus.loading),
+    );
+
+    await tester.pumpWidget(createWidget());
+    await tester.pumpAndSettle();
+
+    final filterButton = find.byIcon(Icons.filter_list);
+    expect(filterButton, findsOneWidget);
+
+    await tester.tap(filterButton);
+    await tester.pumpAndSettle();
+
+    verify(() => mockBloc.add(const LoadFilterOptions(forceReload: true))).called(1);
+  });
 }

--- a/test/features/reports/presentation/widgets/report_filter_controls_test.dart
+++ b/test/features/reports/presentation/widgets/report_filter_controls_test.dart
@@ -53,10 +53,13 @@ void main() {
     await tester.pumpWidget(createWidget());
     await tester.pumpAndSettle();
 
-    final filterButton = find.byIcon(Icons.filter_list);
-    expect(filterButton, findsOneWidget);
+    // Mock the UI to test only the stream subscription timeout inside the bottom sheet builder function
+    // For this, we just need to ensure the report controls build.
+    final widget = find.byType(ReportFilterControls);
+    expect(widget, findsOneWidget);
 
-    await tester.tap(filterButton);
+    // Call the static method directly to test the timeout.
+    ReportFilterControls.showFilterSheet(tester.element(widget));
     await tester.pumpAndSettle();
 
     verify(() => mockBloc.add(const LoadFilterOptions(forceReload: true))).called(1);


### PR DESCRIPTION
Fix unawaited Stream subscriptions and background async tasks error handling

- Ensured exceptions thrown by background tasks wrapped in `unawaited` are properly caught and logged.
- Fixed `unawaited` lint format checking (i.e. `unawaited(future.catchError((e, s) => log.severe(...)))`).
- Fixed GoRouter param parsing `state.extra as Type` to safely handle type check failures by using `state.extra is Type ? state.extra as Type : null`.
- Added a `try/catch` and `.timeout()` wrapper to `bloc.stream.firstWhere` in `onRefresh` callbacks within `RefreshIndicator` UI widgets to prevent an infinite UI hang if the given state condition is never met.
- Validated tests and analyzers.

---
*PR created automatically by Jules for task [11061113301821784413](https://jules.google.com/task/11061113301821784413) started by @Aditya-Bichave*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout protection to pull-to-refresh and sheet-opening flows to avoid indefinite waits and improve responsiveness.
  * Made routing parameter handling more type-safe to prevent navigation errors.

* **Tests**
  * Added widget and bloc tests covering refresh behavior, report filter interactions, and balance update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->